### PR TITLE
Changed the explanation of the NTBias Diagram

### DIFF
--- a/docs/learn-governance.md
+++ b/docs/learn-governance.md
@@ -167,7 +167,7 @@ In contrast, when it has 75% turnout, the tally of "aye" votes has to reach 54%,
 
 Suppose there is a unanimous proposal proposed by the council, ``Negative Turnout Bias`` would be used, so that means the proposal is passed by default. Hence, more token holders have to participate in voting to prevent it from passing if they do not like this proposal.
 
-Referring to the above image, when the referenda only has 25% turnout, the tally of "nay" votes has to reach 34% for it to reject.
+Referring to the above image, when the referenda only has 25% turnout, the tally of "aye" votes has to reach 34% for it to accept.
 
 In short, when turnout rate is low, a super-majority is required to pass the proposal, which means a higher threshold of "aye" (yes) votes have to be reached, but as turnout increases towards 100%, it becomes a simple-majority.
 


### PR DESCRIPTION
I believe (and please correct me if I am wrong) the explanation that the diagram is describing a 34% nay requirement for rejection is backwards. With a negative turnout bias, the whole point is that with few people it takes a a huge percentage to reject (or vice-versa, a small amount of ayes to accept). So when there is only 25% percent turnout in a negative turnout bias situation, the ayes only need 34% of the vote to carry the council's proposal through.