### PR TITLE
inject Kusama network data

### DIFF
--- a/website/fetchNetworkData.js
+++ b/website/fetchNetworkData.js
@@ -1,0 +1,45 @@
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+const fs = require('fs');
+
+const filename = 'networkData.json' || process.env.NETWORK_DATA_FILE_NAME;
+const KSM_DECIMAL = 1000000000000;
+let numOfProposal, numOfValidator, totalIssuance;
+
+(async function () {
+  // Initialise the provider to connect to the local node
+  const provider = new WsProvider('wss://kusama-rpc.polkadot.io/');
+
+  // Create the API and wait until ready
+  const api = await ApiPromise.create({ provider });
+
+  // Retrieve the chain & node information information via rpc calls
+  [numOfProposal, numOfValidator, totalIssuance] = await Promise.all([
+    api.query.treasury.proposalCount(),
+    api.query.staking.validatorCount(),
+    api.query.balances.totalIssuance(),
+  ]);
+
+  processData();
+  process.exit();
+  
+})();
+
+const processData = () => {
+  const totalKSM =  parseInt(totalIssuance.toString()) / KSM_DECIMAL;
+  const data = {
+    proposalCount: numOfProposal.toString(),
+    validatorCount: numOfValidator.toString(),
+    totalIssuance: totalKSM.toString()
+  }
+
+  const json = JSON.stringify(data)
+
+  try {
+    // Write those fetched data to the file
+    fs.writeFileSync(filename, json)
+    console.log('Successfully wrote data to the file')
+  } catch(err) {
+     // An error occurred
+    console.error('Error writing network data to the file', err)
+  }
+}

--- a/website/networkData.json
+++ b/website/networkData.json
@@ -1,0 +1,1 @@
+{"proposalCount":"0","validatorCount":"45","totalIssuance":"7874646.98773723"}

--- a/website/package.json
+++ b/website/package.json
@@ -4,8 +4,8 @@
     "examples": "docusaurus-examples",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "docusaurus-start",
-    "build": "docusaurus-build",
+    "start": "node fetchNetworkData.js && docusaurus-start",
+    "build": "node fetchNetworkData.js && docusaurus-build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
@@ -17,6 +17,8 @@
     "docusaurus": "^1.12.0"
   },
   "dependencies": {
+    "@polkadot/api": "^0.97.1",
+    "remarkable-embed": "^0.4.1",
     "remarkable-katex": "^1.0.1"
   }
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,3 +1,32 @@
+const {Plugin: Embed} = require('remarkable-embed');
+const networkData  = require('./networkData.json');
+
+// Our custom remarkable plugin factory.
+const createVariableInjectionPlugin = variables => {
+  // `let` binding used to initialize the `Embed` plugin only once for efficiency.
+  // See `if` statement below.
+  let initializedPlugin;
+
+  const embed = new Embed();
+  embed.register({
+    // Call the render method to process the corresponding variable with
+    // the passed Remarkable instance.
+    // -> the Markdown markup in the variable will be converted to HTML.
+    inject: key => initializedPlugin.render(variables[key])
+  });
+
+  return (md, options) => {
+    if (!initializedPlugin) {
+      initializedPlugin = {
+        render: md.render.bind(md),
+        hook: embed.hook(md, options)
+      };
+    }
+
+    return initializedPlugin.hook;
+  };
+};
+
 const siteConfig = {
   title: 'Polkadot Wiki', // Title for your website.
   tagline: 'The hub for those interested in learning, building, or running a node on Polkadot.',
@@ -93,6 +122,10 @@ const siteConfig = {
   },
 
   repoUrl: 'https://github.com/paritytech/polkadot',
+
+  markdownPlugins: [
+      createVariableInjectionPlugin(networkData)
+  ],
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
With this, it is able to inject the Kusama / Polkadot network data to the markdown files during rendering. 
`fetchNetworkData.js` is the script for getting & processing those data and `createVariableInjectionPlugin` in `siteConfig.js` will do the injection.

**Example:** 
If you want to inject the total of number KSM to the `index.md`, you can add the following injection code anywhere in the md file: 
{@inject: VARIABLE_DEFINED_IN_JSON}