### PR TITLE
Update slashing / payout based on new Kusama params

### DIFF
--- a/docs/learn-staking.md
+++ b/docs/learn-staking.md
@@ -145,7 +145,7 @@ If you want to know more details about slashing, please look at our [research pa
 
 Note that Kusama runs approximately 4x as fast as Polkadot, except for block production times.  Polkadot will also produce blocks at approximately six second intervals.
 
-Rewards are recorded per session --- approximately one hour on Kusama and four hours on Polkadot --- and paid per era. It takes approximately six hours to finish one eram twenty-four hours on Polkadot.  Thus, rewards will be distributed to the validators and nominators four times per day on Kusama and once per day on Polkadot.
+Rewards are recorded per session --- approximately one hour on Kusama and four hours on Polkadot --- and paid per era. It takes approximately six hours to finish one era, twenty-four hours on Polkadot.  Thus, rewards will be distributed to the validators and nominators four times per day on Kusama and once per day on Polkadot.
 
 ### Example
 

--- a/docs/learn-staking.md
+++ b/docs/learn-staking.md
@@ -108,13 +108,15 @@ Based on Polkadot's latest codebase, the following slashing conditions have been
 
 ### Unresponsiveness
 
-For every session, validators will send an "I'm Online" message to indicate they are online. If a validator produces no blocks during an epoch and fails to send the heartbeat, it will be reported as unresponsive. Depending on the repeated offences and how many other validators were unresponsive or offline, slashing will occur. If one-third of all validators are unresponsive, 5% of their bonded DOTs will be slashed.
+For every session, validators will send an "I'm Online" message to indicate they are online. If a validator produces no blocks during an epoch and fails to send the heartbeat, it will be reported as unresponsive. Depending on the repeated offences and how many other validators were unresponsive or offline, slashing will occur.
 
 Here is the formula for calculation:
 
     Let x = offenders, n = total no. validators
 
-    Min( (3 * (x - 1)) / n, 1) * 0.05
+    min((3 * (k - (n / 10 + 1))) / n, 1) * 0.07
+
+Note that if less than 10% of all validators are offline, no penalty is enacted.
 
 Validators should have a well-architected network infrastructure to ensure the node is running to reduce the risk of being slashed. A high availability setup is desirable, preferably with backup nodes that kick in **only once the original node is verifiably offline** (to avoid double-signing and being slashed for equivocation - see below), together with proxy nodes to avoid being DDoSed when your validator node's IP address is exposed. A comprehensive guide on secure validator setup is in progress with the draft available [here](https://wiki.polkadot.network/docs/en/maintain-guides-secure-validator).
 
@@ -141,24 +143,25 @@ If you want to know more details about slashing, please look at our [research pa
 
 ## Reward Distribution
 
-Based on the current configuration in the Alexander testnet, rewards are recorded per session that is roughly 5 minutes and paid per era. It takes 1 hour to finish an era; that means rewards will be distributed to the validators and nominators each hour.
+Note that Kusama runs approximately 4x as fast as Polkadot, except for block production times.  Polkadot will also produce blocks at approximately six second intervals.
+
+Rewards are recorded per session --- approximately one hour on Kusama and four hours on Polkadot --- and paid per era. It takes approximately six hours to finish one eram twenty-four hours on Polkadot.  Thus, rewards will be distributed to the validators and nominators four times per day on Kusama and once per day on Polkadot.
 
 ### Example
 
 ```
     PER_ERA * BLOCK_TIME = **Reward Distribution Time**
 
-    600 * 6 = 3600 = 1 Hour
+    3600 * 6 seconds = 21,600 s = 6 hours
 
     ***These parameters can be changed by proposing a referendum***
 ```
 
-Validators can create a cut of the reward that is not shared with the nominators. After the value gets deducted, the remaining portion is based on their staked value and split between the validator and all of the nominators who have voted for this validator.
+Validators can create a cut of the reward that is not shared with the nominators. This cut is a percentage of the block reward, not an absolute value. After the value gets deducted, the remaining portion is based on their staked value and split between the validator and all of the nominators who have voted for this validator.
 
-For example, assume reward is 100 DOTs.
-A validator may specify `validator_payment = 50 DOTs` and the remaining 50 DOTs would be split between the validator and their nominators based on the portion of stakes they had.
+For example, assume the block reward for a validator is 10 DOTs. A validator may specify `validator_payment = 50%`, in which case the validator would receive 5 DOTs. The remaining 5 DOTs would then be split between the validator and their nominators based on the portion of stakes they had.
 
-Rewards can be used by the same account (controller) to keep accumulating the rewards or by the stash account (increasing the staked value / not increasing the staked value). Also, it is possible to top-up / withdraw some bonded DOTs without having to un-stake everything.
+Rewards can be directed to the same account (controller) or to the stash account (and either increasing the staked value or not increasing the staked value). It is also possible to top-up / withdraw some bonded DOTs without having to un-stake everything.
 
 ## Inflation
 

--- a/docs/maintain-guides-validator-payout.md
+++ b/docs/maintain-guides-validator-payout.md
@@ -6,7 +6,7 @@ sidebar_label: Validator Payout Overview
 
 ## Payout Scheme
 
-Validators are paid for authoring blocks on the relay chain and signing parachain blocks. Validator payouts occur at the end of every era (on the Alexander testnet, this is approximately once per hour, although this may be modified on Kusama and the Polkadot mainnet). No matter how much stake is behind a validator (by the validator stash itself, as well as by nominators), all validators split the block authoring payout equally.
+Validators are paid for authoring blocks on the relay chain and signing parachain blocks. Validator payouts occur at the end of every era (on the Alexander testnet, this was approximately once per hour, on Kusama once every six hours, and on Polkadot mainnet once per day ). No matter how much stake is behind a validator (by the validator stash itself, as well as by nominators), all validators split the block authoring payout equally.
 
 Validators may also receive "tips" from senders as an incentive to include transactions in their produced blocks.
 
@@ -70,13 +70,13 @@ Nominators have the incentive to nominate the lowest-staked validator, as this w
 
 ## Nominators and Validator Payments
 
-Nominated stake allows you to "vote" for validators and share in the rewards (and slashing) without running a validator node yourself. Validators can choose to keep part of their rewards to "reimburse" themselves for the cost of running a validator node. Other than that, all rewards are shared based on the stake behind each validator. This includes the stake of the validator itself, plus any stake bonded by nominators.
+Nominated stake allows you to "vote" for validators and share in the rewards (and slashing) without running a validator node yourself. Validators can choose to keep a percentage of the rewards due to their validator to "reimburse" themselves for the cost of running a validator node. Other than that, all rewards are shared based on the stake behind each validator. This includes the stake of the validator itself, plus any stake bonded by nominators.
 
-> **NOTE:** Validators set their preference in DOTs, _not_ as a percentage of the reward. Polkadot's block reward is based on the _total_ amount at stake, with the reward peaking when the amount staked is at 50% of the total supply. In periods when there is a lower amount staked, and therefore lower rewards, the validator's payout preference could mean that there is zero left over for nominators.
+> **NOTE:** Validators set their preference as a percentage of the block reward, _not_ an absolute number of DOTs. Polkadot's block reward is based on the _total_ amount at stake, with the reward peaking when the amount staked is at 50% of the total supply. In periods when there is a lower amount staked, and therefore lower rewards, the validator's payout preference could mean that there is zero left over for nominators.
 
 In the following examples, we can see the results of several different validator payment schemes and split between nominator and validator stake. We will assume a single nominator for each validator. However, there can be numerous nominators for each validator. Rewards are still distributed proportionally - for example, if the total rewards to be given to nominators is 2 DOTs, and there are four nominators with equal stake bonded, each will receive 0.5 DOTs. Note also that a single nominator may stake different validators.
 
-Each validator in the example has selected a different validator payment (that is, reward set aside directly for the validator before sharing with all bonded stake). The validator's payment (in DOTs) is listed in brackets (`[]`) next to each validator. Note that since the validator payment is public knowledge, having a low or non-existent validator payment may attract more stake from nominators, since they know they will receive a larger reward.
+Each validator in the example has selected a different validator payment (that is, a percentage of the reward set aside directly for the validator before sharing with all bonded stake). The validator's payment percentage (in DOTs) is listed in brackets (`[]`) next to each validator. Note that since the validator payment is public knowledge, having a low or non-existent validator payment may attract more stake from nominators, since they know they will receive a larger reward.
 
 ```
 Validator Set Size (v): 4
@@ -90,31 +90,31 @@ Payout for each validator (v1 - v4):
 p / v = 8 / 4 = 2 DOTs
 
 v1:
-0.2 DOTs -> validator payment
-(2 - 0.2) = 1.8 -> shared between all stake
-(9 / 18) * 1.8 = 0.9 -> validator stake share
-(9 / 18) * 1.8 = 0.9 -> nominator stake share
-v1 validator total reward: 0.2 + 0.9 = 1.1 DOTs
-v1 nominator reward: 0.9 DOTs
+(0.2 * 2) = 0.4 DOTs -> validator payment
+(2 - 0.4) = 1.6 -> shared between all stake
+(9 / 18) * 1.6 = 0.8 -> validator stake share
+(9 / 18) * 1.6 = 0.8 -> nominator stake share
+v1 validator total reward: 0.4 + 0.8 = 1.2 DOTs
+v1 nominator reward: 0.8 DOTs
 
 v2:
-0.4 DOTs -> validator payment
-(2 - 0.4) = 1.6 -> shared between all stake
-(3 / 9) * 1.6 = 0.53 -> validator stake share
-(6 / 9) * 1.6 = 1.07 -> nominator stake share
-v2 validator total reward: 0.4 + 0.53 = 0.93 DOTs
-v2 nominator reward: 1.07 DOTs
+(0.4 * 2) = 0.8 DOTs -> validator payment
+(2 - 0.8) = 1.2 -> shared between all stake
+(3 / 9) * 1.2 = 0.4 -> validator stake share
+(6 / 9) * 1.2 = 0.8 -> nominator stake share
+v2 validator total reward: 0.8 + 0.4 = 1.2 DOTs
+v2 nominator reward: 0.8 DOTs
 
 v3:
-0.1 DOTs -> validator payment
-(2 - 0.1) = 1.9 -> shared between all stake
-(4 / 8) * 1.9 = 0.95 -> validator stake share
-(4 / 8) * 1.9 = 0.95 -> nominator stake share
-v3 validator total reward: 0.1 + 0.95 DOTs = 1.05 DOTs
-v3 nominator reward: 0.95 DOTs
+(0.1 * 2) = 0.2 DOTs -> validator payment
+(2 - 0.2) = 1.8 -> shared between all stake
+(4 / 8) * 1.8 = 0.9 -> validator stake share
+(4 / 8) * 1.8 = 0.9 -> nominator stake share
+v3 validator total reward: 0.2 + 0.9 DOTs = 1.1 DOTs
+v3 nominator reward: 0.9 DOTs
 
 v4:
-0 DOTs -> validator payment
+(0 * 2) = 0 DOTs -> validator payment
 (2 - 0) = 2.0 -> shared between all stake
 (1 / 6) * 2 = 0.33 -> validator stake share
 (5 / 6) * 2 = 1.67 -> nominator stake share


### PR DESCRIPTION
Some changes have been made to Kusama since the initial writeup:

1. Slashing for offline only occurs if > 10% offline at once
2. Slashing penalty calculations have been changed
3. Validator payment has changed from absolute value to percentage

This makes appropriate changes to the wiki to take these into account