### PR TITLE
Metadata for grants page

### DIFF
--- a/docs/grants.md
+++ b/docs/grants.md
@@ -1,3 +1,9 @@
+---
+id: grants
+title: Web3 Foundation Grantees
+sidebar_label: Grants
+---
+
 # Accepted Grant Applications
 
 This page gives an overview of accepted grants and a link to their GitHub repositories. Keep in mind that not all of the accepted grants have already delivered software.


### PR DESCRIPTION
Grants page was missing header info and was showing up lowercase in sidemenu without a title on the page itself. This fixes the issue.