### PR TITLE
Adding example meta for Emily

### DIFF
--- a/docs/learn-consensus.md
+++ b/docs/learn-consensus.md
@@ -2,6 +2,7 @@
 id: learn-consensus
 title: Polkadot Consensus
 sidebar_label: Polkadot Consensus
+description: An explanation of the consensus model used in Polkadot and Kusama
 ---
 
 ## Why do we need consensus?


### PR DESCRIPTION
@EmilyOstbo here's how you do it. You can create PRs with added description in the header of the wiki pages. You can find these pages in the `/docs` directory. Usually the name corresponds to a section in the wiki - i.e. `learn-staking` is "Staking" under the "Learn" section, etc. Those without prefixes also end up in some categories but aren't as strictly defined (e.g. `grants`).

Anyway, all the fields for this header are documented here: https://docusaurus.io/docs/en/doc-markdown#documents

So basically, just the `decription` but this one field will generate both `description` and `og:description`. Hope this is helpful.

We don't care if you add the meta to all pages and submit a single PR, or to one page per PR, whatever feel better to you.