### PR TITLE
Polkadot mainnet release 2019 to early 2020

### DIFF
--- a/docs/build-build-with-polkadot.md
+++ b/docs/build-build-with-polkadot.md
@@ -41,7 +41,7 @@ This module allows for smart contracts compiled to Wasm code to be deployed to t
 To facilitate development of Wasm smart contracts, Parity is also developing [ink!](https://github.com/paritytech/ink), a domain specific language built
 in Rust that is intended for writing smart contracts.
 
-Polkadot is planned to go live with an initial release at the end of 2019, depending on security audits and launch
+Polkadot is planned to go live with an initial release early in 2020, depending on security audits and launch
 provisions outside of control of the team. Now that the tools have started to appear and stabilize, there has not been
 a better time to get your feet wet and start preparing for launch. But wait! Before you jump head-first into the code,
 you should think about the kind of decentralized application you want to make and understand the different paradigms

--- a/docs/learn-DOT.md
+++ b/docs/learn-DOT.md
@@ -64,9 +64,9 @@ DOTs will have the ability to be bonded for a duration of time in order to add a
 
 ## Mainnet DOTs
 
-Web3 Foundation will distribute up to 20% of mainnet DOTs prior to network launch in 2019 (see the [Light Paper](https://polkadot.network/Polkadot-lightpaper.pdf) or the [Polkadot Network FAQ](https://polkadot.network/faq/)). As Gavin Wood, one of the project's founders, said in his year-end recap, there may be a generally available public sale for some portion of that amount at some point this year. Subscribe to the Polkadot newsletter on [polkadot.network](https://polkadot.network/) for further updates.
+Web3 Foundation will distribute up to 20% of mainnet DOTs prior to network launch in early 2020 (see the [Light Paper](https://polkadot.network/Polkadot-lightpaper.pdf) or the [Polkadot Network FAQ](https://polkadot.network/faq/)). As Gavin Wood, one of the project's founders, said in his year-end recap, there may be a generally available public sale for some portion of that amount at some point this year. Subscribe to the Polkadot newsletter on [polkadot.network](https://polkadot.network/) for further updates.
 
-_Warning: Mainnet DOT tokens are not transferrable until mainnet launch, expected late 2019. Therefore any transfers of Mainnet DOTs are illegitimate and unauthorized. DOTs can not be moved from a current allocation address. Individuals with an allocation of DOTs who transfer their DOT address to someone else can always keep a copy of their private key, therefore there is extreme risk for individuals participating in transfers of DOTs before mainnet launch._
+_Warning: Mainnet DOT tokens are not transferrable until mainnet launch, expected in early 2020. Therefore any transfers of Mainnet DOTs are illegitimate and unauthorized. DOTs can not be moved from a current allocation address. Individuals with an allocation of DOTs who transfer their DOT address to someone else can always keep a copy of their private key, therefore there is extreme risk for individuals participating in transfers of DOTs before mainnet launch._
 
 Testnet dots are freely available now - see below for various ways to obtain them.
 

--- a/docs/learn-roadmap.md
+++ b/docs/learn-roadmap.md
@@ -14,8 +14,9 @@ Polkadot is currently undergoing a series of proof-of-concept testnet releases a
 out. Additionally, Kusama a canary network that will test the economic conditions of an early, unaudited version of Polkadot
 is launched to help inform the ultimate goal of Polkadot.
 
-- Polkadot Genesis - Expected around the end of the year.
+- Polkadot Genesis - Expected early 2020.
 - Kusama - [Announcement][kusama announcement] on 16 July, 2019. [Genesis][kusama genesis] on 23 August 2019. [Kusama CC2][kusama cc2] on 26 September 2019.
+- Westend - (Released January 2020) - A testnet based on the current Kusama codebase.
 - PoC-4 (Release date 3 April 2019) - _Staking changes and GRANDPA optimizations_ [Release Blog post](https://medium.com/polkadot-network/polkadot-proof-of-concept-4-arrives-with-new-ways-to-stake-3b27037346cc)
 - PoC-3 (Released 21 Dec 2018) - _GRANDPA finality gadget added. Testnet: "Alexander"_ [Release Blog Post](https://medium.com/coinmonks/polkadot-hello-world-3-poc-3-on-substrate-is-here-c45d100f72e3)
 - BBQ-Birch testnet (Went live: 15 October 2018): _Added smart contract support._


### PR DESCRIPTION
Several places mention Polkadot being released at the end of 2019, fixing that to say early 2020.

Also added in Westend testnet to list of networks which was released in Jan 2020, deprecating Alexander.