### PR TITLE
Update relevant links page

### DIFF
--- a/docs/learn-relevant-links.md
+++ b/docs/learn-relevant-links.md
@@ -31,6 +31,8 @@ sidebar_label: Links
 ### Substrate
 
 - [What is Substrate?](https://medium.com/paritytech/what-is-substrate-29af4231d7e0) - Explanation of the framework used to build Polkadot.
+- [Parity Substrate](https://github.com/paritytech/substrate) - First implementation, written in Rust. Parity Technologies is a 75-person development team based in the UK and Germany. Parity’s tech is responsible for running the premier client for Ethereum, powering 40% of the nodes in the network. Parity also maintains a client for [Bitcoin](https://github.com/paritytech/parity-bitcoin) and developed and released [Zebra](https://github.com/ZcashFoundation/zebra), a rust implementation of a zcash node.
+- [Substrate Developer Hub](https://substrate.dev/) - Overviews, tutorials and reference documentation for Substrate.
 - [Substrate Intro](https://youtu.be/iUMZyL5kTwc) - Dr. Gavin Wood presents Substrate, one of the technologies underlying Polkadot.
 - [How Substrate relates to Polkadot](https://medium.com/polkadot-network/a-tale-of-two-technologies-presentation-transcript-e7397c1c7a49) - A Tale of Two Technologies Presentation Transcript
 - [Polkadot & Substrate Overview](https://www.youtube.com/watch?v=0IoUZdDi5Is&feature=youtu.be) - Dr. Gavin Wood presents Substrate (blockchain in-a-box + VM) and Polkadot, and builds a blockchain on-stage in 30 minutes using Substrate.
@@ -41,9 +43,9 @@ sidebar_label: Links
 ### Governance
 
 - [Governance](learn-governance) - Overview of governance system.
-- [Governance Demo](https://www.youtube.com/watch?v=VsZuDJMmVPY&feature=youtu.be&t=24734) - Dr. Gavin Wood presents the
-  initial governance structure for Polkadot. (Video)
+- [Governance Demo](https://www.youtube.com/watch?v=VsZuDJMmVPY&feature=youtu.be&t=24734) - Dr. Gavin Wood presents the initial governance structure for Polkadot. (Video)
 - [Kusama Rollout and Governance](https://polkadot.network/kusama-rollout-and-governance/) - Information on the governance on the Kusama Canary network.
+- [Governance on Polkadot](https://www.crowdcast.io/e/governance-on-polkadot--) - A webinar explaining how governance works in Polkadot and Kusama.
 
 ### Consensus and Finality
 
@@ -52,15 +54,6 @@ sidebar_label: Links
 ### Research
 
 - [W3F Research](https://research.web3.foundation) - Research hub for Web3 Foundation.
-
-### Kusama
-
-- [Kusama Homepage](https://kusama.network) - The Kusama canary network homepage.
-- [Kusama Announcement](https://polkadot.network/kusama-network-the-canary-network/) - The announcement of Kusama.
-- [Kusama Rollout and Governance](https://polkadot.network/kusama-rollout-and-governance/) - Initial Kusama rollout
-  plans and governance structure.
-- [Kusama CC2 Announcement](https://polkadot.network/kusama-cc2/) - Announcement on Kusama CC2, the next chapter of
-  the Kusama series.
 
 ## Development
 
@@ -77,11 +70,6 @@ sidebar_label: Links
 - [Polkadot Runtime Environment specification](https://github.com/w3f/polkadot-re-spec/blob/master/polkadot_re_spec.pdf) - In progress. A complete specification of the Polkadot Runtime Environment.
 - [Polkadot.js](https://polkadot.js.org/) - Tools, utilities and client in JS. Polkadot JS is a 3-person development team in Germany and is building the JavaScript implementation of Polkadot.
 - [ChainSafe's Go PRE](https://github.com/ChainSafeSystems/go-pre) is a 25-person development team based in Toronto. ChainSafe is building an implementation of the beacon chain for Ethereum 2.0 client in TypeScript and this Go implementation of Polkadot.
-
-### Substrate
-
-- [Parity Substrate](https://github.com/paritytech/substrate) - First implementation, written in Rust. Parity Technologies is a 75-person development team based in the UK and Germany. Parity’s tech is responsible for running the premier client for Ethereum, powering 40% of the nodes in the network. Parity also maintains clients for Bitcoin and is building one for Zcash.
-- [Substrate Developer Hub](https://substrate.dev/) - Overviews, tutorials and reference documentation for Substrate.
 
 ### Cumulus
 
@@ -115,3 +103,16 @@ sidebar_label: Links
 - [Polkascan](http://polkascan.io/) \- Real-time multi-chain data for Polkadot Relay Chain ation on and Parity Substrate chains.
 - [Polka.io](https://polka.io/) \- Polkadot Muti-Chain Explorer
 - [Polkastat](http://polkastat.xyz/) \- See staking and validator inform
+
+### Crowdcast Webinars
+
+- [Polkadot Homepage](https://www.crowdcast.io/polkadot) - List of all Crowdcast webinars that the Web3 Foundation has done.
+- [Governance on Polkadot](https://www.crowdcast.io/e/governance-on-polkadot--) - An explanation of how governance works in Polkadot and Kusama, with Bill Laboon.
+- [Kusama](https://www.crowdcast.io/e/qpz8aran) - An overview of Kusama with Anson Lau.
+- [Block Production and Finalization in Polkadot](https://www.crowdcast.io/e/polkadot-block-production) - An explanation of how BABE and GRANDPA work together to produce and finalize blocks on Kusama, with Bill Laboon.
+- [Validating on Polkadot](https://www.crowdcast.io/e/validating-on-polkadot) - An explanation of how to validate on Polkadot, with Joe Petrowski and David Dorgan of Parity Technologies, along with Tim Ogilvie from Staked.
+- [Understanding Accounts and Keys in Polkadot](https://www.crowdcast.io/e/polkadot-keys) - An explanation of what the different kinds of accounts and keys are used for in Polkadot, with Bill Laboon and Chinmay Patel of BlockX Labs.
+- [Participating in Kusama](https://www.crowdcast.io/e/participating-on-kusama) - How to participate in Kusama in a variety of different roles, with Logan Saether.
+- [Developing Apps that Interact with Polkadot](https://www.crowdcast.io/e/developing-apps-on-polkadot) - Bill Laboon walks through how to write your own scripts and programs to interact with Polkadot via the Polkadot API.
+- [Adding Web3 Logins to a Web2.0 App](https://www.crowdcast.io/e/web3-logins-workshop) Bruno Skvorc explains how to add a login process to a legacy Web2.0 application.
+- [A Distributed Drawing Program on Kusama](https://www.crowdcast.io/e/distributed-drawing) - Expanding on his previous talk, Bill Laboon uses Shawn Tabrizi's `remarkable` codebase to make a node.js app which listens to the Kusama chain and allows users to set pixels to programmatically draw a shared picture.


### PR DESCRIPTION
There were a few issues with this page -

1. No links to any of our crowdcasts =(
2. Some out-of-date info (e.g. zebra has been released as Parity's zcash client)
3. There were two identical Kusama sections

We may want to split this page into multiple sections in the future, as it is getting long, but this PR is limited in scope and is just fixing up what's already there for now.  It will make it easier for the bigger changes that we should probably make in the near future.