### PR TITLE
Remove build deploy parachains page

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -35,7 +35,6 @@
         "ids": [
           "build-exchange-integration",
           "build-examples-index",
-          "build-deploy-parachains",
           "build-hackathon"
         ]
       }


### PR DESCRIPTION
Closes #230 until a parachain-enabled testnet is up. Heavy revamps in progress on cumulus / parachain side, so not smart to update guide right now. Revisit in a week or so.