### PR TITLE
switch to linkchecker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   check-links:
     docker:
-      - image: web3f/link-checker:v0.1.0
+      - image: web3f/link-checker:v1.0.1
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: check links
           command: |
-            pylinkvalidate.py --parser=html5lib -P http://localhost:3000/docs/en/ -d 0
+            linkchecker -v --ignore-url=!\/en\/ http://localhost:3000/
 
   deploy-website:
     docker:


### PR DESCRIPTION
Uses https://github.com/linkchecker/linkchecker instead of pylinkvalidate, this allows us to ignore urls with regex.