### PR TITLE
basic oracle information

### DIFF
--- a/docs/build-oracle.md
+++ b/docs/build-oracle.md
@@ -1,0 +1,36 @@
+---
+id: build-oracle
+title: Oracles
+sidebar_label: Oracles
+---
+
+In the blockchain context, an _oracle_ is a way to bring real-world data onto
+the blockchain so that it can be used by a decentralized application.
+
+Oracles serve many purposes for application builders. 
+
+- Most stablecoin designs use an oracle to bring in data of the exchange rate
+  of assets, in order to peg their value to a real world currency.
+- Synthetic assets use oracles as price feeds in order to determine if the
+  underlying cryptocurrency sufficiently collateralizes the debt position.
+- Prediction markets use oracles to decide the outcome of real world events
+  and determine the payout of the prediction shares.
+- Decentralized insurance markets use oracles to bring in information about
+  whether a claim is valid or not.
+
+Oracle solutions range from centralized and trusted to decentralized and 
+game-theory based. On the centralized end of the spectrum, an oracle could be
+a single account that has the authority to dictate the real-world data on-chain.
+On the decentralized end, a [complex game of "chicken"][schellingcoin] can be
+played among various staked actors who risk getting slashed if they don't submit
+the same data as everyone else. Solutions such as [ChainLink][chainlink] fit
+somewhere in the middle, where the amount of trust you put into the reporting
+oracles is minimized based on your preferences. 
+
+When using an oracle in your application you should be aware of the benefits and
+risks that are baked into its specific model. As the Polkadot ecosystem develops
+and oracle parachains begin to appear, this article will be updated with a
+comparison of the different solutions and the benefits each provides.
+
+[schellingcoin]: https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed/
+[chainlink]: https://polkadot.network/chainlink-reaches-milestone-with-polkadot/

--- a/docs/build-oracle.md
+++ b/docs/build-oracle.md
@@ -7,7 +7,7 @@ sidebar_label: Oracles
 In the blockchain context, an _oracle_ is a way to bring real-world data onto
 the blockchain so that it can be used by a decentralized application.
 
-Oracles serve many purposes for application builders. 
+Oracles serve many purposes for application builders.  For example,
 
 - Most stablecoin designs use an oracle to bring in data of the exchange rate
   of assets, in order to peg their value to a real world currency.

--- a/docs/build-oracle.md
+++ b/docs/build-oracle.md
@@ -30,7 +30,7 @@ oracles is minimized based on your preferences.
 When using an oracle in your application you should be aware of the benefits and
 risks that are baked into its specific model. As the Polkadot ecosystem develops
 and oracle parachains begin to appear, this article will be updated with a
-comparison of the different solutions and the benefits each provides.
+comparison of the different solutions and the drawbacks and benefits each provides.
 
 [schellingcoin]: https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed/
 [chainlink]: https://polkadot.network/chainlink-reaches-milestone-with-polkadot/

--- a/docs/build-oracle.md
+++ b/docs/build-oracle.md
@@ -25,7 +25,7 @@ On the decentralized end, a [complex game of "chicken"][schellingcoin] can be
 played among various staked actors who risk getting slashed if they don't submit
 the same data as everyone else. Solutions such as [ChainLink][chainlink] fit
 somewhere in the middle, where the amount of trust you put into the reporting
-oracles is minimized based on your preferences. 
+oracles can be adjusted based on your preferences. 
 
 When using an oracle in your application you should be aware of the benefits and
 risks that are baked into its specific model. As the Polkadot ecosystem develops

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -37,6 +37,10 @@
         "title": "Builder's Portal",
         "sidebar_label": "Builder's Portal"
       },
+      "build-oracle": {
+        "title": "Oracles",
+        "sidebar_label": "Oracles"
+      },
       "build-pdk": {
         "title": "Parachain Development Kits (PDKs)",
         "sidebar_label": "Parachain Development Kits (PDKs)"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -19,7 +19,8 @@
           "build-dev-roadmap",
           "build-pdk",
           "build-cumulus",
-          "build-smart-contracts"
+          "build-smart-contracts",
+          "build-oracle"
         ]
       },
       {


### PR DESCRIPTION
closes #279 

Just adds a stub for oracles for now. Later we will need to add more information about different oracle parachains like ChainLink, etc.