### PR TITLE
revert CI link checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: check links
           command: |
-            linkchecker --ignore-url="^(?:(?!http))(?:(?!\/en\/).)*$" --check-extern http://localhost:3000/
+            linkchecker --ignore-url="^(?:(?!\/en\/).)*$" --check-extern http://localhost:3000/
 
   deploy-website:
     docker:


### PR DESCRIPTION
Closes https://github.com/w3f/polkadot-wiki/issues/309

Shows a single error that seems legit. Now it only checks local links with `/en/` in the url.