### PR TITLE
Update Kusama nomination page for lazy payouts

### DIFF
--- a/docs/maintain-guides-how-to-nominate-kusama.md
+++ b/docs/maintain-guides-how-to-nominate-kusama.md
@@ -32,7 +32,9 @@ Click on "Nominate" on an account you've bonded and you will be presented with a
 
 ![Nominating validators](/img/NPoS/nominate.png)
 
-Select them, confirm the transaction, and you're done - you are now nominating. You should notice your balance increasing shortly.
+Select them, confirm the transaction, and you're done - you are now nominating.  Your nominations will become active in the next era.  Eras last four hours on Kusama - depending on when you do this, your nominations may become active almost immediately, or you may have to wait almost the entire four hours before your nominations are active.  You can chek how far along Kusama is in the current era on the [Staking page](https://polkadot.js.org/apps/#/staking).
+
+Assuming at least one of your nominations ends up in the active validator set, you will start to get rewards allocated to you.  In order to claim them (i.e., add them to your account), you must manually claim them.  See the [Claiming Rewards](learn-staking#claiming-rewards) section of the Staking wiki page for more details.
 
 ### Step 3: Stop nominating
 


### PR DESCRIPTION
The Kusama nomination page said something like "pretty soon you will start getting payouts".  I changed it to both explain eras and to add a link to the Claiming Rewards page since this now has to be done manually (although it looks like simplified payouts PR is coming soon and we may need to revert back at some point...)