### PR TITLE
Updating FAQ

### DIFF
--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -10,16 +10,17 @@ _This FAQ focuses on technical questions for users interested in developing appl
 
 ### What is the launch process of Polkadot Beta?
 
-The network will launch first in as a Proof-of-Authority (PoA) chain, with governance
-controlled by the single Sudo (super-user) account, and functionality restricted to disallow
-transfers of funds. 
+The Polkadot network will launch first in as a Proof-of-Authority (PoA) chain.
+During this time, governance will be controlled by the single Sudo (super-user)
+account, and functionality will be restricted to (among other things) disallow
+the transfer of funds. 
 
-During this time, validator will be able to start joining the network and signalling
+During this time, validators can start joining the network by signalling
 their intention to participate in consensus. When a sufficient number of validator
 are sourced from the community, the Sudo account will initiate the transition
 of the chain security from PoA to Proof-of-Stake (PoS). After this happens,
-the first validator elections will begin and the chain is secured by the
-economic stake that is bonded by validators and nominators.
+the first validator elections will begin and the chain  will be going forward 
+secured by the economic stake that is bonded by validators and nominators.
 
 After the chain has been secured by the decentralized community of validators,
 the next step is to transition the governance of the chain into the hands of the
@@ -32,31 +33,31 @@ The final step to transition to full-functioning Polkadot is the enabling of
 transfer functionality. The community will need to propose a new upgrade and vote
 upon it in order to accomplish this. If the vote to enable transfers passes, then
 it will be enacted shortly thereafter. When this takes place, Polkadot will
-move out of it's Beta release state.
+be fully live and move out of it's Beta release label.
 
 ### How many validators will be validating at Polkadot Beta launch?
 
-Initially only a few authority validators will be securing the network. However,
+Initially only a few authorized validators will be securing the network. However,
 as [detailed in the answer above](#what-is-the-launch-process-of-polkadot-beta),
-the network will right away be available for vaidators to start registering
-their intentions. The transition to Proof-of-Stake will largely depend on when
-a sufficient number of validators have registered and are ready to take over
-the security of the network. This number can be as low as 50 but probably
-closer to 100.
+the network will right away be available to vaidators that want to register
+their intention to validate. The transition to Proof-of-Stake will largely
+depend on when a sufficient number of validators have registered and are ready
+to take over the security of the network. This number can be as low as 50 but
+probably closer to 100.
 
 ## Validators
 
 ### How do I apply to be a validator?
 
-There is no central authority that decides on validators, so there is no _one_
-application that you can fill out. Since becoming a validator is permissionless,
-in order to become one you must only set up a validator node and register
-your intention to validate on chain. For detailed instruction on how to do this
-you can consult the [wiki guide](maintain-guides-how-to-validate-kusama.md) on
-validating for Kusama.
+There is no central authority that decides on validators, so there is not per se
+an _application_ that you can fill out. Registering as a validator is
+permissionless, in order to become one you must only set up a validator node and
+mark your intention to validate on chain. For detailed instruction on how to do
+this you can consult the [wiki guide](maintain-guides-how-to-validate-kusama.md)
+on validating for Kusama.
 
-However, not that because you've set up a validator and have registered your
-intention does not mean that you will be included in the _active set_ right
+However, once you've set up a validator and have registered your intention it
+does not mean that you will be included in the _active set_ right
 away. The validators are elected to the active set based on the results of an
 election algorithm known as [Phragmen's method](learn-phragmen). Phragmen's
 tries to accomplish two things, 1) select `n` members from a larger set based
@@ -67,8 +68,8 @@ You will likely want to campaign your validator to the community in order to
 get more backing. You are looking for _nominators_ that will put up their tokens
 to increase the stake for your validator. Besides this, for validators who
 cannot acquire the minimum stake from the community, Parity and Web3 Foundation
-run a join program called [Thousand Validators][thousand validators] that will
-nominate validators if they conform to some requirements.
+run a joint program called [Thousand Validators][thousand validators] that will
+nominate validators if they apply and fit the requirements.
 
 ### How are validators rewarded?
 
@@ -114,14 +115,14 @@ such as implementing signature aggregation for finalization messages the number
 of validators could reasonably scale up. However, increasing validators above
 one thousand remains a goal for later iterations of Polkadot.
 
-It is also worth mentioning that one thousand validators is already higher than
+It is also worth mentioning that one thousand validators is more than
 the number of validators of similar PoS chains with comparable levels of economic
-security as Polkadot. The closes contenders are operating with around 150
-validators, while Kusama is running with 180 securely.
+security as Polkadot. The closest contenders are operating with around 150
+validators, while Kusama is running with 180 securely as of April 2020.
 
 Additionally, other projects sometimes have a different definition of _validator_
-that approximates more closely to just remote signing keys without the full
-set-up of a validating node. On Polkadot, each validator is running their own
+that approximates more closely to remote signing keys without the full
+operation of a validating node. On Polkadot, each validator is running their own
 validating node and performing full verification of the Relay Chain, voting on
 finality, producing blocks in their decided slots, and verifying parachain state
 transitions. Other projects may consider validators and "validating nodes" as
@@ -145,23 +146,27 @@ environment.
 No - and yes. The Polkadot Relay Chain does not implement smart contracts
 natively. The reason for not having smart contracts on the Relay Chain is 
 party of the design philosophy for Polkadot that dictates it should be the 
-minimal logic required.
+minimal logic required to accomplish its job.
 
 However, Polkadot will be a platform for other chains that _do_ implement
 smart contracts. It's possible for parachains to enable smart contract functionality
 and then benefit from the security and interoperability features of Polkadot. 
 Additionally, already existing smart contract chains can connect to Polkadot
-as a parachain, or via a bridge. 
+as a parachain, or via a bridge.
+
+While the Polkadot Relay Chain does not implement smart contracts directly,
+undoubtedly there will be parachains that do. So it's better to say that the 
+Polkadot _ecosystem_ has smart contracts versus "Polkadot has smart contracts."
 
 ### How will the Polkadot Relay Chain connect to external chains in the ecosystem?
 
 One of the cornerstone interoperability technologies being research and developed
-for deployment on Polkadot is cross-chain bridges. Bridges can in a variety
-of flavors with varying levels of trust associated with them. Polkadot is mostly
+for deployment on Polkadot is cross-chain bridges. Bridges come in a variety
+of flavors with varying levels of trust associated with them. Polkadot is predominantly
 researching the trust-minimized flavor that imposes economic costs on the operators
 of the bridge, and therefore makes it economically secure. Bridge efforts are being
 work on in concert with other projects in the ecosystem. Eventually, there
-will be bridges between Polkadot and most of the major chains. 
+will be bridges between Polkadot and most of the other major chains. 
 
 ## DOTs
 
@@ -196,33 +201,38 @@ individuals to participate in trading of DOTs before Polkadot launch.
 
 ### What prevents Polkadot governance from failing?
 
-To date, runtime upgrades have successfully taken place through the governance
-process of Polkadot on the testnets as well as on [Kusama](kusama-index).
-Although the field of on-chain blockchain governance is still new, and we don't
-know exactly what is optimal yet, the governance logic of Polkadot has been
-shown to work in a live economic environment. Since blockchains need a method
-to adapt and evolve, an on-chain governance system was necessary for the long-term
-success of Polkadot. Ultimately, the token holders are the actors that prevent
-Polkadot's governance from failing by using their economic value to vote on
-the progression of the protocol.
+Polkadot's governance has already been shown to work, examples of which can by
+found in the runtime upgrades that have successfully taken place through on the 
+testnets as well as in a real economic environment on [Kusama](kusama-index).
+
+It is fair to say that the field of on-chain blockchain governance is still new,
+and no one can claim to know exactly what is the optimal version of on-chain
+governance yet. However, Polkadot takes a brave step forward in pioneering
+thought-through mechanisms for evolving a blockchain.
+
+Blockchains need a method to adapt and evolve. Therefore, an on-chain governance
+system was necessary for the long-term success of Polkadot. Ultimately, it is
+the token holders that are resonsible for preventing Polkadot's governance from
+failing by using their economic value and conviction to sway the progression of
+the protocol.
 
 ### What prevents Polkadot governance from becoming plutocratic?
 
 A savvy reader might have noticed that the answer to the previous question
 endowed the token holder with the ultimate responsibility to ensure that
-Polkadot's governance does not fail. By following the course of this assertion,
+Polkadot's governance does not fail. By following the train of this assertion,
 one might assume that Polkadot's governance is susceptible to becoming ruled
 by a few large token holders (called _whales_ in trading parlance) and therefore
-being a mere plutocracy. 
+become a mere plutocracy (rule of the rich).
 
 There are a couple further mechanisms that are built-in to the governance system
 to resist this plutocratic tendency. One of these mechanisms is called conviction
 voting, and imbues greater voting power to token holders who are willing to lock
-their tokens on the protocol for longer lengths of time to display _conviction_
+their tokens on the protocol for longer lengths of time. Longer lock-ups display _conviction_
 in a vote. Conviction voting could allow a highly determined minority to overrule
 the vote of an apathetic majority in certain situations. Another mechanism is
 known as Adaptive Quorum Biasing, and this makes it so that proposals have a
-varying threshold for approval or rejction based on what part of the governance
+varying threshold for approval or rejection based on what part of the governance
 protocol that the proposal originated in. For details on the subtleties of
 Polkadot's governance system, please see the [governance page](learn-governance).
 
@@ -244,7 +254,7 @@ up to parachain implementers.
 Parachains are not ephemeral. As long as someone is keeping the data for a
 parachain, the parachain can move between being a parachain, a parathread, or
 a separate sovereign chain at different points of its lifetime. Especially
-with parathreads, parachains can be decomissioned to only produce blocks when
+with parathreads, parachains can be decommissioned to only produce blocks when
 their usage and throughput makes it necessary.
 
 When a parachain loses an auction for renewal, that parachain has a few options.

--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -101,6 +101,32 @@ same Rust code that is ran in Polkadot.
 give you the estimation that is based on the currently elected set, as well as
 some statistics about Kusama validators.
 
+### Why will Polkadot have only 1000 validators while other projects have hundreds of thousands?
+
+Polkadot's goal to have 1000 validators is set to be something that is practically
+achievable in the short term with high confidence of good performance in a live
+environment. Furthermore, validators in Polkadot are not the only stakers, and
+if we consider the number of stakers that can be possible on Polkadot the number
+can scale up to hundreds of thousands. Since validators are performing critical
+consensus work to maintain the security of the chain including all of its shards,
+a more modest number of validators is estimated to start. Upon later improvements,
+such as implementing signature aggregation for finalization messages the number
+of validators could reasonably scale up. However, increasing validators above
+one thousand remains a goal for later iterations of Polkadot.
+
+It is also worth mentioning that one thousand validators is already higher than
+the number of validators of similar PoS chains with comparable levels of economic
+security as Polkadot. The closes contenders are operating with around 150
+validators, while Kusama is running with 180 securely.
+
+Additionally, other projects sometimes have a different definition of _validator_
+that approximates more closely to just remote signing keys without the full
+set-up of a validating node. On Polkadot, each validator is running their own
+validating node and performing full verification of the Relay Chain, voting on
+finality, producing blocks in their decided slots, and verifying parachain state
+transitions. Other projects may consider validators and "validating nodes" as
+separate entities.
+
 ## Relay Chain
 
 ### What is the expected block time on the Relay Chain?
@@ -143,6 +169,40 @@ moved from the current allocation address. Individuals with an allocation of DOT
 can always keep a copy of their private key, therefore it is extreme risk for
 individuals to participate in trading of DOTs before Polkadot launch.
 
+## Governance
+
+### What prevents Polkadot governance from failing?
+
+To date, runtime upgrades have successfully taken place through the governance
+process of Polkadot on the testnets as well as on [Kusama](kusama-index).
+Although the field of on-chain blockchain governance is still new, and we don't
+know exactly what is optimal yet, the governance logic of Polkadot has been
+shown to work in a live economic environment. Since blockchains need a method
+to adapt and evolve, an on-chain governance system was necessary for the long-term
+success of Polkadot. Ultimately, the token holders are the actors that prevent
+Polkadot's governance from failing by using their economic value to vote on
+the progression of the protocol.
+
+### What prevents Polkadot governance from becoming plutocratic?
+
+A savvy reader might have noticed that the answer to the previous question
+endowed the token holder with the ultimate responsibility to ensure that
+Polkadot's governance does not fail. By following the course of this assertion,
+one might assume that Polkadot's governance is susceptible to becoming ruled
+by a few large token holders (called _whales_ in trading parlance) and therefore
+being a mere plutocracy. 
+
+There are a couple further mechanisms that are built-in to the governance system
+to resist this plutocratic tendency. One of these mechanisms is called conviction
+voting, and imbues greater voting power to token holders who are willing to lock
+their tokens on the protocol for longer lengths of time to display _conviction_
+in a vote. Conviction voting could allow a highly determined minority to overrule
+the vote of an apathetic majority in certain situations. Another mechanism is
+known as Adaptive Quorum Biasing, and this makes it so that proposals have a
+varying threshold for approval or rejction based on what part of the governance
+protocol that the proposal originated in. For details on the subtleties of
+Polkadot's governance system, please see the [governance page](learn-governance).
+
 ## Parachains
 
 ### How do parachain economics work?
@@ -155,6 +215,21 @@ of the parachain and the Polkadot network is completely separate from parachain
 economics. Parachains need collators to continue to progress, so it wouldn't be
 unreasonable to see them incentivize collator nodes in some way but it is completely
 up to parachain implementers.
+
+### Are parachains ephemeral? What happens when a parachain loses the next auction?
+
+Parachains are not ephemeral. As long as someone is keeping the data for a
+parachain, the parachain can move between being a parachain, a parathread, or
+a separate sovereign chain at different points of its lifetime. Especially
+with parathreads, parachains can be decomissioned to only produce blocks when
+their usage and throughput makes it necessary.
+
+When a parachain loses an auction for renewal, that parachain has a few options.
+In most cases, becoming a parathread instead would be a suitable choice. Parathreads
+are still secured by the Relay Chain, but don't need to hold a parachain slot
+and can produce a block when its economically feasible for them. For more on
+parachains please see the [parachains page](learn-parachains) and for more on
+parathreads see [here](learn-parathreads).
 
 ## Networking
 

--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -12,8 +12,8 @@ _This FAQ focuses on technical questions for users interested in developing appl
 
 The Polkadot network will launch first as a Proof-of-Authority (PoA) chain.
 During this time, governance will be controlled by the single Sudo (super-user)
-account, and functionality will be restricted to (among other things) disallow
-the transfer of funds. 
+account, and functionality will be restricted. Among other things, transfer of
+funds will not be enabled during this period.
 
 During this time, validators can start joining the network and signaling
 their intention to participate in consensus. When a sufficient number of validators
@@ -44,6 +44,11 @@ their intention to validate. The transition to Proof-of-Stake will largely
 depend on when a sufficient number of validators have registered and are ready
 to take over the security of the network. This number can be as low as 50 but
 probably closer to 100.
+
+The launch process is expected to be similar to that of the Kusama network.
+Kusama transitioned to PoS when there were 50 validators ready, but in a matter
+of months scaled up the validator count to 225. Polkadot's validator count is
+expected to scale up in a similar fashion. 
 
 ## Validators
 
@@ -135,7 +140,7 @@ separate entities.
 The Kusama network, an early and unaudited release of the Polkadot code is
 currently operating at a rate of one block every six seconds. 
 
-It is expected that Polkadot will also target its block production for producing
+We expect that Polkadot will target its block production rate to produce
 a block every six seconds. However, it is still subject to change. It may go
 as low as two to three seconds after optimizations, or it may potentially
 increase in order to handle the capacity of the parachain networking in a live
@@ -278,7 +283,8 @@ needed.
 
 The Rust implementation of the specification was built and primarily maintained
 by a team of contributors at Parity Technologies. The Go and JavaScript versions
-are maintained by Protocol Labs as well as community contributors. It is an open
+are maintained by Protocol Labs as well as community contributors. A [Nim][nim libp2p] 
+version of the library also exists. Libp2p as a whole is an open
 source project that is actively developed and expanded on various code repositories
 hosted on [GitHub][libp2p github].
 
@@ -344,6 +350,7 @@ The "Answered by Gav" series is a collection of posts uploaded to Reddit of ques
 
 [fee calculation]: https://substrate.dev/docs/en/next/development/module/fees#fee-calculatio
 [libp2p]: https://libp2p.io
+[nim libp2p]: https://github.com/status-im/nim-libp2p
 [libp2p github]: https://github.com/libp2p
 [substrate network]: https://crates.parity.io/sc_network/index.html
 [thousand validators]: https://thousand-validators.kusama.network/#/

--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -10,36 +10,36 @@ _This FAQ focuses on technical questions for users interested in developing appl
 
 ### What is the launch process of Polkadot Beta?
 
-The Polkadot network will launch first in as a Proof-of-Authority (PoA) chain.
+The Polkadot network will launch first as a Proof-of-Authority (PoA) chain.
 During this time, governance will be controlled by the single Sudo (super-user)
 account, and functionality will be restricted to (among other things) disallow
 the transfer of funds. 
 
-During this time, validators can start joining the network by signalling
-their intention to participate in consensus. When a sufficient number of validator
+During this time, validators can start joining the network and signaling
+their intention to participate in consensus. When a sufficient number of validators
 are sourced from the community, the Sudo account will initiate the transition
 of the chain security from PoA to Proof-of-Stake (PoS). After this happens,
-the first validator elections will begin and the chain  will be going forward 
+the first validator elections will begin, and from that time onward, the chain will be 
 secured by the economic stake that is bonded by validators and nominators.
 
 After the chain has been secured by the decentralized community of validators,
 the next step is to transition the governance of the chain into the hands of the
-token holders. The Sudo account will now initiate an upgrade that erases the
+token holders. The Sudo account will initiate an upgrade that erases the
 Sudo logic from the chain entirely and replaces it with the stakeholder
-governance modules. From henceforward, the network is in the hands of the token
-holders and no longer under control of an authority.
+governance modules. From this point, the network is entirely in the hands of the token
+holders and no longer under control of any centralized authority.
 
 The final step to transition to full-functioning Polkadot is the enabling of
-transfer functionality. The community will need to propose a new upgrade and vote
+transfer functionality. The community will need to propose a runtime upgrade and vote
 upon it in order to accomplish this. If the vote to enable transfers passes, then
 it will be enacted shortly thereafter. When this takes place, Polkadot will
-be fully live and move out of it's Beta release label.
+be fully live and move out of its Beta release label.
 
 ### How many validators will be validating at Polkadot Beta launch?
 
 Initially only a few authorized validators will be securing the network. However,
 as [detailed in the answer above](#what-is-the-launch-process-of-polkadot-beta),
-the network will right away be available to vaidators that want to register
+the network will right away be available to validators that want to register
 their intention to validate. The transition to Proof-of-Stake will largely
 depend on when a sufficient number of validators have registered and are ready
 to take over the security of the network. This number can be as low as 50 but
@@ -51,7 +51,7 @@ probably closer to 100.
 
 There is no central authority that decides on validators, so there is not per se
 an _application_ that you can fill out. Registering as a validator is
-permissionless, in order to become one you must only set up a validator node and
+permissionless; in order to become one you must only set up a validator node and
 mark your intention to validate on chain. For detailed instruction on how to do
 this you can consult the [wiki guide](maintain-guides-how-to-validate-kusama.md)
 on validating for Kusama.
@@ -59,22 +59,22 @@ on validating for Kusama.
 However, once you've set up a validator and have registered your intention it
 does not mean that you will be included in the _active set_ right
 away. The validators are elected to the active set based on the results of an
-election algorithm known as [Phragmen's method](learn-phragmen). Phragmen's
-tries to accomplish two things, 1) select `n` members from a larger set based
+election algorithm known as [Phragmen's method](learn-phragmen). Phragmen's method
+tries to accomplish two goals: 1) select `n` members from a larger set based
 on stake-weighted votes and 2) equalize the stake backing each validator as 
 much as possible.
 
 You will likely want to campaign your validator to the community in order to
 get more backing. You are looking for _nominators_ that will put up their tokens
-to increase the stake for your validator. Besides this, for validators who
+to increase the stake for your validator. For validators who
 cannot acquire the minimum stake from the community, Parity and Web3 Foundation
-run a joint program called [Thousand Validators][thousand validators] that will
+also run a joint program called [Thousand Validators][thousand validators] that will
 nominate validators if they apply and fit the requirements.
 
 ### How are validators rewarded?
 
 Validators are rewarded from the inflation of the Relay Chain, transaction fees,
-and tips. However they only take a percentage of the former two. More details
+and tips. However, they only take a percentage of the former two. More details
 can be read on the page for [validator payouts](maintain-guides-validator-payout).
 
 ### What is the minimum stake necessary to be elected as an active validator?
@@ -86,7 +86,7 @@ validators are waiting in the pool.
 
 There are a few ways to estimate the minimum stake.
 
-One way, can be to navigate
+One way can be to navigate
 to the [Polkadot Apps](https://polkadot.js.org/apps) and click on the Staking
 tab. Scroll all the way down to the bottom and look at the stake backing the
 validator at the end of the list. That's roughly the minimum stake required
@@ -99,7 +99,7 @@ exact results of running an election on the current set of validators using the
 same Rust code that is ran in Polkadot. 
 
 - [Validator stats script](https://github.com/ansonla3/kusama-validator-stats) can
-give you the estimation that is based on the currently elected set, as well as
+give you an estimate that is based on the currently elected set, as well as
 some statistics about Kusama validators.
 
 ### Why will Polkadot have only 1000 validators while other projects have hundreds of thousands?
@@ -111,14 +111,14 @@ if we consider the number of stakers that can be possible on Polkadot the number
 can scale up to hundreds of thousands. Since validators are performing critical
 consensus work to maintain the security of the chain including all of its shards,
 a more modest number of validators is estimated to start. Upon later improvements,
-such as implementing signature aggregation for finalization messages the number
+such as implementing signature aggregation for finalization messages, the number
 of validators could reasonably scale up. However, increasing validators above
 one thousand remains a goal for later iterations of Polkadot.
 
 It is also worth mentioning that one thousand validators is more than
 the number of validators of similar PoS chains with comparable levels of economic
 security as Polkadot. The closest contenders are operating with around 150
-validators, while Kusama is running with 180 securely as of April 2020.
+validators, while Kusama is running with 225 securely as of April 2020.
 
 Additionally, other projects sometimes have a different definition of _validator_
 that approximates more closely to remote signing keys without the full
@@ -145,13 +145,13 @@ environment.
 
 No - and yes. The Polkadot Relay Chain does not implement smart contracts
 natively. The reason for not having smart contracts on the Relay Chain is 
-party of the design philosophy for Polkadot that dictates it should be the 
+party of the design philosophy for Polkadot that dictates that the Relay Chain should be the 
 minimal logic required to accomplish its job.
 
 However, Polkadot will be a platform for other chains that _do_ implement
 smart contracts. It's possible for parachains to enable smart contract functionality
 and then benefit from the security and interoperability features of Polkadot. 
-Additionally, already existing smart contract chains can connect to Polkadot
+Additionally, existing smart contract chains can connect to Polkadot
 as a parachain, or via a bridge.
 
 While the Polkadot Relay Chain does not implement smart contracts directly,
@@ -165,7 +165,7 @@ for deployment on Polkadot is cross-chain bridges. Bridges come in a variety
 of flavors with varying levels of trust associated with them. Polkadot is predominantly
 researching the trust-minimized flavor that imposes economic costs on the operators
 of the bridge, and therefore makes it economically secure. Bridge efforts are being
-work on in concert with other projects in the ecosystem. Eventually, there
+worked on in concert with other projects in the ecosystem. Eventually, there
 will be bridges between Polkadot and most of the other major chains. 
 
 ## DOTs
@@ -190,18 +190,18 @@ the [Polkadot Network FAQ](https://polkadot.network/faq/)).  Subscribe to the
 Polkadot newsletter on [polkadot.network](https://polkadot.network/) for further
 updates.
 
-DOT token are not transferrable until the launch of Polkadot Beta is complete.
-Any transfers before that time of DOTs are illegitimate and unauthorized. DOTs
-are currenly represented on Ethereum as the DOT Indicator Token, these cannot be
+DOT tokens are not transferable until the launch of Polkadot Beta is complete.
+Any transfers of DOTs before that time are illegitimate and unauthorized. DOTs
+are currently represented on Ethereum as the DOT Indicator Token, these cannot be
 moved from the current allocation address. Individuals with an allocation of DOTs
-can always keep a copy of their private key, therefore it is extreme risk for
+can always keep a copy of their private key, therefore it is extremely risky for
 individuals to participate in trading of DOTs before Polkadot launch.
 
 ## Governance
 
 ### What prevents Polkadot governance from failing?
 
-Polkadot's governance has already been shown to work, examples of which can by
+Polkadot's governance has already been shown to work. Examples can be
 found in the runtime upgrades that have successfully taken place through on the 
 testnets as well as in a real economic environment on [Kusama](kusama-index).
 
@@ -212,7 +212,7 @@ thought-through mechanisms for evolving a blockchain.
 
 Blockchains need a method to adapt and evolve. Therefore, an on-chain governance
 system was necessary for the long-term success of Polkadot. Ultimately, it is
-the token holders that are resonsible for preventing Polkadot's governance from
+the token holders that are responsible for preventing Polkadot's governance from
 failing by using their economic value and conviction to sway the progression of
 the protocol.
 
@@ -225,15 +225,15 @@ one might assume that Polkadot's governance is susceptible to becoming ruled
 by a few large token holders (called _whales_ in trading parlance) and therefore
 become a mere plutocracy (rule of the rich).
 
-There are a couple further mechanisms that are built-in to the governance system
+There are several other mechanisms that are built-in to the governance system
 to resist this plutocratic tendency. One of these mechanisms is called conviction
 voting, and imbues greater voting power to token holders who are willing to lock
 their tokens on the protocol for longer lengths of time. Longer lock-ups display _conviction_
 in a vote. Conviction voting could allow a highly determined minority to overrule
 the vote of an apathetic majority in certain situations. Another mechanism is
-known as Adaptive Quorum Biasing, and this makes it so that proposals have a
+known as Adaptive Quorum Biasing.  This makes proposals have a
 varying threshold for approval or rejection based on what part of the governance
-protocol that the proposal originated in. For details on the subtleties of
+protocol the proposal originated in. For details on the subtleties of
 Polkadot's governance system, please see the [governance page](learn-governance).
 
 ## Parachains
@@ -243,10 +243,10 @@ Polkadot's governance system, please see the [governance page](learn-governance)
 Parachains have the flexibility to implement their own monetary system or
 incentive structure for collators. However, this is not strictly necessary.
 Since the collator's job is to continue to give recent state transitions to
-the validators on the relay chain whom validate each transition, the security
+the validators on the relay chain who validate each transition, the security
 of the parachain and the Polkadot network is completely separate from parachain
 economics. Parachains need collators to continue to progress, so it wouldn't be
-unreasonable to see them incentivize collator nodes in some way but it is completely
+unreasonable to see them incentivize collator nodes in some way but the specific mechanism is completely
 up to parachain implementers.
 
 ### Are parachains ephemeral? What happens when a parachain loses the next auction?
@@ -262,7 +262,7 @@ In most cases, becoming a parathread instead would be a suitable choice. Parathr
 are still secured by the Relay Chain, but don't need to hold a parachain slot
 and can produce a block when its economically feasible for them. For more on
 parachains please see the [parachains page](learn-parachains) and for more on
-parathreads see [here](learn-parathreads).
+parathreads see [the parathreads page](learn-parathreads).
 
 ## Networking
 
@@ -270,7 +270,7 @@ parathreads see [here](learn-parathreads).
 
 [Libp2p][libp2p] is a modular and extensible networking stack that is used by
 IPFS, Substrate, and many other projects. It is a collection of peer-to-peer
-protocols for finding peers and connecting to them. It's modules have logic for
+protocols for finding peers and connecting to them. Its modules have logic for
 content routing, peer routing, peer discovery, different transports, and NAT
 traversals. It is intended to be used by applications for building large scale
 peer-to-peer networks by only selecting the parts of the protocol suite that are
@@ -287,7 +287,7 @@ hosted on [GitHub][libp2p github].
 Yes, since Polkadot is built with Substrate. Substrate uses a networking protocol
 that is based on libp2p (specifically the Rust libp2p library). However, Substrate
 uses a mix of standard libp2p protocols and protocols that are homegrown and not
-official libp2p standards. Of the standards protocols, these which are shared
+official libp2p standards. Of the standards protocols, those which are shared
 with other implementations of libp2p such as IPFS, are connection-checking (ping),
 asking for information on a peer (identity), and Kademlia random walks (kad).
 
@@ -311,7 +311,7 @@ integration between the two applications.
 
 ### What is the minimum amount of KSM I can have in my account?
 
-It is recommended to always ensure that you keep at least 0.1 KSM in your account in order to avoid the reaping threshold of 0.01 KSM.  If you have less than 0.01 KSM in your account, that account will be "reaped" - it will be removed and no longer occupy space on the chain. In other words, no accounts are allowed on-chain with an account balance of less than 0.01 KSM.   This is a dust prevention measure, in order to ensure that the chain is not full of accounts with minuscule amounts of KSM taking up space. Since the blockchain is copied to every person running a full node, any savings of space provides dramatic benefits in terms of scalability.
+We recommend users always keep at least 0.1 KSM in their account in order to avoid the reaping threshold of 0.01 KSM.  If you have less than 0.01 KSM in your account, that account will be "reaped" - it will be removed and no longer occupy space on the chain. In other words, no accounts are allowed on-chain with an account balance of less than 0.01 KSM.   This is a dust prevention measure, in order to ensure that the chain is not full of accounts with minuscule amounts of KSM taking up space. Since the blockchain is copied to every person running a full node, any savings of space provide dramatic benefits in terms of scalability.
 
 ### What are the transfer fees for Kusama?
 

--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -6,7 +6,7 @@ sidebar_label: Frequently Asked Questions (FAQs)
 
 _This FAQ focuses on technical questions for users interested in developing applications for Polkadot. If you have a more general question, you may wish to search for the answer on the main [Polkadot Network FAQ](https://polkadot.network/faq). If you have a question which is not answered, please feel free to ask on the Polkadot Watercooler [Riot channel](https://riot.im/app/#/room/#polkadot-watercooler:matrix.org)._
 
-## Polkadot
+## Polkadot Launch
 
 ### What is the launch process of Polkadot Beta?
 
@@ -44,6 +44,8 @@ a sufficient number of validators have registered and are ready to take over
 the security of the network. This number can be as low as 50 but probably
 closer to 100.
 
+## Validators
+
 ### How do I apply to be a validator?
 
 There is no central authority that decides on validators, so there is no _one_
@@ -68,6 +70,39 @@ cannot acquire the minimum stake from the community, Parity and Web3 Foundation
 run a join program called [Thousand Validators][thousand validators] that will
 nominate validators if they conform to some requirements.
 
+### How are validators rewarded?
+
+Validators are rewarded from the inflation of the Relay Chain, transaction fees,
+and tips. However they only take a percentage of the former two. More details
+can be read on the page for [validator payouts](maintain-guides-validator-payout).
+
+### What is the minimum stake necessary to be elected as an active validator?
+
+The minimum stake that is necessary to be elected as an active validator is
+dynamic and can change over time. It depends not only on how much stake is being
+put behind each validator, but also the size of the active set and how many
+validators are waiting in the pool.
+
+There are a few ways to estimate the minimum stake.
+
+One way, can be to navigate
+to the [Polkadot Apps](https://polkadot.js.org/apps) and click on the Staking
+tab. Scroll all the way down to the bottom and look at the stake backing the
+validator at the end of the list. That's roughly the minimum stake required
+to enter the active set at that era.
+
+You can also use some tools some to perform estimations.
+
+- [Offline Phragmen](https://github.com/kianenigma/offline-phragmen) can provide
+exact results of running an election on the current set of validators using the 
+same Rust code that is ran in Polkadot. 
+
+- [Validator stats script](https://github.com/ansonla3/kusama-validator-stats) can
+give you the estimation that is based on the currently elected set, as well as
+some statistics about Kusama validators.
+
+## Relay Chain
+
 ### What is the expected block time on the Relay Chain?
 
 The Kusama network, an early and unaudited release of the Polkadot code is
@@ -79,6 +114,8 @@ as low as two to three seconds after optimizations, or it may potentially
 increase in order to handle the capacity of the parachain networking in a live
 environment.
 
+## DOTs
+
 ### What is the inflation rate of the DOT?
 
 The inflation rate is 10% per year.
@@ -88,11 +125,25 @@ while another portion may go directly to the treasury. The exact percentage that
 goes into both varies and is based on the amount of DOTs that are staked.
 Please see the article on [inflation](learn-staking#inflation) for more information.
 
-### How are validators rewarded?
+### Can I buy or transfer DOT tokens?
 
-Validators are rewarded from the inflation of the Relay Chain, transaction fees,
-and tips. However they only take a percentage of the former two. More details
-can be read on the page for [validator payouts](maintain-guides-validator-payout).
+Testnet DOT tokens are freely available from a variety of sources. See
+the [DOT page](learn-DOT) for details.
+
+The Web3 Foundation will distribute up to 20% of mainnet DOTs prior to network
+launch (see [Light Paper](https://polkadot.network/Polkadot-lightpaper.pdf) or
+the [Polkadot Network FAQ](https://polkadot.network/faq/)).  Subscribe to the
+Polkadot newsletter on [polkadot.network](https://polkadot.network/) for further
+updates.
+
+DOT token are not transferrable until the launch of Polkadot Beta is complete.
+Any transfers before that time of DOTs are illegitimate and unauthorized. DOTs
+are currenly represented on Ethereum as the DOT Indicator Token, these cannot be
+moved from the current allocation address. Individuals with an allocation of DOTs
+can always keep a copy of their private key, therefore it is extreme risk for
+individuals to participate in trading of DOTs before Polkadot launch.
+
+## Parachains
 
 ### How do parachain economics work?
 
@@ -102,46 +153,72 @@ Since the collator's job is to continue to give recent state transitions to
 the validators on the relay chain whom validate each transition, the security
 of the parachain and the Polkadot network is completely separate from parachain
 economics. Parachains need collators to continue to progress, so it wouldn't be
-unreasonable to see them incentivize collator nodes in some way but it is completely up to parachain implementers.
+unreasonable to see them incentivize collator nodes in some way but it is completely
+up to parachain implementers.
 
-### What are the transfer fees for Kusama and Polkadot?
+## Networking
 
-It is important to note that the cost of transferring KSM or DOT tokens is dynamic. Currently, the minimum cost of transferring KSM is 0.01 KSM (the base fee), although this can be changed via governance. However, actual transaction fees will vary based on a variety of factors. Specifically, fee calculation follows the following formula:
+### What is libp2p?
 
-```
-base_fee + (tx_length * length_fee) + WeightToFee(weight)
-```
+[Libp2p][libp2p] is a modular and extensible networking stack that is used by
+IPFS, Substrate, and many other projects. It is a collection of peer-to-peer
+protocols for finding peers and connecting to them. It's modules have logic for
+content routing, peer routing, peer discovery, different transports, and NAT
+traversals. It is intended to be used by applications for building large scale
+peer-to-peer networks by only selecting the parts of the protocol suite that are
+needed.
 
-Please see the (Substrate page on fee calculation)[https://substrate.dev/docs/en/next/development/module/fees#fee-calculation] for more detailed information.
+The Rust implementation of the specification was built and primarily maintained
+by a team of contributors at Parity Technologies. The Go and JavaScript versions
+are maintained by Protocol Labs as well as community contributors. It is an open
+source project that is actively developed and expanded on various code repositories
+hosted on [GitHub][libp2p github].
+
+### Does Polkadot use libp2p?
+
+Yes, since Polkadot is built with Substrate. Substrate uses a networking protocol
+that is based on libp2p (specifically the Rust libp2p library). However, Substrate
+uses a mix of standard libp2p protocols and protocols that are homegrown and not
+official libp2p standards. Of the standards protocols, these which are shared
+with other implementations of libp2p such as IPFS, are connection-checking (ping),
+asking for information on a peer (identity), and Kademlia random walks (kad).
+
+Of the protocols that are custom to Substrate, there are the legacy Substrate
+stream, a request-response for getting information on blocks (sync), a light
+client protocol, a notification protocol for transactions, and block announcement.
+For detailed information on how Substrate uses libp2p and the standard and custom
+protocols, please see the [networking documentation][substrate network]. 
+
+### How does libp2p differ from IPFS?
+
+The [Interplanetary Filesystem][ipfs] (IPFS) is a peer-to-peer hypermedia protocol
+used primarily for storage of files. It allows one to upload a file onto the
+network and share it with its content addressable URI. IPFS, like Substrate,
+is an application of libp2p and exists higher on the technology stack. Although
+both IPFS and Substrate use libp2p, it cannot be said that Substrate "uses" IPFS
+since besides sharing the underlying library for networking there is no native
+integration between the two applications.
+
+## Kusama
 
 ### What is the minimum amount of KSM I can have in my account?
 
 It is recommended to always ensure that you keep at least 0.1 KSM in your account in order to avoid the reaping threshold of 0.01 KSM.  If you have less than 0.01 KSM in your account, that account will be "reaped" - it will be removed and no longer occupy space on the chain. In other words, no accounts are allowed on-chain with an account balance of less than 0.01 KSM.   This is a dust prevention measure, in order to ensure that the chain is not full of accounts with minuscule amounts of KSM taking up space. Since the blockchain is copied to every person running a full node, any savings of space provides dramatic benefits in terms of scalability.
 
-### Can I buy or transfer DOT tokens?
+### What are the transfer fees for Kusama?
 
-Testnet DOT and KSM tokens are freely available from a variety of sources - see the [DOT page](learn-DOT) for details.
+It is important to note that the cost of transferring KSM is dynamic.
+Currently, the minimum cost of transferring KSM is 0.01 KSM (the base fee), although
+this can be changed via governance. However, actual transaction fees will vary
+based on a variety of factors. Specifically, fee calculation follows the following
+formula:
 
-Kusama tokens are available via the [claims process](https://claim.kusama.network/) (if you have already purchased DOTs), the [frictional faucet](https://guide.kusama.network/en/latest/start/faucet/), or via [grant request](http://grants.web3.foundation) from the Web3 Foundation.  Upon obtaining Kusama tokens, they are freely transferable.
+```
+base_fee + (tx_length * length_fee) + WeightToFee(weight)
+```
 
-The Web3 Foundation will distribute up to 20% of mainnet DOTs prior to network launch (see [Light Paper](https://polkadot.network/Polkadot-lightpaper.pdf) or the [Polkadot Network FAQ](https://polkadot.network/faq/)).  Subscribe to the Polkadot newsletter on [polkadot.network](https://polkadot.network/) for further updates.
-
-Mainnet DOT tokens are not transferrable until mainnet launch, expected in early 2020. Any transfers before that time of mainnet DOTs are illegitimate and unauthorized. DOTs can not be moved from a current allocation address. Individuals with an allocation of DOTs who transfer their DOT address to someone else can always keep a copy of their private key, therefore there is extreme risk for individuals participating in transfers of DOTs before mainnet launch.
-
-### What are the ways to find out the minimum stake necessary for the validators?
-
-There are a few ways to estimate it.
-
-- [Offline Phragmen](https://github.com/kianenigma/offline-phragmen)
-
-If you want to know what would be the outcome of the election in the next era, this can provide an estimation result. You can customize parameters such as number of validators to elect, network, and WebSocket endpoint, but it would take some time to build the binary.
-- [Validator stats script](https://github.com/ansonla3/kusama-validator-stats)
-
-This script helps you quickly identify which validator is the lowest-staked and the basic statistics about staking on Kusama.
-
-- [Copy everything from the Staking page](https://polkadot.js.org/apps/#/staking) 
-
-It is also possible to copy both `own stake` and `other stake` on the Staking page to a spreadsheet and then do a simple calculation.
+Please see the [fee calculation][fee calculation] page in the Substrate documentation
+for more detailed information.
 
 
 ## Answered by Gav series
@@ -157,4 +234,8 @@ The "Answered by Gav" series is a collection of posts uploaded to Reddit of ques
 - [How to tackle the concentration risk of Validators in data centers?](https://www.reddit.com/r/dot/comments/bcqwit/answered_by_gav_how_to_tackle_the_concentration/)
 
 
+[fee calculation]: https://substrate.dev/docs/en/next/development/module/fees#fee-calculatio
+[libp2p]: https://libp2p.io
+[libp2p github]: https://github.com/libp2p
+[substrate network]: https://crates.parity.io/sc_network/index.html
 [thousand validators]: https://thousand-validators.kusama.network/#/

--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -140,6 +140,29 @@ as low as two to three seconds after optimizations, or it may potentially
 increase in order to handle the capacity of the parachain networking in a live
 environment.
 
+### Does Polkadot have smart contracts?
+
+No - and yes. The Polkadot Relay Chain does not implement smart contracts
+natively. The reason for not having smart contracts on the Relay Chain is 
+party of the design philosophy for Polkadot that dictates it should be the 
+minimal logic required.
+
+However, Polkadot will be a platform for other chains that _do_ implement
+smart contracts. It's possible for parachains to enable smart contract functionality
+and then benefit from the security and interoperability features of Polkadot. 
+Additionally, already existing smart contract chains can connect to Polkadot
+as a parachain, or via a bridge. 
+
+### How will the Polkadot Relay Chain connect to external chains in the ecosystem?
+
+One of the cornerstone interoperability technologies being research and developed
+for deployment on Polkadot is cross-chain bridges. Bridges can in a variety
+of flavors with varying levels of trust associated with them. Polkadot is mostly
+researching the trust-minimized flavor that imposes economic costs on the operators
+of the bridge, and therefore makes it economically secure. Bridge efforts are being
+work on in concert with other projects in the ecosystem. Eventually, there
+will be bridges between Polkadot and most of the major chains. 
+
 ## DOTs
 
 ### What is the inflation rate of the DOT?

--- a/docs/learn-faq.md
+++ b/docs/learn-faq.md
@@ -6,31 +6,93 @@ sidebar_label: Frequently Asked Questions (FAQs)
 
 _This FAQ focuses on technical questions for users interested in developing applications for Polkadot. If you have a more general question, you may wish to search for the answer on the main [Polkadot Network FAQ](https://polkadot.network/faq). If you have a question which is not answered, please feel free to ask on the Polkadot Watercooler [Riot channel](https://riot.im/app/#/room/#polkadot-watercooler:matrix.org)._
 
-### How many validators will be validating at Mainnet launch?
+## Polkadot
 
-Most likely somewhere between 50 - 100, increasing to 1000 or so later on. [Source](https://youtu.be/IRc5Jma_eH8?t=1630) The number of validators can be changed by governance, and so it is difficult to state precisely how many will be in the active validator set at any particular point in the future.
+### What is the launch process of Polkadot Beta?
+
+The network will launch first in as a Proof-of-Authority (PoA) chain, with governance
+controlled by the single Sudo (super-user) account, and functionality restricted to disallow
+transfers of funds. 
+
+During this time, validator will be able to start joining the network and signalling
+their intention to participate in consensus. When a sufficient number of validator
+are sourced from the community, the Sudo account will initiate the transition
+of the chain security from PoA to Proof-of-Stake (PoS). After this happens,
+the first validator elections will begin and the chain is secured by the
+economic stake that is bonded by validators and nominators.
+
+After the chain has been secured by the decentralized community of validators,
+the next step is to transition the governance of the chain into the hands of the
+token holders. The Sudo account will now initiate an upgrade that erases the
+Sudo logic from the chain entirely and replaces it with the stakeholder
+governance modules. From henceforward, the network is in the hands of the token
+holders and no longer under control of an authority.
+
+The final step to transition to full-functioning Polkadot is the enabling of
+transfer functionality. The community will need to propose a new upgrade and vote
+upon it in order to accomplish this. If the vote to enable transfers passes, then
+it will be enacted shortly thereafter. When this takes place, Polkadot will
+move out of it's Beta release state.
+
+### How many validators will be validating at Polkadot Beta launch?
+
+Initially only a few authority validators will be securing the network. However,
+as [detailed in the answer above](#what-is-the-launch-process-of-polkadot-beta),
+the network will right away be available for vaidators to start registering
+their intentions. The transition to Proof-of-Stake will largely depend on when
+a sufficient number of validators have registered and are ready to take over
+the security of the network. This number can be as low as 50 but probably
+closer to 100.
 
 ### How do I apply to be a validator?
 
-See ("How To Validate on Kusama")[maintain-guides-how-to-validate-kusama.md].  Note that just because you run a validator does not mean you will necessarily be producing blocks; only a certain number of validators will be part of the active validator set, based on the amount of stake they can attract and the results of the (Phragmen election)[learn-phragmen].
+There is no central authority that decides on validators, so there is no _one_
+application that you can fill out. Since becoming a validator is permissionless,
+in order to become one you must only set up a validator node and register
+your intention to validate on chain. For detailed instruction on how to do this
+you can consult the [wiki guide](maintain-guides-how-to-validate-kusama.md) on
+validating for Kusama.
 
-### How does consensus on the relay chain work?
+However, not that because you've set up a validator and have registered your
+intention does not mean that you will be included in the _active set_ right
+away. The validators are elected to the active set based on the results of an
+election algorithm known as [Phragmen's method](learn-phragmen). Phragmen's
+tries to accomplish two things, 1) select `n` members from a larger set based
+on stake-weighted votes and 2) equalize the stake backing each validator as 
+much as possible.
 
-See the [consensus](learn-consensus) page.
+You will likely want to campaign your validator to the community in order to
+get more backing. You are looking for _nominators_ that will put up their tokens
+to increase the stake for your validator. Besides this, for validators who
+cannot acquire the minimum stake from the community, Parity and Web3 Foundation
+run a join program called [Thousand Validators][thousand validators] that will
+nominate validators if they conform to some requirements.
 
-### What is the expected block time on the relay chain?
+### What is the expected block time on the Relay Chain?
 
-The Kusama network is currently operating at a rate of one block approximately every six seconds.
+The Kusama network, an early and unaudited release of the Polkadot code is
+currently operating at a rate of one block every six seconds. 
 
-The initial expected block time on the mainnet Polkadot chain will also be targeted at every six seconds.  However, this is subject to change and after optimization, may go down to as low as every two to three seconds. It also may potentially be longer (up to 10 - 15 seconds) due to the constraint of networking all parachain data.
+It is expected that Polkadot will also target its block production for producing
+a block every six seconds. However, it is still subject to change. It may go
+as low as two to three seconds after optimizations, or it may potentially
+increase in order to handle the capacity of the parachain networking in a live
+environment.
 
-### What is the token inflation rate?
+### What is the inflation rate of the DOT?
 
-This is difficult to calculate precisely, since the [inflation rate will vary](learn-staking#inflation) based on what percentage of the DOTs are staked. For both Kusama and Polkadot, inflation is estimated to be around 10 - 20% for the first year.  Inflation on testnets and parachains will vary more dramatically.
+The inflation rate is 10% per year.
+
+A portion of the inflation is rewarded to validators for performing their duties,
+while another portion may go directly to the treasury. The exact percentage that
+goes into both varies and is based on the amount of DOTs that are staked.
+Please see the article on [inflation](learn-staking#inflation) for more information.
 
 ### How are validators rewarded?
 
-Validators are rewarded from the block reward of the relay chain. Block rewards consist of transaction fees (and tips) and block production rewards. For more details, see the [validator payout page](maintain-guides-validator-payout).
+Validators are rewarded from the inflation of the Relay Chain, transaction fees,
+and tips. However they only take a percentage of the former two. More details
+can be read on the page for [validator payouts](maintain-guides-validator-payout).
 
 ### How do parachain economics work?
 
@@ -93,3 +155,6 @@ The "Answered by Gav" series is a collection of posts uploaded to Reddit of ques
 - [Also is there any detailed overview of how exactly a token transfer from ETH could be exchanged with another chain's currency?](https://www.reddit.com/r/dot/comments/b87ds8/answered_by_gav_also_is_there_any_detailed/)
 - [Can I run multiple Validators with the same Session Key?](https://www.reddit.com/r/dot/comments/bcqrx9/answered_by_gav_can_i_run_multiple_validators/)
 - [How to tackle the concentration risk of Validators in data centers?](https://www.reddit.com/r/dot/comments/bcqwit/answered_by_gav_how_to_tackle_the_concentration/)
+
+
+[thousand validators]: https://thousand-validators.kusama.network/#/


### PR DESCRIPTION
closes #298 closes #219 

The FAQ page was pretty outdated and not up to standards. While adding content to supersede #355,
I decided it would be a good idea to give the whole page a blanket update as well.

- [x] Updates the FAQ page.
- [x] Adds answer to questions that cause confusion in the community (#298)
- [x] Adds a section for networking and LibP2P (#219)