### PR TITLE
add availability and validity link in sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -57,7 +57,7 @@
         "ids": [
           "learn-accounts",
           "learn-architecture",
-	  "learn-availability",  
+          "learn-availability",  
           "learn-security",
           "learn-consensus",
           "learn-governance",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -57,6 +57,7 @@
         "ids": [
           "learn-accounts",
           "learn-architecture",
+	  "learn-availability",  
           "learn-security",
           "learn-consensus",
           "learn-governance",


### PR DESCRIPTION
The AnV page was orphaned (no sidebar link).  This just adds it to the Learn section where it belongs.