### PR TITLE
Removed note on NPoS phase note on Wiki

### DIFF
--- a/docs/maintain-guides-how-to-nominate-kusama.md
+++ b/docs/maintain-guides-how-to-nominate-kusama.md
@@ -68,7 +68,7 @@ you to select some validators.
 Select them, confirm the transaction, and you're done - you are now nominating. Your nominations
 will become active in the next era. Eras last six hours on Kusama - depending on when you do this,
 your nominations may become active almost immediately, or you may have to wait almost the entire six
-hours before your nominations are active. You can chek how far along Kusama is in the current era on
+hours before your nominations are active. You can check how far along Kusama is in the current era on
 the [Staking page](https://polkadot.js.org/apps/#/staking).
 
 Assuming at least one of your nominations ends up in the active validator set, you will start to get

--- a/docs/maintain-guides-how-to-validate-kusama.md
+++ b/docs/maintain-guides-how-to-validate-kusama.md
@@ -192,9 +192,7 @@ verified. You can then compare that to the current highest block via
 
 > **Note:** If you do not already have KSM, this is as far as you will be able to go until the end
 > of the soft launch period. You can still run a node, but you will need to have a minimal amount of
-> KSM to continue, as balance transfers are disabled during the soft launch. Please keep in mind
-> that even for those with KSM, they will only be indicating their _intent_ to validate; they will
-> also not be able to run a validator until the NPoS phase starts.
+> KSM to continue, as balance transfers are disabled during the soft launch.
 
 ## Bond KSM
 


### PR DESCRIPTION
Simply removed the part of the note mentioning NPoS phase: "Please keep in mind that even for those with KSM, they will only be indicating their intent to validate; they will also not be able to run a validator until the NPoS phase starts."