### PR TITLE
Fixed broken link to learn-phragmen.md

### DIFF
--- a/docs/learn-governance.md
+++ b/docs/learn-governance.md
@@ -294,7 +294,7 @@ on every two weeks). All members have a fixed term (1 year). Council members can
 only by a referendum.
 
 To elect a new council member, Polkadot employs the same election scheme as used for choosing the
-active set of validators, a [Phragmén election][phragmen]. The election also chooses a set number of
+active set of validators, a [Phragmén election](learn-phragmen). The election also chooses a set number of
 runners up (currently seven in Kusama) that will remain in the queue with their votes intact.
 
 As opposed to a "first past the post", where voters must decide only on a single candidate chosen


### PR DESCRIPTION
Fixed link syntax and name of page to allow navigation to https://wiki.polkadot.network/docs/en/learn-phragmen