### PR TITLE
Fixed link to Phragmén paper reference

### DIFF
--- a/docs/learn-phragmen.md
+++ b/docs/learn-phragmen.md
@@ -9,7 +9,7 @@ sidebar_label: Sequential Phragmen Method
 The sequential Phragmén method is a multi-winner election method introduced by Edvard Phragmén in
 the 1890s.
 
-The quote below taken from the reference [Phragmén paper][phragmen paper] sums up the purpose of the
+The quote below taken from the reference [Phragmén paper](#external-resources) sums up the purpose of the
 sequential Phragmén method:
 
 > The problem that Phragmén’s methods try to solve is that of electing a set of a given numbers of

--- a/docs/learn-phragmen.md
+++ b/docs/learn-phragmen.md
@@ -9,8 +9,8 @@ sidebar_label: Sequential Phragmen Method
 The sequential Phragmén method is a multi-winner election method introduced by Edvard Phragmén in
 the 1890s.
 
-The quote below taken from the reference [Phragmén paper](#external-resources) sums up the purpose of the
-sequential Phragmén method:
+The quote below taken from the reference [Phragmén paper](#external-resources) sums up the purpose
+of the sequential Phragmén method:
 
 > The problem that Phragmén’s methods try to solve is that of electing a set of a given numbers of
 > persons from a larger set of candidates. Phragmén discussed this in the context of a parliamentary


### PR DESCRIPTION
Corrected markdown syntax and changed the link to navigate to the external resources heading at the bottom of the page where the paper is linked