### PR TITLE
Wireguard subsection added to systemd article in Wiki

### DIFF
--- a/docs/maintain-guides-how-to-systemd.md
+++ b/docs/maintain-guides-how-to-systemd.md
@@ -53,3 +53,57 @@ You can tail the logs with `journalctl` like so:
 ```bash
 journalctl -f -u polkadot-validator
 ```
+
+## Wireguard systemd configuration
+
+You can automatically restart your VPN tunnel between your validator and its sentries using the
+configuration you have already created in the
+[Set Up a Sentry Node - Public Node](maintain-guides-how-to-setup-sentry-node) guide.
+
+Create a file called `wireguard.service` in `/etc/systemd/system`.
+
+```bash
+touch /etc/systemd/system/wireguard.service
+```
+
+Write the commands needed to auto-start wireguard previously configured as `wg0` into the `wgo.conf`
+file in the `/etc/wireguard/` directory.
+
+```
+[Unit]
+Description=Wireguard VPN
+
+[Service]
+Type=forking
+ExecStart=PATH_TO_WG-QUICK_BIN up wg0
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The path to the wg-quick binary on Debian based distributions is usually: `/usr/bin/wg-quick`. If in
+doubt, run `whereis wg-quick`. To enable this to autostart on boot:
+
+```bash
+systemctl enable wireguard.service
+```
+
+Start it manually with:
+
+```bash
+systemctl start wireguard.service
+```
+
+You can check that it's working with:
+
+```bash
+systemctl status wireguard.service
+```
+
+You can tail the logs with journalctl like so:
+
+```bash
+journalctl -f -u wireguard
+```


### PR DESCRIPTION
This PR was created with the fix for the issue #513 "Add Wireguard information to the "Using systemd for the Validator Node" section" 