### PR TITLE
Add styling to Kusama button

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -12,7 +12,7 @@ const siteConfig = {
     { doc: 'build-index', label: 'Build' },
     { doc: 'learn-introduction', label: 'Learn' },
     { doc: 'maintain-index', label: 'Maintain '},
-    { doc: 'kusama-index', label: 'Kusama' },
+    { href: 'https://wiki.polkadot.network/docs/en/kusama-index', label: 'Kusama' },
     { search: true },
     { languages: true }
   ],

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -33,10 +33,6 @@
   cursor: pointer;
 }
 
-.navigationSlider .slidingNav ul li.siteNavGroupActive > a {
-  background-color: black;
-}
-
 .fixedHeaderContainer {
   background: black;
 }
@@ -142,6 +138,17 @@
 .full-width {
   width: 100%;
   text-align: center;
+}
+
+
+.navigationSlider .slidingNav ul li.siteNavGroupActive > a {
+ background-color: black;
+}
+
+
+.nav-site :nth-child(4) {
+  background-color: #E6007A !important;
+  border: solid 1px silver;
 }
 
 body {


### PR DESCRIPTION
This styles the Kusama button to make it different from other buttons on the navbar. In order to make this not affect the other button's styling I changed the Kusama link to a direct "external" link instead of a documentation link. This was done in order to avoid the automatically styling that Docusaurus does to documentation links ([reference](https://docusaurus.io/docs/en/navigation#active-links-in-site-navigation-bar)).

![image](https://user-images.githubusercontent.com/25539605/84499788-8e046e80-acb3-11ea-84ed-5654458801ae.png)
