### PR TITLE
Linking more Teched Videos to Wiki pages

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -18,6 +18,8 @@ period, please proceed to the [attesting to a statement](#attesting-to-a-stateme
 
 > To learn more on How to claim your DOTs post genesis, check out our walkthrough
 > [video](https://www.youtube.com/watch?v=rjhWfKXJTCg&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=22)
+> and our video on
+> [Claiming DOTs with an Ethereum address generated using an old mnemonic phrase](https://www.youtube.com/watch?v=AlwrM27x3As&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=16)
 
 ## Making a Claim
 

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -16,6 +16,9 @@ If you are making a claim on Polkadot for the first time, please read on below i
 [making a claim](#making-a-claim) section. If you've already claimed during the pre-genesis claims
 period, please proceed to the [attesting to a statement](#attesting-to-a-statement) section instead.
 
+> To learn more on How to claim your DOTs post genesis, check out our walkthrough
+> [video](https://www.youtube.com/watch?v=rjhWfKXJTCg&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=22)
+
 ## Making a Claim
 
 If you did not make a claim in the pre-genesis claims period, then you are able to claim your DOT

--- a/docs/learn-account-generation.md
+++ b/docs/learn-account-generation.md
@@ -12,6 +12,9 @@ There are several ways to generate a Polkadot address:
 - [Polkadot.js Web Apps](#polkadotjs)
 - [Parity Signer](#parity-signer)
 
+> To learn more on how to create Polkadot accounts, head over to our
+> [video](https://www.youtube.com/watch?v=hhUZ40ZWqkE&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=19)
+
 ## DISCLAIMER: Key Security
 
 Your secret seed is the _only_ way to get access to your account. You must keep the secret both

--- a/docs/maintain-nominator.md
+++ b/docs/maintain-nominator.md
@@ -68,6 +68,8 @@ using, reputation, the vision behind the validator, and more.
 > [Why Nominate on Polkadot & Kusama video](https://www.youtube.com/watch?v=weG_uzdSs1E&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=4)
 > and
 > [What to Consider when Nominating Validators on Polkadot and Kusama](https://www.youtube.com/watch?v=K-a4CgVchvU&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=9)
+> and
+> [Nominating/Staking on Polkadot and Kusama](https://www.youtube.com/watch?v=NYs9oWAbzbE&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=14)
 
 ### Guides
 

--- a/docs/maintain-validator.md
+++ b/docs/maintain-validator.md
@@ -48,6 +48,7 @@ in exchange for their activities.
 - [Slashing Consequences](https://wiki.polkadot.network/docs/en/learn-staking#slashing) - Learn more
   about slashing consequences for running a validator node.
 - [Why You Should be A Validator on Polkadot and Kusama](https://www.youtube.com/watch?v=0EmP0s6JOW4&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=2)
+- [Roles and Responsibilities of a Validator](https://www.youtube.com/watch?v=riVg_Up_fCg&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&index=15)
 
 ## Security / Key Management
 


### PR DESCRIPTION
I added in a few more recent technical explainer videos that were posted on the Polkadot Youtube channel to each of the wiki pages. 
There still is:
-[] Polkadot launch: Governance phase 
that hasn't yet been added to the wiki page, but it's labeled as `unlisted` on YT