### PR TITLE
Remove duplicate iframe tag

### DIFF
--- a/docs/build-build-with-polkadot.md
+++ b/docs/build-build-with-polkadot.md
@@ -201,7 +201,6 @@ Rob Habermeier, a co-founder of Polkadot, last year gave a talk at EthCC that in
 which you can watch below.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/thgtXq5YMOo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe width="560" height="315" >
 
 ### How to deploy your parachain or parathread in Polkadot
 


### PR DESCRIPTION
The extra opening iframe tag was causing all content after the video not to be shown on the rendered page.