### PR TITLE
Remove Social Recovery TODO

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,6 @@ For brand-new learners of Polkadot:
 - [Setting an Identity][identity]
 - [Creating a Proxy Account][proxy]
 - [Making Proposals and Voting for Referenda][democracy]
-- Social Recovery (Coming soon!)
 - [Running for the Council][council]
 - [Voting for Councillors][council voting]
 - [Using the Treasury][treasury]


### PR DESCRIPTION
We have a [social recovery guide](https://guide.kusama.network/docs/en/kusama-social-recovery#docsNav) but it's a Kusama-only feature so we can remove the line from the Polkadot guides page.