### PR TITLE
Fix #docsnav container height for smaller width displays

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -16,6 +16,9 @@
 }
 
 @media only screen and (min-width: 1024px) {
+  #docsNav {
+    height: 80%;
+  }
 }
 
 @media only screen and (max-width: 1023px) {
@@ -213,7 +216,6 @@ body {
 }
 #docsNav {
   padding-top: 30px;
-  height: 80%;
 }
 
 @media only screen and (max-width: 700px) {


### PR DESCRIPTION
In browser windows with width between 700px and 1024px there has been always an annoying container of doc navigation covering the main content. This pr fixes it.

![pic-selected-200818-2137-41](https://user-images.githubusercontent.com/1465430/90558964-3136a000-e19d-11ea-9ff8-b10b2d10646c.png)
