### PR TITLE
Add research links

### DIFF
--- a/docs/research.md
+++ b/docs/research.md
@@ -7,3 +7,17 @@ sidebar_label: Research Pages
 The Polkadot [research pages](https://research.polkadot.network) are edited directly by the
 researchers at W3F and contains papers, articles and documents that are sources for the information
 on the wiki.
+
+The following papers and articles may be of special interest for those interested in investigsting
+Polkadot from a research or academic perspective.
+
+- [Overview of Polkadot and its Design Considerations](https://arxiv.org/pdf/2005.13456.pdf) - A
+  broad overview of the design of Polkadot.
+- [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) -
+  A description of the NPoS scheme which selects which validators are allowed to participate in the
+  consensus protocol of Polkadot.
+- [BABE](https://research.web3.foundation/en/latest/polkadot/BABE/Babe.html) - Blind Assignment for
+  Blockchain Extension, the block production mechanism of Polkadot's relay chain.
+- [GRANDPA](https://research.web3.foundation/en/latest/polkadot/GRANDPA.html) - GHOST-based
+  Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. This page includes both
+  the abstract and the full GRANDPA papers.


### PR DESCRIPTION
Seems like we should add some links to our papers / articles on the research.md page.

My worry is that the links might go stale, but a) I feel like they let people know what to expect before heading off the wiki to the research page and b) they've stayed pretty constant for a few months already and c) CI will yell at us if they go stale anyways.
