### PR TITLE
Polkadot release updates

### DIFF
--- a/docs/build-build-with-polkadot.md
+++ b/docs/build-build-with-polkadot.md
@@ -21,24 +21,23 @@ application in anticipation of the Polkadot mainnet launch later this year.
 
 ## Where are we now?
 
-- Polkadot release: **Early 2020**
-- Canary release: **Kusama**
-- Current testnet: **Westend**
+- Mainnet: **Polkadot**
+- Canary network: **Kusama**
+- Current major testnets: **Westend** (Polkadot clone) and **Rococo** (parachains)
 - Substrate: **2.0.0**
-- Cumulus: **In development** ([Demo Available](https://github.com/paritytech/cumulus))
 - ink!: **In development**
   ([Documentation](https://substrate.dev/docs/en/knowledgebase/smart-contracts))
 
 ## What you need to know
 
-Polkadot is currently on the v0.7 release with a testnet called Westend and a value-bearing canary
+Polkadot mainnet has been released.  There are also two major testnets - **Westend**, which aims to run similarly to the current Polkadot mainnet, and **Rococo**, which is used specifically for testing parachains.   Additionally, there is  a value-bearing canary
 network called Kusama. Polkadot is being built with
 [implementations in various programming languages](learn-implementations) ranging from Rust to
 JavaScript. Currently the leading implementation is built in Rust and built on the Substrate
 framework. Substrate is a library that allows developers to develop entire blockchain applications
 with ease by bundling together a networking protocol, consensus, and Wasm interpreter. Cumulus, an
-extension to Substrate, will allow any Substrate built chain to connect to Polkadot and become a
-parachain. Substrate is currently nearing its official 2.0.0 tagged release that will solidify its
+extension to Substrate, allows any Substrate built chain to connect to Polkadot and become a
+parachain. Substrate is currently on its 2.0.0 tagged release that solidified its
 API.
 
 Polkadot does not natively support smart contracts, however there will be parachains that do.
@@ -49,8 +48,7 @@ permissionlessly by users or with specific rules dependent on the chain. To faci
 of Wasm smart contracts, Parity is also developing [ink!](https://github.com/paritytech/ink), a
 domain specific language built in Rust for writing smart contracts.
 
-Polkadot is planned to go live with an initial release early in 2020, depending on security audits
-and launch provisions outside of control of the team. Now that the tools have started to appear and
+Polkadot mainnet has been running since May 2020. Now that the tools have started to appear and
 stabilize, there has not been a better time to get your feet wet and start preparing for launch. But
 wait! Before you jump head-first into the code, you should think about the kind of decentralized
 application you want to make and understand the different paradigms available to developers who want

--- a/docs/build-build-with-polkadot.md
+++ b/docs/build-build-with-polkadot.md
@@ -30,15 +30,15 @@ application in anticipation of the Polkadot mainnet launch later this year.
 
 ## What you need to know
 
-Polkadot mainnet has been released.  There are also two major testnets - **Westend**, which aims to run similarly to the current Polkadot mainnet, and **Rococo**, which is used specifically for testing parachains.   Additionally, there is  a value-bearing canary
-network called Kusama. Polkadot is being built with
-[implementations in various programming languages](learn-implementations) ranging from Rust to
-JavaScript. Currently the leading implementation is built in Rust and built on the Substrate
-framework. Substrate is a library that allows developers to develop entire blockchain applications
-with ease by bundling together a networking protocol, consensus, and Wasm interpreter. Cumulus, an
-extension to Substrate, allows any Substrate built chain to connect to Polkadot and become a
-parachain. Substrate is currently on its 2.0.0 tagged release that solidified its
-API.
+Polkadot mainnet has been released. There are also two major testnets - **Westend**, which aims to
+run similarly to the current Polkadot mainnet, and **Rococo**, which is used specifically for
+testing parachains. Additionally, there is a value-bearing canary network called Kusama. Polkadot is
+being built with [implementations in various programming languages](learn-implementations) ranging
+from Rust to JavaScript. Currently the leading implementation is built in Rust and built on the
+Substrate framework. Substrate is a library that allows developers to develop entire blockchain
+applications with ease by bundling together a networking protocol, consensus, and Wasm interpreter.
+Cumulus, an extension to Substrate, allows any Substrate built chain to connect to Polkadot and
+become a parachain. Substrate is currently on its 2.0.0 tagged release that solidified its API.
 
 Polkadot does not natively support smart contracts, however there will be parachains that do.
 Substrate chains can include smart contract functionality by using the

--- a/docs/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain-guides-how-to-validate-polkadot.md
@@ -4,10 +4,7 @@ title: Run a Validator (Polkadot)
 sidebar_label: How to run a Validator on Polkadot
 ---
 
-> The following information applies to the Polkadot network, which is currently in the soft launch
-> phase. During soft launch the network starts as a Proof-of-Authority network before transitioning
-> to Proof-of-Stake. You will be able to follow this guide to set up your validator but the first
-> validator election and rewards will not start until later. If you want to set up a validator on
+> The following information applies to the Polkadot network. If you want to set up a validator on
 > Kusama, check out the [Kusama guide](mirror-maintain-guides-how-to-validate-kusama) instead.
 
 This guide will instruct you how to set up a validator node on the Polkadot network.

--- a/docs/maintain-sync.md
+++ b/docs/maintain-sync.md
@@ -78,11 +78,12 @@ https://github.com/paritytech/substrate-light-ui
 > Not recommended if you're a validator. Please see
 > [secure validator setup](maintain-guides-secure-validator)
 
-
 - Install WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
 - Install Ubuntu (same webpage): https://docs.microsoft.com/en-us/windows/wsl/install-win10
-- Determine the latest version of the Polkadot binary (you can see the latest releases here: https://github.com/paritytech/polkadot/releases)
-- Download the correct Polkadot binary within Ubuntu by running the following command.  Replace `*VERSION*` with the tag of the latest version from the last step (e.g. `v0.8.22`):
+- Determine the latest version of the Polkadot binary (you can see the latest releases here:
+  https://github.com/paritytech/polkadot/releases)
+- Download the correct Polkadot binary within Ubuntu by running the following command. Replace
+  `*VERSION*` with the tag of the latest version from the last step (e.g. `v0.8.22`):
   `curl -sL https://github.com/paritytech/polkadot/releases/download/*VERSION*/polkadot -o polkadot`
 - Run the following: `sudo chmod +x polkadot`
 - Run the following: `./polkadot --name "Your Node Name Here"`
@@ -103,8 +104,10 @@ particular architecture or Linux distribution. If you see an error like
 your system. You will either need to compile the [source code yourself](#clone-and-build) or use
 [docker](#using-docker).
 
-- Determine the latest version of the Polkadot binary (you can see the latest releases here: https://github.com/paritytech/polkadot/releases)
-- Download the correct Polkadot binary within Ubuntu by running the following command.  Replace `*VERSION*` with the tag of the latest version from the last step (e.g. `v0.8.22`):
+- Determine the latest version of the Polkadot binary (you can see the latest releases here:
+  https://github.com/paritytech/polkadot/releases)
+- Download the correct Polkadot binary within Ubuntu by running the following command. Replace
+  `*VERSION*` with the tag of the latest version from the last step (e.g. `v0.8.22`):
   `curl -sL https://github.com/paritytech/polkadot/releases/download/*VERSION*/polkadot -o polkadot`
 - Run the following: `sudo chmod +x polkadot`
 - Run the following: `./polkadot --name "Your Node Name Here"`
@@ -135,7 +138,8 @@ cd kusama
 cargo build --release
 ```
 
-Alternatively, if you wish to use a specific release, you can check out a specific tag (`v0.8.3` in the example below):
+Alternatively, if you wish to use a specific release, you can check out a specific tag (`v0.8.3` in
+the example below):
 
 ```bash
 git clone https://github.com/paritytech/polkadot kusama

--- a/docs/maintain-sync.md
+++ b/docs/maintain-sync.md
@@ -78,14 +78,12 @@ https://github.com/paritytech/substrate-light-ui
 > Not recommended if you're a validator. Please see
 > [secure validator setup](maintain-guides-secure-validator)
 
-For the most recent binary please see the
-[release page](https://github.com/paritytech/polkadot/releases/) on the polkadot repository. The URL
-in the code snippet below may become slightly out-of-date.
 
 - Install WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
 - Install Ubuntu (same webpage): https://docs.microsoft.com/en-us/windows/wsl/install-win10
-- Download Polkadot binary within Ubuntu by running:
-  `curl -sL https://github.com/paritytech/polkadot/releases/download/v0.8.3/polkadot -o polkadot`
+- Determine the latest version of the Polkadot binary (you can see the latest releases here: https://github.com/paritytech/polkadot/releases)
+- Download the correct Polkadot binary within Ubuntu by running the following command.  Replace `*VERSION*` with the tag of the latest version from the last step (e.g. `v0.8.22`):
+  `curl -sL https://github.com/paritytech/polkadot/releases/download/*VERSION*/polkadot -o polkadot`
 - Run the following: `sudo chmod +x polkadot`
 - Run the following: `./polkadot --name "Your Node Name Here"`
 - Find your node at https://telemetry.polkadot.io/#list/Kusama
@@ -105,8 +103,9 @@ particular architecture or Linux distribution. If you see an error like
 your system. You will either need to compile the [source code yourself](#clone-and-build) or use
 [docker](#using-docker).
 
-- Download Polkadot binary by running:
-  `curl -sL https://github.com/paritytech/polkadot/releases/download/v0.8.3/polkadot -o polkadot`
+- Determine the latest version of the Polkadot binary (you can see the latest releases here: https://github.com/paritytech/polkadot/releases)
+- Download the correct Polkadot binary within Ubuntu by running the following command.  Replace `*VERSION*` with the tag of the latest version from the last step (e.g. `v0.8.22`):
+  `curl -sL https://github.com/paritytech/polkadot/releases/download/*VERSION*/polkadot -o polkadot`
 - Run the following: `sudo chmod +x polkadot`
 - Run the following: `./polkadot --name "Your Node Name Here"`
 - Find your node at https://telemetry.polkadot.io/#list/Kusama
@@ -136,7 +135,7 @@ cd kusama
 cargo build --release
 ```
 
-Alternatively, check out a specific tagged release:
+Alternatively, if you wish to use a specific release, you can check out a specific tag (`v0.8.3` in the example below):
 
 ```bash
 git clone https://github.com/paritytech/polkadot kusama


### PR DESCRIPTION
There were a few mentions we had of things happening in the future which have already happened.

Additionally, I changed the instructions to future-proof our instructions for building a node from source (our code snippets referenced version  `v0.8.3`.  I replaced it with `*VERSION*` and included a step to always determine the latest release, instead of having a note "this may be outdated, double-check".  This way they will be forced to check before cloning it down.