### PR TITLE
Fixed Kusama Grammar errors

### DIFF
--- a/docs/kusama-coc.md
+++ b/docs/kusama-coc.md
@@ -33,9 +33,9 @@ Please see the bug bounty.
 Please note: these are just a few examples and you can always consult a team member if you have any
 questions.
 
-Angry aggressive comments towards individuals or other projects on any medium of communication
-Knowingly distributing false information about Kusama or other projects Harassing other individuals
-or projects (trolling).
+- Angry aggressive comments towards individuals or other projects on any medium of communication.
+- Knowingly distributing false information about Kusama or other projects.
+- Harassing other individuals or projects (trolling).
 
 ## What To Do If You Witness or Are Subject To Unacceptable Behavior
 
@@ -43,4 +43,4 @@ If you are being harassed, notice that someone else is being harassed, or have a
 relating to harassment, please contact the administrator of the channel you’re in.
 
 This Code of Conduct may be revised at any time. We are always willing to revise this document based
-on feedback from the Kusama participants and or Polkadot community.
+on feedback from the Kusama participants and/or the Polkadot community.


### PR DESCRIPTION
I noticed a few grammatical errors on the Kusama code of conduct page, so I've just created a PR for them. 