### PR TITLE
Removes the Kusama sidebar

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -433,8 +433,7 @@
       "General": "General",
       "Learn": "Learn",
       "Build": "Build",
-      "Maintain": "Maintain",
-      "Kusama": "Kusama"
+      "Maintain": "Maintain"
     }
   },
   "pages-strings": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -154,37 +154,5 @@
         ]
       }
     ]
-  },
-  "kusama": {
-    "Kusama": [
-      "kusama-index",
-      {
-        "type": "subcategory",
-        "label": "Get Started",
-        "ids": ["kusama-faucet", "kusama-claims", "kusama-endpoints"]
-      },
-      {
-        "type": "subcategory",
-        "label": "What to Try",
-        "ids": [
-          "mirror-maintain-guides-how-to-validate-kusama",
-          "mirror-maintain-guides-how-to-nominate-kusama",
-          "mirror-learn-governance",
-          "mirror-learn-identity",
-          "mirror-learn-treasury",
-          "mirror-build-build-with-polkadot",
-          "maintain-guides-society-kusama"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "What to Break",
-        "ids": ["mirror-maintain-errors", "kusama-bug-bounty", "kusama-adverserial-cheatsheet"]
-      },
-      "kusama-timeline",
-      "kusama-community",
-      "kusama-time-periods",
-      "kusama-coc"
-    ]
   }
 }


### PR DESCRIPTION
closes #852 

This removes the Kusama sidebar when a Kusama page is visited - but I think we might still run into the issue of Kusama pages getting indexed by the Algolia search engine. A possible extension to this would be to add a blanket redirect for any URL on the wiki that contains "kusama" to be redirected to the Kusama guide. That might be overkill though since we have the Kusama button clearly visible, and users can understand that's where the Kusama information lives (right?).