### PR TITLE
Fixed sidebar order / next button

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -8,7 +8,7 @@
       "research",
       "community",
       "contributing",
-      "contributors",	
+      "contributors",
       "glossary",
       "learn-ledger",
       "faq"
@@ -114,7 +114,7 @@
     ],
     "Maintain": [
       "maintain-index",
-	"maintain-polkadot-parameters",	
+      "maintain-polkadot-parameters",
       {
         "type": "subcategory",
         "label": "Nodes and Dapps",
@@ -123,11 +123,7 @@
       {
         "type": "subcategory",
         "label": "Nominator Guides",
-        "ids": [
-          "maintain-guides-how-to-nominate-polkadot",
-          "maintain-guides-how-to-chill",
-          "maintain-guides-how-to-unbond"
-        ]
+        "ids": ["maintain-guides-how-to-nominate-polkadot", "maintain-guides-how-to-unbond"]
       },
       {
         "type": "subcategory",


### PR DESCRIPTION
Last instance of the same page ID in sidebars.json takes precedence in sidebar display, but first instance is what's followed when generating next button. Since chill page is referenced in sidebar twice, a bug in the UI happens. This fixes it.