### PR TITLE
Adding repo secret token to Action

### DIFF
--- a/.github/workflows/stalecheck.yml
+++ b/.github/workflows/stalecheck.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: actions/checkout@master
       - name: Check for stale files.
         run: yarn; node scripts/stalecheck.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The stale check action failed because I forgot to add the token into the action's YML. This should fix it. The token is automatically taken from the repo's environment, and generated by Github.