### PR TITLE
Add terms for missed searches

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,6 +30,11 @@ UTC.
 On August 21, 2020, Redenomination of DOT occurred. From this date, one DOT (old) equals 100 new
 DOT.
 
+## Polkadot Roadmap
+
+For more information on the Polkadot roadmap please visit the
+[official Polkadot website](https://polkadot.network/technology/#roadmap).
+
 ## Validators
 
 ### How do I apply to be a validator?

--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -174,7 +174,7 @@ On Polkadot there are four different balance types that indicate whether your ba
 for transfers, to pay fees, or must remain frozen and not used due to an on-chain requirement.
 
 The balance types are defined by the `AccountData` struct in Substrate. The four types of balances
-include `free`, `reserved`, `misc_frozen` (`miscFrozen` in camel-case), and `fee_frozen` (`feeFrozen
+include `free`, `reserved`, `misc_frozen` (`miscFrozen` in camel-case), and `fee_frozen` (`feeFrozen`
 in camel-case).
 
 In general, the **usable** balance of the account is the amount that is `free` minus any funds that

--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -168,6 +168,27 @@ PolkaProject is an independent site which is not affiliated with Web3 Foundation
 
 Hardware wallet integration is possible with Ledger. A full guide is available [here](learn-ledger).
 
+## Balance Types
+
+On Polkadot there are four different balance types that indicate whether your balance can be used
+for transfers, to pay fees, or must remain frozen and not used due to an on-chain requirement.
+
+The balance types are defined by the `AccountData` struct in Substrate. The four types of balances
+include `free`, `reserved`, `misc_frozen` (`miscFrozen` in camel-case), and `fee_frozen` (`feeFrozen
+in camel-case).
+
+In general, the **usable** balance of the account is the amount that is `free` minus any funds that
+are considered frozen (either `misc_frozen` or `free_frozen`) and depends on the reason for which
+the funds are to be used. If the funds are to be used for transfers then the usable amount is the
+"free" amount minus any `misc_frozen` funds. However, if the funds are to be used to pay transaction
+fees than the usable amount would be the "free" funds minus any funds that are `fee_frozen`.
+
+The "total" balance of the account is considered the amount of "free" funds in the account
+subtracted by any funds that are "reserved." Reserved funds are held due to on-chain requirements
+and can usually be freed by making some on-chain action. For example, the "Identity" pallet reserves
+funds while an on-chain identity is registered, but by clearing the identity you can unreserve the
+funds and make them free again.
+
 ## Existential Deposit and Reaping
 
 When you generate an account (address), you only generate a _key_ that lets you access it. The

--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -174,8 +174,8 @@ On Polkadot there are four different balance types that indicate whether your ba
 for transfers, to pay fees, or must remain frozen and not used due to an on-chain requirement.
 
 The balance types are defined by the `AccountData` struct in Substrate. The four types of balances
-include `free`, `reserved`, `misc_frozen` (`miscFrozen` in camel-case), and `fee_frozen` (`feeFrozen`
-in camel-case).
+include `free`, `reserved`, `misc_frozen` (`miscFrozen` in camel-case), and `fee_frozen`
+(`feeFrozen` in camel-case).
 
 In general, the **usable** balance of the account is the amount that is `free` minus any funds that
 are considered frozen (either `misc_frozen` or `free_frozen`) and depends on the reason for which


### PR DESCRIPTION
closes #1136 

I'm not sure "redeem" is a relevant term any longer. I searched both Substrate codebase and the polkadot-js apps codebase for the term and didn't find anything.