### PR TITLE
Broken hashquark link - replacment?

### DIFF
--- a/docs/learn-validator.md
+++ b/docs/learn-validator.md
@@ -68,8 +68,6 @@ exchange for their activities.
 
 ## Validator Stats
 
-- [HashQuark Staking Strategy](https://labs.hashquark.io/#/polka/strategy) - The HashQuark staking
-  strategy dashboard helps you choose the optimal set-up to maximize rewards.
 - [Polkastats](https://polkastats.io/) - Polkastats is a cleanly designed dashboard for validator
   statistics.
 - [Polkanalytics](https://polkanalytics.com/#/dashboard) - A validator dashboard that displays the

--- a/docs/learn-validator.md
+++ b/docs/learn-validator.md
@@ -68,6 +68,8 @@ exchange for their activities.
 
 ## Validator Stats
 
+- [HashQuark Staking Strategy](https://polkacube.hashquark.io/#/polkadot/strategy) - The HashQuark staking
+  strategy dashboard helps you choose the optimal set-up to maximize rewards, and provides other useful network monitoring tools.
 - [Polkastats](https://polkastats.io/) - Polkastats is a cleanly designed dashboard for validator
   statistics.
 - [Polkanalytics](https://polkanalytics.com/#/dashboard) - A validator dashboard that displays the


### PR DESCRIPTION
Removed, as it goes to a 404.

Possibly replaced by this tool by them instead? https://polkacube.hashquark.io/#/polkadot