### PR TITLE
Wallet updates in learn-accounts

### DIFF
--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -149,7 +149,7 @@ Please note that as this keeps your accounts in the browser, it is not a safe pl
 holdings. By definition, a browser is a "hot wallet" and susceptible to a wide range of attacks, so
 keep your funds in cold storage when dealing with non-trivial amounts. For improved security, you
 can securely stash away the seed phrase for your accounts and remove all traces of the accounts from
-your computer after creating
+your computer after creating it.
 
 Other than the extension and the default UI, Polkadot and Kusama addresses can also be created with
 the [Subkey tool](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). Subkey is

--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -147,9 +147,9 @@ beyond repair, the phrase will come in handy.
 
 Please note that as this keeps your accounts in the browser, it is not a safe place to keep large
 holdings. By definition, a browser is a "hot wallet" and susceptible to a wide range of attacks, so
-keep your funds in cold storage when dealing with non-trivial amounts. Creating cold storage is as
-simple as securely stashing away the seed phrase for your accounts and removing all traces of the
-accounts from your computer.
+keep your funds in cold storage when dealing with non-trivial amounts. For improved security, you
+can securely stash away the seed phrase for your accounts and remove all traces of the accounts from
+your computer after creating
 
 Other than the extension and the default UI, Polkadot and Kusama addresses can also be created with
 the [Subkey tool](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). Subkey is
@@ -158,15 +158,15 @@ approachable. Follow the instructions in the
 [Subkey documentation](https://substrate.dev/docs/en/knowledgebase/integrate/subkey). When used
 properly, Subkey is the **most secure** available method of creating an account.
 
-There is also the very secure [Parity Signer](https://www.parity.io/signer/) but it currently only
-supports Kusama addresses, not Polkadot or generic Substrate.
-
-Alternatively, you might find some wallets on the
-[Polkaproject.com page](http://www.polkaproject.com/) but bear in mind that these are **unaudited**
-and not officially affiliated with Web3 Foundation or the Polkadot project unless otherwise stated.
-PolkaProject is an independent site which is not affiliated with Web3 Foundation.
+There is also the very secure [Parity Signer](https://www.parity.io/signer/). This keeps your keys
+on an air-gapped mobile phone. However, it does require obtaining an old Android or iOS-compatible
+phone that you are comfortable using only for Parity Signer.
 
 Hardware wallet integration is possible with Ledger. A full guide is available [here](learn-ledger).
+
+Alternatively, you might find other wallets on the [Wallet](build-wallets) page, but bear in mind
+that some of these are **unaudited** and are not officially affiliated with Web3 Foundation or the
+Polkadot project unless otherwise stated.
 
 ## Balance Types
 

--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -149,7 +149,7 @@ Please note that as this keeps your accounts in the browser, it is not a safe pl
 holdings. By definition, a browser is a "hot wallet" and susceptible to a wide range of attacks, so
 keep your funds in cold storage when dealing with non-trivial amounts. For improved security, you
 can securely stash away the seed phrase for your accounts and remove all traces of the accounts from
-your computer after creating it.
+your computer after creating them.
 
 Other than the extension and the default UI, Polkadot and Kusama addresses can also be created with
 the [Subkey tool](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). Subkey is


### PR DESCRIPTION
1. Parity Signer now works on Polkadot
2. We now have our own page of wallets, no need to link to Polkaproject
3. Some other slight rewording and re-ordering