### PR TITLE
Fixes stalecheck

### DIFF
--- a/scripts/stalecheck.js
+++ b/scripts/stalecheck.js
@@ -8,14 +8,26 @@ const maxAgeDays = 21;
 const techedu = ["swader", "swader", "lsaether", "lsaether", "ansonla3", "ansonla3", "laboon"];
 
 const getStaleIssues = async (octokit) => {
-  const { data } = await octokit.issues.listForRepo({
-    owner: "w3f",
-    repo: "polkadot-wiki",
-    state: "open",
-    labels: "stale",
-  });
+  let page = 0;
+  let fullData = [];
 
-  return data;
+  while (true) {
+    const { data } = await octokit.issues.listForRepo({
+      owner: "w3f",
+      repo: "polkadot-wiki",
+      state: "open",
+      labels: "stale",
+      per_page: 100,
+      page,
+    });
+
+    if (!data.length) break;
+
+    fullData.push(...data);
+    page++;
+  }
+
+  return fullData;
 }
 
 async function stalecheck() {
@@ -42,7 +54,7 @@ async function stalecheck() {
     // Pick a random technical educator
     let assignee = techedu[Math.floor(Math.random() * techedu.length)];
     // Create issue
-    let creation = await octokit.issues
+    await octokit.issues
       .create({
         owner: "w3f",
         repo: "polkadot-wiki",


### PR DESCRIPTION
Otctokit returns paginated responses with a max of 100 responses per page. At the moment we are getting a total of 207 responses. So if a page was already marked sufficiently long in the past it would get duplicated. Now it won't.