### PR TITLE
Update oversubscribed numbers

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -264,9 +264,9 @@ biasing, or identity-based quadratic voting.
 
 ## Oversubscribed
 
-If more than 256 nominators nominate the same validator, it is "oversubscribed", and only the top
-256 staked nominators (ranked by amount of stake) are paid rewards. Other nominators will receive no
-rewards for that era.
+If more than the maximum number nominators nominate the same validator, it is "oversubscribed", and only the top
+staked nominators (ranked by amount of stake, up the maximum number of nominators) are paid rewards. Other nominators will receive no
+rewards for that era. The current maximum number of nominators is {{ kusama_max_nominators }} on Kusama and {{ polkadot_max_nominators }} on Polkadot, but it can be modified via governance.
 
 ## Pallet
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -264,9 +264,11 @@ biasing, or identity-based quadratic voting.
 
 ## Oversubscribed
 
-If more than the maximum number nominators nominate the same validator, it is "oversubscribed", and only the top
-staked nominators (ranked by amount of stake, up the maximum number of nominators) are paid rewards. Other nominators will receive no
-rewards for that era. The current maximum number of nominators is {{ kusama_max_nominators }} on Kusama and {{ polkadot_max_nominators }} on Polkadot, but it can be modified via governance.
+If more than the maximum number nominators nominate the same validator, it is "oversubscribed", and
+only the top staked nominators (ranked by amount of stake, up the maximum number of nominators) are
+paid rewards. Other nominators will receive no rewards for that era. The current maximum number of
+nominators is {{ kusama_max_nominators }} on Kusama and {{ polkadot_max_nominators }} on Polkadot,
+but it can be modified via governance.
 
 ## Pallet
 

--- a/docs/learn-nominator.md
+++ b/docs/learn-nominator.md
@@ -45,16 +45,18 @@ details.
 
 ### Oversubscribed Validators
 
-Validators can only pay out to a certain number of nominators per era. This is currently set to {{ polkadot_max_nominators }}, but can be modified via governance. If more than {{ polkadot_max_nominators }} nominators nominate the same
-validator, it is "oversubscribed", and only the top {{ polkadot_max_nominators }} staked nominators (ranked by amount of
-stake) are paid rewards. Other nominators will receive no rewards for that era, although their stake
-will still be used to calculate entry into the active validator set.
+Validators can only pay out to a certain number of nominators per era. This is currently set to
+{{ polkadot_max_nominators }}, but can be modified via governance. If more than
+{{ polkadot_max_nominators }} nominators nominate the same validator, it is "oversubscribed", and
+only the top {{ polkadot_max_nominators }} staked nominators (ranked by amount of stake) are paid
+rewards. Other nominators will receive no rewards for that era, although their stake will still be
+used to calculate entry into the active validator set.
 
 Although it is difficult to determine exactly how many nominators will nominate a given validator in
 the next era, one can estimate based on the current number of nominators. A nominator with only 5
-nominators in this era, for instance, is unlikely to have more than {{ polkadot_max_nominators }} in the next era. An
-already-oversubscribed validator with 1000 nominators this era, however, is much more likely to be
-oversubscribed in the next era as well.
+nominators in this era, for instance, is unlikely to have more than {{ polkadot_max_nominators }} in
+the next era. An already-oversubscribed validator with 1000 nominators this era, however, is much
+more likely to be oversubscribed in the next era as well.
 
 ### Possible effect of inactive nominations on rewards
 

--- a/docs/learn-nominator.md
+++ b/docs/learn-nominator.md
@@ -45,15 +45,15 @@ details.
 
 ### Oversubscribed Validators
 
-Validators can only pay out to 256 nominators per era. If more than 256 nominators nominate the same
-validator, it is "oversubscribed", and only the top 256 staked nominators (ranked by amount of
+Validators can only pay out to a certain number of nominators per era. This is currently set to {{ polkadot_max_nominators }}, but can be modified via governance. If more than {{ polkadot_max_nominators }} nominators nominate the same
+validator, it is "oversubscribed", and only the top {{ polkadot_max_nominators }} staked nominators (ranked by amount of
 stake) are paid rewards. Other nominators will receive no rewards for that era, although their stake
 will still be used to calculate entry into the active validator set.
 
 Although it is difficult to determine exactly how many nominators will nominate a given validator in
 the next era, one can estimate based on the current number of nominators. A nominator with only 5
-nominators in this era, for instance, is unlikely to have more than 256 in the next era. An
-already-oversubscribed validator with 500 nominators this era, however, is much more likely to be
+nominators in this era, for instance, is unlikely to have more than {{ polkadot_max_nominators }} in the next era. An
+already-oversubscribed validator with 1000 nominators this era, however, is much more likely to be
 oversubscribed in the next era as well.
 
 ### Possible effect of inactive nominations on rewards

--- a/docs/learn-phragmen.md
+++ b/docs/learn-phragmen.md
@@ -610,11 +610,11 @@ an optimal manner.
 
 There are several further restrictions put in place to limit the complexity of the election and
 payout. As already mentioned, any given nominator can only select up to 16 validators to nominate.
-Conversely, a single validator can have only {{ polkadot_max_nominators }} nominators. A drawback to this is that it is
-possible, if the number of nominators is very high or the number of validators is very low, that all
-available validators may be "oversubscribed" and unable to accept more nominations. In this case, one may
-need a larger amount of stake to participate in staking, since nominations are priority-ranked in
-terms of amount of stake.
+Conversely, a single validator can have only {{ polkadot_max_nominators }} nominators. A drawback to
+this is that it is possible, if the number of nominators is very high or the number of validators is
+very low, that all available validators may be "oversubscribed" and unable to accept more
+nominations. In this case, one may need a larger amount of stake to participate in staking, since
+nominations are priority-ranked in terms of amount of stake.
 
 ## External Resources
 

--- a/docs/learn-phragmen.md
+++ b/docs/learn-phragmen.md
@@ -610,9 +610,9 @@ an optimal manner.
 
 There are several further restrictions put in place to limit the complexity of the election and
 payout. As already mentioned, any given nominator can only select up to 16 validators to nominate.
-Conversely, a single validator can have only 256 nominators. A drawback to this is that it is
+Conversely, a single validator can have only {{ polkadot_max_nominators }} nominators. A drawback to this is that it is
 possible, if the number of nominators is very high or the number of validators is very low, that all
-available validators may be "saturated" and unable to accept more nominations. In this case, one may
+available validators may be "oversubscribed" and unable to accept more nominations. In this case, one may
 need a larger amount of stake to participate in staking, since nominations are priority-ranked in
 terms of amount of stake.
 

--- a/docs/learn-simple-payouts.md
+++ b/docs/learn-simple-payouts.md
@@ -25,11 +25,11 @@ after they were earned. This means that all rewards must be claimed within 84 er
 
 Anyone can trigger a payout for any validator, as long as they are willing to pay the transaction
 fee. Someone must submit a transaction with a validator ID and an era index. Polkadot will
-automatically calculate that validator's reward, find the top {{ polkadot_max_nominators }} nominators for that era, and
-distribute the rewards pro rata.
+automatically calculate that validator's reward, find the top {{ polkadot_max_nominators }}
+nominators for that era, and distribute the rewards pro rata.
 
-> Note: The Staking system only applies the highest {{ polkadot_max_nominators }} nominations to each validator to reduce the
-> complexity of the staking set.
+> Note: The Staking system only applies the highest {{ polkadot_max_nominators }} nominations to
+> each validator to reduce the complexity of the staking set.
 
 These details are handled for you automatically if you use the
 [Polkadot-JS UI](https://polkadot.js.org/apps/#/staking/payout), which also allows you to submit

--- a/docs/learn-simple-payouts.md
+++ b/docs/learn-simple-payouts.md
@@ -25,10 +25,10 @@ after they were earned. This means that all rewards must be claimed within 84 er
 
 Anyone can trigger a payout for any validator, as long as they are willing to pay the transaction
 fee. Someone must submit a transaction with a validator ID and an era index. Polkadot will
-automatically calculate that validator's reward, find the top 256 nominators for that era, and
+automatically calculate that validator's reward, find the top {{ polkadot_max_nominators }} nominators for that era, and
 distribute the rewards pro rata.
 
-> Note: The Staking system only applies the highest 256 nominations to each validator to reduce the
+> Note: The Staking system only applies the highest {{ polkadot_max_nominators }} nominations to each validator to reduce the
 > complexity of the staking set.
 
 These details are handled for you automatically if you use the

--- a/docs/learn-staking.md
+++ b/docs/learn-staking.md
@@ -125,9 +125,9 @@ only gets 8.3 in return, whereas Kitty gets 12.5 with the same amount of stake.
 
 There is an additional factor to consider in terms of rewards. While there is no limit to the number
 of nominators a validator may have, a validator does have a limit to how many nominators to which it
-can pay rewards. In Polkadot and Kusama, this limit is currently 256, although this can be modified
-via runtime upgrade. A validator with more than 256 nominators is _oversubscribed_. When payouts
-occur, only the top 256 nominators as measured by amount of stake allocated to that validator will
+can pay rewards. In Polkadot and Kusama, this limit is currently {{ polkadot_max_nominators }}, although this can be modified
+via runtime upgrade. A validator with more than {{ polkadot_max_nominators }} nominators is _oversubscribed_. When payouts
+occur, only the top {{ polkadot_max_nominators }} nominators as measured by amount of stake allocated to that validator will
 receive rewards. All other nominators are essentially "wasting" their stake - they used their
 nomination to elect that validator to the active stake, but receive no rewards in exchange for doing
 so.

--- a/docs/learn-staking.md
+++ b/docs/learn-staking.md
@@ -125,10 +125,11 @@ only gets 8.3 in return, whereas Kitty gets 12.5 with the same amount of stake.
 
 There is an additional factor to consider in terms of rewards. While there is no limit to the number
 of nominators a validator may have, a validator does have a limit to how many nominators to which it
-can pay rewards. In Polkadot and Kusama, this limit is currently {{ polkadot_max_nominators }}, although this can be modified
-via runtime upgrade. A validator with more than {{ polkadot_max_nominators }} nominators is _oversubscribed_. When payouts
-occur, only the top {{ polkadot_max_nominators }} nominators as measured by amount of stake allocated to that validator will
-receive rewards. All other nominators are essentially "wasting" their stake - they used their
+can pay rewards. In Polkadot and Kusama, this limit is currently {{ polkadot_max_nominators }},
+although this can be modified via runtime upgrade. A validator with more than
+{{ polkadot_max_nominators }} nominators is _oversubscribed_. When payouts occur, only the top
+{{ polkadot_max_nominators }} nominators as measured by amount of stake allocated to that validator
+will receive rewards. All other nominators are essentially "wasting" their stake - they used their
 nomination to elect that validator to the active stake, but receive no rewards in exchange for doing
 so.
 

--- a/scripts/inject-dict.json
+++ b/scripts/inject-dict.json
@@ -40,5 +40,13 @@
     "default": { "kusama": 6, "polkadot": 24 },
     "path": "consts.treasury.spendPeriod",
     "filters": ["blocksToDays"]
+  },
+  {
+    "tpl": "kusama_max_nominators",
+    "default": "128"
+  },
+  {
+    "tpl": "polkadot_max_nominators",
+    "default": "128"
   }
 ]


### PR DESCRIPTION
Updated the nominator oversubscription limits and changed it to use an injected variable.

This value can't (AFAIK) be directly queried on-chain, so I have just set it to default.  We'll still have to update it but at least it's all in one place.