### PR TITLE
Update learn-auction.md: Fix Broken Link

### DIFF
--- a/docs/learn-auction.md
+++ b/docs/learn-auction.md
@@ -243,7 +243,7 @@ considered essential to the ecosystem's future.
 
 ## Resources
 
-- [Parachain Allocation](https://research.web3.foundation/en/latest/polkadot/Parachain-Allocation.html) -
+- [Parachain Allocation](https://research.web3.foundation/en/latest/polkadot/economics/2-parachain-allocation.html) -
   W3F research page on parachain allocation that goes more in depth to the mechanism.
 - [paritytech/polkadot#239](https://github.com/paritytech/polkadot/pull/239) - Pull request
   introducing the parachain slots code.


### PR DESCRIPTION
Fixed the link to the "Parachain Allocation" research page.