### PR TITLE
Remove kusama reference from polkadot wiki

### DIFF
--- a/docs/learn-treasury.md
+++ b/docs/learn-treasury.md
@@ -10,8 +10,8 @@ The treasury is a pot of funds collected through transaction fees, slashing,
 by making a spending proposal that, if approved by the [Council](learn-governance#Council), will
 enter a waiting period before distribution. This waiting period is known as the budget period, and
 its duration is subject to [governance](learn-governance), with current defaults set to
-{{ spend_period }} days for Polkadot mainnet, and 6 days for Kusama. The treasury attempts to spend
-as many proposals in the queue as it can without running out of funds.
+{{ spend_period }} days for Polkadot. The treasury attempts to spend as many proposals in the queue
+as it can without running out of funds.
 
 If the treasury ends a budget period without spending all of its funds, it suffers a burn of a
 percentage of its funds -- thereby causing deflationary pressure.


### PR DESCRIPTION
Instead of making an ad hoc `kusama_spend_period` variable, just removing Kusama ref here.  See  https://github.com/w3f/polkadot-wiki/issues/1379#issuecomment-754734871

Let me know if you disagree, otherwise this is a simple PR.