### PR TITLE
Update steps to create a bounty based on new UI changes

### DIFF
--- a/docs/learn-treasury.md
+++ b/docs/learn-treasury.md
@@ -244,7 +244,11 @@ tab in the options bar on the top of the site. After, click on 'Bounties' and fi
 upper-right side of the interface. Complete the bounty title, the requested allocation (including curator's fee) and
 confirm the call.
 
-After this, a Council member will need to assist you to pass the bounty proposal for vote as a motion. 
+After this, a Council member will need to assist you to pass the bounty proposal for vote as a motion. You can 
+contact the Council by joining the Direcion channel for [Polkadot](https://parity.link/polkadot-direction) or 
+[Kusama](https://parity.link/kusama-direction) in Element or joining our [Kusama](https://parity.link/kusama-discord) 
+or [Polkadot](https://parity.link/polkadot-discord) Discord servers and publishing a short description of your bounty 
+with a link to one of the forums in the Direction channels for contextual information. 
 
 A bounty can be cancelled by deleting the earmark for a specific treasury amount or be closed if the
 tasks have been completed. On the opposite side, the 90 days life of a bounty can be extended by

--- a/docs/learn-treasury.md
+++ b/docs/learn-treasury.md
@@ -232,12 +232,19 @@ sub-bounties for more granularity and allocation in the next iteration of the me
 
 ### Creating a Bounty Proposal
 
-Anyone can create a Bounty proposal using Polkadot JS Apps: Users will be able to submit a proposal
+Anyone can create a Bounty proposal using Polkadot JS Apps: Users are able to submit a proposal
 on the dedicated Bounty section under Governance. The development of a robust user interface to view
-and manage bounties in the Polkadot Apps is on its way and it will serve Council members, Curators
-and Beneficiaries of the bounties, as well as all Kusama users observing the on-chain treasury
+and manage bounties in the Polkadot Apps is still under development and it will serve Council members, Curators
+and Beneficiaries of the bounties, as well as all users observing the on-chain treasury
 governance. For now, the help of a Councillor is needed to open a bounty proposal as a motion to be
 voted.
+
+To submit a bounty, please visit [Polkadot JS Apps](https://polkadot.js.org/apps) and click on the governance 
+tab in the options bar on the top of the site. After, click on 'Bounties' and find the button '+ Add Bounty' on the 
+upper-right side of the interface. Complete the bounty title, the requested allocation (including curator's fee) and
+confirm the call.
+
+After this, a Council member will need to assist you to pass the bounty proposal for vote as a motion. 
 
 A bounty can be cancelled by deleting the earmark for a specific treasury amount or be closed if the
 tasks have been completed. On the opposite side, the 90 days life of a bounty can be extended by


### PR DESCRIPTION
Added some steps a user can follow to submit a bounty. Maybe a screenshot like these would be needed there:

<img width="1388" alt="Screenshot 2021-01-14 at 12 21 31" src="https://user-images.githubusercontent.com/22815262/104586459-c747f700-5665-11eb-8db9-35f4720227d8.png">

<img width="719" alt="Screenshot 2021-01-14 at 12 41 26" src="https://user-images.githubusercontent.com/22815262/104586503-d62ea980-5665-11eb-8ec4-6789ad5213d0.png">
