### PR TITLE
Update maintain-guides-how-to-validate-kusama.md

### DIFF
--- a/docs/maintain-guides-how-to-validate-kusama.md
+++ b/docs/maintain-guides-how-to-validate-kusama.md
@@ -399,5 +399,5 @@ If you have Docker installed, you can use it to start your validator node withou
 the binary. You can do this with a simple one line command:
 
 ```sh
-$ docker run parity/polkadot:v0.7.28 --validator --name "name on telemetry"
+$ docker run parity/polkadot:latest --validator --name "name on telemetry" --chain kusama
 ```


### PR DESCRIPTION
Docker command featured an old version of the image and did not specify the flag needed to run on the kusama chain as opposed to the default polkadot chain.