### PR TITLE
Removed unsupported `--ws-cors` parameter.

### DIFF
--- a/docs/build-node-management.md
+++ b/docs/build-node-management.md
@@ -46,7 +46,7 @@ polkadot export-blocks --from 0 <output_file>
 Use the `--rpc-external` flag to expose RPC ports and `--ws-external` to expose websockets. Not all
 RPC calls are safe to allow and you should use an RPC proxy to filter unsafe calls. Select ports
 with the `--rpc-port` and `--ws-port` options. To limit the hosts who can access, use the
-`--rpc-cors` and `--ws-cors` options.
+`--rpc-cors` option.
 
 **Execution**
 


### PR DESCRIPTION
--ws-cors parameter does not exists and leads to an error when starting polkadot.