### PR TITLE
Fix a logical error in Learn Phragmén 

### DIFF
--- a/docs/learn-phragmen.md
+++ b/docs/learn-phragmen.md
@@ -237,7 +237,7 @@ _Note: in terms of validator selection, for the following algorithm, you can thi
    won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm
    described above.
 2. However, as candidates are elected, a weighted mapping is built, defining the weights of each
-   selection of a validator by each candidate.
+   selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/de/learn-phragmen.md
+++ b/website/translated_docs/de/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/es-ES/learn-phragmen.md
+++ b/website/translated_docs/es-ES/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/fi/learn-phragmen.md
+++ b/website/translated_docs/fi/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/fr/learn-phragmen.md
+++ b/website/translated_docs/fr/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/hi-IN/learn-phragmen.md
+++ b/website/translated_docs/hi-IN/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/hr-HR/learn-phragmen.md
+++ b/website/translated_docs/hr-HR/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/id-ID/learn-phragmen.md
+++ b/website/translated_docs/id-ID/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/it/learn-phragmen.md
+++ b/website/translated_docs/it/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/ja/learn-phragmen.md
+++ b/website/translated_docs/ja/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/ko/learn-phragmen.md
+++ b/website/translated_docs/ko/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/ms-MY/learn-phragmen.md
+++ b/website/translated_docs/ms-MY/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/pt-BR/learn-phragmen.md
+++ b/website/translated_docs/pt-BR/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/pt-PT/learn-phragmen.md
+++ b/website/translated_docs/pt-PT/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/ru/learn-phragmen.md
+++ b/website/translated_docs/ru/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/sk-SK/learn-phragmen.md
+++ b/website/translated_docs/sk-SK/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/th-TH/learn-phragmen.md
+++ b/website/translated_docs/th-TH/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/tr/learn-phragmen.md
+++ b/website/translated_docs/tr/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/ur-IN/learn-phragmen.md
+++ b/website/translated_docs/ur-IN/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/ur-PK/learn-phragmen.md
+++ b/website/translated_docs/ur-PK/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/zh-CN/learn-phragmen.md
+++ b/website/translated_docs/zh-CN/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 

--- a/website/translated_docs/zh-TW/learn-phragmen.md
+++ b/website/translated_docs/zh-TW/learn-phragmen.md
@@ -160,7 +160,7 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 _Note: in terms of validator selection, for the following algorithm, you can think of "voters" as "nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm described above.
-2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a validator by each candidate.
+2. However, as candidates are elected, a weighted mapping is built, defining the weights of each selection of a nominator by each candidate.
 
 In more depth, the algorithm operates like so:
 


### PR DESCRIPTION
This PR replaces a single word in the the "Learn Phragmén" wiki entry: `validator` to `nominator`. I believe this an overseen logical error. 

As the text states that
* `validator` == `candidate`
* `nominator` == `voter`, 

it does not make sense to me that 
> "as candidates are elected, a weighted mapping is build, defining the weights of each selection of a `[candidate]` by each candidate". 

I suppose you meant to say `nominator` or `voter`.
