### PR TITLE
Fix staking mention and naming

### DIFF
--- a/docs/build-wallets.md
+++ b/docs/build-wallets.md
@@ -25,11 +25,11 @@ that the wallet software is using the latest version of the
 
 ### Supported Wallets
 
-| Wallet Name                                               | Development State | Team Name | Description       | Custody       | Supports |
-| --------------------------------------------------------- | ----------------- | --------- | ----------------- | ------------- | -------- |
-| [Signer](https://www.parity.io/signer/)                   | Live              | Parity    | IOS and Android   | Non-custodial |          |
-| [Polkadot-JS](https://polkadot.js.org/apps/#/accounts)    | Live              | Parity    | Browser           | Non-Custodial | Staking  |
-| [Polkadot{.js}](https://github.com/polkadot-js/extension) | Live              | Parity    | Browser extension | Non-custodial | Staking  |
+| Wallet Name                                                       | Development State | Team Name | Description       | Custody       | Supports |
+| ----------------------------------------------------------------- | ----------------- | --------- | ----------------- | ------------- | -------- |
+| [Parity Signer](https://www.parity.io/signer/)                    | Live              | Parity    | iOS and Android   | Non-custodial | Staking  |
+| [Polkadot-js apps](https://polkadot.js.org/apps/#/accounts)       | Live              | Parity    | Browser           | Non-Custodial | Staking  |
+| [Polkadot-js extension](https://github.com/polkadot-js/extension) | Live              | Parity    | Browser extension | Non-custodial | Staking  |
 
 > Note: the wallets page is currently being reviewed. Currently only Parity-developed wallets are
 > listed.


### PR DESCRIPTION
- Polkadot-js apps and extension are both part of the Polkadot-js repo. To ease search engine indexing, I suggest using Polkadot-js (the name of the repo).
- Adding the full name of Parity Signer, as it appears on mobile stores
- Adding the Staking ability for Signer.