### PR TITLE
Add Polkadot JS Desktop App to Wallets page

### DIFF
--- a/docs/build-wallets.md
+++ b/docs/build-wallets.md
@@ -25,11 +25,12 @@ that the wallet software is using the latest version of the
 
 ### Supported Wallets
 
-| Wallet Name                                                        | Development State | Team Name | Description       | Custody       | Supports |
-| ------------------------------------------------------------------ | ----------------- | --------- | ----------------- | ------------- | -------- |
-| [Parity Signer](https://www.parity.io/signer/) (see warning below) | Live              | Parity    | iOS and Android   | Non-custodial | Staking  |
-| [Polkadot-js apps](https://polkadot.js.org/apps/#/accounts)        | Live              | Parity    | Browser           | Non-Custodial | Staking  |
-| [Polkadot-js extension](https://github.com/polkadot-js/extension)  | Live              | Parity    | Browser extension | Non-custodial | Staking  |
+| Wallet Name                                                         | Development State | Team Name | Description       | Custody       | Supports |
+| ------------------------------------------------------------------- | ----------------- | --------- | ----------------- | ------------- | -------- |
+| [Parity Signer](https://www.parity.io/signer/) (see warning below)  | Live              | Parity    | iOS and Android   | Non-custodial | Staking  |
+| [Polkadot-js Desktop](https://github.com/polkadot-js/apps/releases) | Live              | Parity    | Win, Mac, Linux   | Non-custodial | Staking  |
+| [Polkadot-js extension](https://github.com/polkadot-js/extension)   | Live              | Parity    | Browser extension | Non-custodial | Staking  |
+| [Polkadot-js apps](https://polkadot.js.org/apps/#/accounts)         | Live              | Parity    | Browser           | Non-Custodial | Staking  |
 
 > Warning: Parity Signer currently does not allow you to see the transaction you are signing. This
 > means that you are at risk if connected to a compromised version of Polkadot-JS. A fix is being


### PR DESCRIPTION
As part of the [Open Grant](https://github.com/EthWorks/Open-Grants-Program/blob/master/applications/polkadot-desktop-app.md) we've packaged the Polkadot JS Apps UI as an Electron desktop app. This version stores account on user's hard drive, so it can be considered much safer than the web UI (which uses browser's local storage).

The Electron App is maintained and supported by @jacogr and myself.