### PR TITLE
docs: updated polkadotjs explorer entry

### DIFF
--- a/docs/build-tools-index.md
+++ b/docs/build-tools-index.md
@@ -11,8 +11,8 @@ developers, feel free to [add it in](contributing).
 ## Block Explorers
 
 - [Polkadot-JS Apps Explorer](https://polkadot.js.org/apps/#/explorer) - Polkadot dashboard block
-  explorer. Currently connects to Kusama by default, but can be configured to connect to Polkadot,
-  Westend, or other remote or local endpoints.
+  explorer. Supports dozens of other networks, including Kusama, Westend, and other remote or local
+  endpoints. [Access via IPFS](https://ipfs.io/ipns/dotapps.io)
 - [Polkascan](https://polkascan.io/) - Blockchain explorer for Polkadot, Kusama, and other related
   chains. [Repo](https://github.com/polkascan/polkascan-os).
 - [Subscan](https://subscan.io) - Blockchain explorer for Substrate chains.


### PR DESCRIPTION
Should close #1746 .

Updated PolkadotJS Explorer entry and added dynamic IPFS link (so this link always points to latest explorer/app version)