### PR TITLE
docs: added info on how to get runtime diffs

### DIFF
--- a/docs/maintain-networks.md
+++ b/docs/maintain-networks.md
@@ -60,7 +60,7 @@ Check your node is connected by viewing it on
 
 ### Differences
 
-Runtime differences (ie. existential and multisignature deposit sizes) between the different
+Runtime differences (e.g. existential and multisignature deposit sizes) between the different
 networks can be found by doing a `diff` between the `src/lib.rs` of the respositories. For example,
 to compare the Polkadot and Westend runtimes:
 

--- a/docs/maintain-networks.md
+++ b/docs/maintain-networks.md
@@ -68,6 +68,12 @@ to compare the Polkadot and Westend runtimes:
 - `ls` - show the available runtimes
 - `diff polkadot/src/lib.rs westend/src/lib.rs`
 
+You can also paste the runtimes
+([Polkadot](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/lib.rs),
+[Westend](https://github.com/paritytech/polkadot/blob/master/runtime/westend/src/lib.rs)) into a
+web-based diff tool like [Diffchecker](https://www.diffchecker.com/) if you're not comfortable with
+the CLI.
+
 ## Substrate Networks
 
 To connect to a Substrate public network first follow the [instructions][substrate install] for

--- a/docs/maintain-networks.md
+++ b/docs/maintain-networks.md
@@ -58,6 +58,16 @@ Follow the instruction [here](learn-DOT#getting-westies) for instructions on acq
 Check your node is connected by viewing it on
 [Telemetry](https://telemetry.polkadot.io/#list/Westend).
 
+### Differences
+
+Runtime differences (ie. existential and multisignature deposit sizes) between the different
+networks can be found by doing a `diff` between the `src/lib.rs` of the respositories. For example,
+to compare the Polkadot and Westend runtimes:
+
+- `git clone https://github.com/paritytech/polkadot && cd polkadot/runtime`
+- `ls` - show the available runtimes
+- `diff polkadot/src/lib.rs westend/src/lib.rs`
+
 ## Substrate Networks
 
 To connect to a Substrate public network first follow the [instructions][substrate install] for


### PR DESCRIPTION
Should close #1802 

Added to this page after "Westend Test Network": https://wiki.polkadot.network/docs/en/maintain-networks#network-differences

