### PR TITLE
fix stale learn-comparisons-cosmos

### DIFF
--- a/docs/learn-comparisons-cosmos.md
+++ b/docs/learn-comparisons-cosmos.md
@@ -120,7 +120,7 @@ nominating a validator does not assign any governance voting rights to the valid
 
 Polkadot uses [Cross-Chain Message Passing (XCMP)](learn-crosschain) for parachains to send
 arbitrary messages to each other. Parachains open connections with each other and can send messages
-via their established channels. [Collators](learn-collators) are full nodes of parachains and full
+via their established channels. [Collators](learn-collator) are full nodes of parachains and full
 nodes of the relay chain, so collator nodes are a key component of message passing. Messages do not
 pass through the Relay Chain, only proofs of post and channel operations (open, close, etc.) go into
 the Relay Chain. This enhances scalability by keeping data on the edges of the system.


### PR DESCRIPTION
broken link fix.

other than that, this page appears to be up to date.

should close #1850 