### PR TITLE
Change commas to underscores; fix some typos

### DIFF
--- a/docs/build-protocol-info.md
+++ b/docs/build-protocol-info.md
@@ -18,14 +18,14 @@ practical information for dealing with the chain.
 
 ### Redenomination
 
-Polkadot conducted a poll, which ended on 27 July 2020 (block 888,888), in which the stakeholders
+Polkadot conducted a poll, which ended on 27 July 2020 (block 888_888), in which the stakeholders
 decided to redenominate the DOT token. The redenomination does not change the number of base units
 (called "plancks" in Polkadot) in the network. The only change is that a single DOT token will be
 1e10 plancks instead of the original 1e12 plancks. See the Polkadot blog posts explaining the
 [details](https://medium.com/polkadot-network/the-first-polkadot-vote-1fc1b8bd357b) and the
 [results](https://medium.com/polkadot-network/the-results-are-in-8f6b1ca2a4e6) of the vote.
 
-The redenomination took effect 72 hours after transfers were enabled, at block 1,248,326, which
+The redenomination took effect 72 hours after transfers were enabled, at block 1_248_326, which
 occurred at approximately 16:50 UTC on 21 Aug 2020.
 
 ## Addresses

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ transitioning the governance of the chain into the hands of the token (DOT) hold
 point where Polkadot became decentralized.
 
 The final step of the transition to full-functioning Polkadot was the enabling of transfer
-functionality, which occurred on Polkadot at block number 1,205,128 on August 18, 2020, at 16:39
+functionality, which occurred on Polkadot at block number 1_205_128 on August 18, 2020, at 16:39
 UTC.
 
 On August 21, 2020, Redenomination of DOT occurred. From this date, one DOT (old) equals 100 new
@@ -153,7 +153,7 @@ there will be bridges between Polkadot and most of the other major chains.
 ### What is the difference between DOT (old) and new DOT?
 
 The DOT (old) unit on Polkadot was at twelve decimal places, otherwise known as 1e12 Plancks. On 21
-August, 2020, Denomiation Day, the DOT (old) value was redenominated to 1e10 (10'000'000'000, or ten
+August, 2020, Denomination Day, the DOT (old) value was redenominated to 1e10 (10_000_000_000, or ten
 billion) Plancks, meaning that the new DOT was valued at ten decimal places. Following the
 [redenomination](redenomination), the new DOT is called DOT.
 

--- a/docs/kusama-parameters.md
+++ b/docs/kusama-parameters.md
@@ -25,7 +25,7 @@ details on how Kusama's parameters differ from Polkadot's._
 | Slot    | 6 seconds | 1       |
 | Epoch   | 1 hour    | 600     |
 | Session | 1 hour    | 600     |
-| Era     | 6 hours   | 3,600   |
+| Era     | 6 hours   | 3_600   |
 
 \*_A maximum of one block per slot can be in a canonical chain. However, occasionally a slot will be
 without a block in the chain. Thus, the times given are estimates. See [Consensus](learn-consensus)
@@ -35,41 +35,41 @@ for more details._
 
 | Democracy        | Time   | Slots   | Description                                                                                                                                                   |
 | ---------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Voting period    | 7 days | 100,800 | How long the public can vote on a referendum.                                                                                                                 |
-| Launch period    | 7 days | 100,800 | How long the public can select which proposal to hold a referendum on, i.e., every week, the highest-weighted proposal will be selected to have a referendum. |
-| Enactment period | 8 days | 115,200 | Time it takes for a successful referendum to be implemented on the network.                                                                                   |
+| Voting period    | 7 days | 100_800 | How long the public can vote on a referendum.                                                                                                                 |
+| Launch period    | 7 days | 100_800 | How long the public can select which proposal to hold a referendum on, i.e., every week, the highest-weighted proposal will be selected to have a referendum. |
+| Enactment period | 8 days | 115_200 | Time it takes for a successful referendum to be implemented on the network.                                                                                   |
 
 | Council       | Time  | Slots  | Description                                                          |
 | ------------- | ----- | ------ | -------------------------------------------------------------------- |
-| Term duration | 1 day | 14,400 | The length of a council member's term until the next election round. |
-| Voting period | 1 day | 14,400 | The council's voting period for motions.                             |
+| Term duration | 1 day | 14_400 | The length of a council member's term until the next election round. |
+| Voting period | 1 day | 14_400 | The council's voting period for motions.                             |
 
 The Kusama Council consists of up to 19 members and up to 19 runners up.
 
 | Technical committee     | Time    | Slots   | Description                                                                                    |
 | ----------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------- |
-| Cool-off period         | 7 days  | 604,800 | The time a veto from the technical committee lasts before the proposal can be submitted again. |
-| Emergency voting period | 3 hours | 1,800   | The voting period after the technical committee expedites voting.                              |
+| Cool-off period         | 7 days  | 604_800 | The time a veto from the technical committee lasts before the proposal can be submitted again. |
+| Emergency voting period | 3 hours | 1_800   | The voting period after the technical committee expedites voting.                              |
 
 ### Staking, Validating, and Nominating
 
 | Kusama               | Time    | Slots   | Description                                                                                                                                                                                         |
 | -------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Term duration        | 6 hours | 3,600   | The time for which a validator is in the set after being elected. Note, this duration can be shortened in the case the a validator misbehaves.                                                      |
-| Nomination period    | 6 hours | 3,600   | How often a new validator set is [elected](learn-phragmen).                                                                                                                                         |
-| Bonding duration     | 7 days  | 604,800 | How long until your funds will be transferrable after unbonding. Note that the bonding duration is defined in eras, not directly by slots.                                                          |
-| Slash defer duration | 7 days  | 604,800 | Prevents overslashing and validators "escaping" and getting their nominators slashed with no repercussions to themselves. Note that the bonding duration is defined in eras, not directly by slots. |
+| Term duration        | 6 hours | 3_600   | The time for which a validator is in the set after being elected. Note, this duration can be shortened in the case the a validator misbehaves.                                                      |
+| Nomination period    | 6 hours | 3_600   | How often a new validator set is [elected](learn-phragmen).                                                                                                                                         |
+| Bonding duration     | 7 days  | 604_800 | How long until your funds will be transferrable after unbonding. Note that the bonding duration is defined in eras, not directly by slots.                                                          |
+| Slash defer duration | 7 days  | 604_800 | Prevents overslashing and validators "escaping" and getting their nominators slashed with no repercussions to themselves. Note that the bonding duration is defined in eras, not directly by slots. |
 
 ### Treasury
 
 | Treasury               | Time   | Slots  | Description                                                  |
 | ---------------------- | ------ | ------ | ------------------------------------------------------------ |
-| Periods between spends | 6 days | 86,400 | When the treasury can spend again after spending previously. |
+| Periods between spends | 6 days | 86_400 | When the treasury can spend again after spending previously. |
 
 Burn percentage is currently `0.20%`, though instead of being burned this amount is temporarily
 redirected into the [Society](maintain-guides-society-kusama)'s treasury to fund growth.
 
 ### Precision
 
-KSM have 12 decimals of precision. In other words, 1e12 (1,000,000,000,000 or one trillion) Plancks
+KSM have 12 decimals of precision. In other words, 1e12 (1_000_000_000_000, or one trillion) Plancks
 make up a single KSM.

--- a/docs/learn-DOT.md
+++ b/docs/learn-DOT.md
@@ -24,7 +24,7 @@ are equal to 1e10 Planck.
 | Millidot (mDOT) | 7              | 0.0010000000 |
 | Dot (DOT)       | 10             | 1.0000000000 |
 
-_Note: This changed at block #1,248,328. Previously, DOT were denominated as equal to 1e12 Planck,
+_Note: This changed at block #1_248_328. Previously, DOT were denominated as equal to 1e12 Planck,
 just like Kusama. This denomination is deprecrated, and, if necessary, referred to as "DOT (old)".
 See [Redenomination of DOT](redenomination) for more details._
 

--- a/docs/learn-accounts.md
+++ b/docs/learn-accounts.md
@@ -356,7 +356,7 @@ Deposit = DepositBase + threshold * DepositFactor
 Where `DepositBase` and `DepositFactor` are chain constants set in the runtime code.
 
 Currently, the DepositBase is equal to `deposit(1, 88)` (key size is 32; value is size 4+4+16+32 =
-56 bytes) and the DepositFactor is equal to `deposit(0,32)` (additional address of 32 bytes).
+56 bytes) and the DepositFactor is equal to `deposit(0, 32)` (additional address of 32 bytes).
 
 The deposit function in JavaScript is defined below, cribbed from the
 [Rust source](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/constants.rs#L26).

--- a/docs/learn-comparison-ethereum-2.md
+++ b/docs/learn-comparison-ethereum-2.md
@@ -88,13 +88,13 @@ Validators run a primary Beacon Chain node and multiple validator clients - one 
 These validators get assigned to "committees", which are randomly selected groups to validate shards
 in the network. Ethereum 2.0 relies on having a large validator set to provide availability and
 validity guarantees: They need at least 111 validators per shard to run the network and 256
-validators per shard to finalize all shards within one epoch. With 64 shards, that's 16,384
+validators per shard to finalize all shards within one epoch. With 64 shards, that's 16_384
 validators (given 256 validators per shard). [3][4]
 
 Polkadot is able to provide strong finality and availability guarantees with much fewer validators.
 Polkadot uses [Nominated Proof of Stake (NPoS)](learn-staking) to select validators from a smaller
 set, letting smaller holders nominate validators to run infrastructure while still claiming the
-rewards of the system, without running a node of their own. Polkadot plans to have 1,000 validators
+rewards of the system, without running a node of their own. Polkadot plans to have 1_000 validators
 by the end of its first year of operation, and needs about ten validators for each parachain in the
 network.
 

--- a/docs/learn-comparisons-cosmos.md
+++ b/docs/learn-comparisons-cosmos.md
@@ -92,7 +92,7 @@ it has quadratic transport complexity, but can only finalize one block at a time
 ## Staking Mechanics
 
 Polkadot uses [Nominated Proof of Stake (NPoS)](learn-staking) to select validators using the
-[sequential Phragmén algorithm](learn-phragmen). The validator set size is set by governance (1,000
+[sequential Phragmén algorithm](learn-phragmen). The validator set size is set by governance (1_000
 validators planned) and stakers who do not want to run validator infrastructure can nominate up to
 16 validators. Phragmén's algorithm selects the optimal allocation of stake, where optimal is based
 on having the most evenly staked set.

--- a/docs/learn-governance.md
+++ b/docs/learn-governance.md
@@ -171,7 +171,7 @@ _To know more about where these above formulas come from, please read the
 Example:
 
 Assume:
-- We only have 1,500 DOT tokens in total.
+- We only have 1_500 DOT tokens in total.
 - Public proposal
 
 John  - 500 DOT

--- a/docs/learn-launch.md
+++ b/docs/learn-launch.md
@@ -43,7 +43,7 @@ under control of any centralized authority.
 
 To enable balance transfers, the community [made a public proposal](maintain-guides-democracy) for a
 runtime upgrade that lifted the restriction on balance transfers. Transfer functionality was
-subsequently enabled on Polkadot at block number 1,205,128 on August 18, 2020, at 16:39 UTC.
+subsequently enabled on Polkadot at block number 1_205_128 on August 18, 2020, at 16:39 UTC.
 
 ## Redenomination
 
@@ -58,8 +58,7 @@ that will pass through Polkadot's normal governance processes. The core function
 to be unlocked sequentially &mdash; several features can be unlocked with a single proposal.
 
 Parachains will first roll out on Kusama with a common good parachain, followed by the first slot
-auction and winner's onboarding. Once those parachains are working well on Kusama, the first common
-good parachain will launch, and then the first slot auction will take place on Polkadot.
+auction and winner's onboarding. 
 
 ## Polkadot 2.0
 

--- a/docs/learn-phragmen.md
+++ b/docs/learn-phragmen.md
@@ -560,8 +560,8 @@ like to dive even more deeply, you can review the
 Paying out rewards for staking from every validator to all of their nominators can cost a
 non-trivial amount of chain resources (in terms of space on chain and resources to compute). Assume
 a system with 200 validators and 1000 nominators, where each of the nominators has nominated 10
-different validators. Payout would thus require `1000 * 10`, or 10,000 transactions. In an ideal
-scenario, if every nominator selects a single validator, only 1,000 transactions would need to take
+different validators. Payout would thus require `1_000 * 10`, or 10_000 transactions. In an ideal
+scenario, if every nominator selects a single validator, only 1_000 transactions would need to take
 place - an order of magnitude fewer. Empirically, network slowdown at the beginning of an era has
 occurred due to the large number of individual payouts by validators to nominators. In extreme
 cases, this could be an attack vector on the system, where nominators nominate many different
@@ -585,7 +585,7 @@ Another issue is that we want to ensure that as equal a distribution of votes as
 the elected validators or council members. This helps us increase the security of the system by
 ensuring that the minimum amount of tokens in order to join the active validator set or council is
 as high as possible. For example, assume a result of five validators being elected, where validators
-have the following stake: `{1000, 20, 10, 10, 10}`, for a total stake of 1,050. In this case, a
+have the following stake: `{1_000, 20, 10, 10, 10}`, for a total stake of 1_050. In this case, a
 potential attacker could join the active validator set with only 11 tokens, and could obtain a
 majority of validators with only 33 tokens (since the attacker only has to have enough stake to
 "kick out" the three lowest validators).

--- a/docs/learn-security.md
+++ b/docs/learn-security.md
@@ -23,7 +23,7 @@ fill their blocks. A major flaw in this idea is that the lower market cap coins 
 economic security attached, and be easier to attack. A real life example of a 51% attack occurred
 recently (
 [Ethereum Classic attack on January 10](https://cointelegraph.com/news/ethereum-classic-51-attack-the-reality-of-proof-of-work)
-), in which an unknown attacker double spent 219,500 ETC (~1.1M USD). This was followed by two more
+), in which an unknown attacker double spent 219_500 ETC (~1.1 million USD). This was followed by two more
 51% attacks on ETC.
 
 Polkadot overcomes security scalability concerns since it gravitates all the economic incentives to

--- a/docs/learn-staking.md
+++ b/docs/learn-staking.md
@@ -398,9 +398,8 @@ for details.
 ```
     PER_ERA * BLOCK_TIME = **Reward Distribution Time**
 
-    3600 * 6 seconds = 21,600 s = 6 hours
+    3_600 * 6 seconds = 21_600 s = 6 hours
 
-    ***These parameters can be changed by proposing a referendum***
 ```
 
 Validators can create a cut of the reward that is not shared with the nominators. This cut is a

--- a/docs/maintain-guides-how-to-nominate-kusama.md
+++ b/docs/maintain-guides-how-to-nominate-kusama.md
@@ -153,7 +153,7 @@ staking model.
 
 `NUMBER_OF_TOKENS`: The number of KSM / DOT you would like to stake to the network. **Note**: KSM
 has twelve decimal places and is always represented as an integer with zeroes at the end. So 1 KSM =
-1,000,000,000,000 units.
+1_000_000_000_000 Plancks.
 
 `REWARD_DESTINATION`:
 

--- a/docs/maintain-guides-how-to-nominate-polkadot.md
+++ b/docs/maintain-guides-how-to-nominate-polkadot.md
@@ -153,7 +153,7 @@ staking model.
 `NUMBER_OF_TOKENS`: The number of DOT you would like to stake to the network.
 
 > **Note**: DOT has ten decimal places and is always represented as an integer with zeroes at the
-> end. So 1 DOT = 10,000,000,000 units.
+> end. So 1 DOT = 10_000_000_000 Plancks.
 
 `REWARD_DESTINATION`:
 

--- a/docs/maintain-guides-society-kusama.md
+++ b/docs/maintain-guides-society-kusama.md
@@ -131,10 +131,10 @@ Example:
 ```
 Let's assume we have 5 members in the society.
 
-lock_duration = 100 - 50,000 / (5 + 500)
+lock_duration = 100 - 50_000 / (5 + 500)
 lock_duration * MAX_LOCK_DURATION_IN_BLOCKS
 
-Result = 1% * 15,552,000 ~ 11 days
+Result = 1% * 15_552_000 ~ 11 days
 ```
 
 Based on the above calculation, it is required to wait close to 11 days to get the slashed funds.

--- a/docs/maintain-polkadot-parameters.md
+++ b/docs/maintain-polkadot-parameters.md
@@ -16,16 +16,16 @@ _NOTE: Kusama runs 4x as fast as Polkadot, except Polkadot also has 6 second blo
 Kusama's parameters differ from Polkadot's._
 
 - Slot: 6 seconds \*(generally one block per slot, although see note below)
-- Epoch: 4 hours (2,400 slots x 6 seconds)
+- Epoch: 4 hours (2_400 slots x 6 seconds)
 - Session: 4 hours (Session and Epoch lengths are the same)
-- Era: 24 hours (6 sessions per Era, 2,400 slots x 6 epochs x 6 seconds)
+- Era: 24 hours (6 sessions per Era, 2_400 slots x 6 epochs x 6 seconds)
 
 | Polkadot | Time      | Slots\* |
 | -------- | --------- | ------- |
 | Slot     | 6 seconds | 1       |
-| Epoch    | 4 hours   | 2,400   |
-| Session  | 4 hours   | 2,400   |
-| Era      | 24 hours  | 14,400  |
+| Epoch    | 4 hours   | 2_400   |
+| Session  | 4 hours   | 2_400   |
+| Era      | 24 hours  | 14_400  |
 
 \*_A maximum of one block per slot can be in a canonical chain. However, occasionally a slot will be
 without a block in the chain. Thus, the times given are estimates. See [Consensus](learn-consensus)
@@ -35,43 +35,43 @@ for more details._
 
 | Democracy        | Time    | Slots   | Description                                                                                                                                                   |
 | ---------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Voting period    | 28 days | 403,200 | How long the public can vote on a referendum.                                                                                                                 |
-| Launch period    | 28 days | 403,200 | How long the public can select which proposal to hold a referendum on, i.e., every week, the highest-weighted proposal will be selected to have a referendum. |
-| Enactment period | 28 days | 403,200 | Time it takes for a successful referendum to be implemented on the network.                                                                                   |
+| Voting period    | 28 days | 403_200 | How long the public can vote on a referendum.                                                                                                                 |
+| Launch period    | 28 days | 403_200 | How long the public can select which proposal to hold a referendum on, i.e., every week, the highest-weighted proposal will be selected to have a referendum. |
+| Enactment period | 28 days | 403_200 | Time it takes for a successful referendum to be implemented on the network.                                                                                   |
 
 | Council       | Time   | Slots   | Description                                                          |
 | ------------- | ------ | ------- | -------------------------------------------------------------------- |
-| Term duration | 7 days | 100,800 | The length of a council member's term until the next election round. |
-| Voting period | 7 days | 100,800 | The council's voting period for motions.                             |
+| Term duration | 7 days | 100_800 | The length of a council member's term until the next election round. |
+| Voting period | 7 days | 100_800 | The council's voting period for motions.                             |
 
 The Polkadot Council consists of up to 13 members and up to 20 runners up.
 
 | Technical committee     | Time    | Slots   | Description                                                                                    |
 | ----------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------- |
-| Cool-off period         | 7 days  | 100,800 | The time a veto from the technical committee lasts before the proposal can be submitted again. |
-| Emergency voting period | 3 hours | 1,800   | The voting period after the technical committee expedites voting.                              |
+| Cool-off period         | 7 days  | 100_800 | The time a veto from the technical committee lasts before the proposal can be submitted again. |
+| Emergency voting period | 3 hours | 1_800   | The voting period after the technical committee expedites voting.                              |
 
 ### Staking, Validating, and Nominating
 
 | Kusama               | Time    | Slots   | Description                                                                                                                                                                                         |
 | -------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Term duration        | 1 Day   | 14,400  | The time for which a validator is in the set after being elected. Note, this duration can be shortened in the case that a validator misbehaves.                                                     |
-| Nomination period    | 1 Day   | 14,400  | How often a new validator set is elected according to Phragmén's method.                                                                                                                            |
-| Bonding duration     | 28 days | 403,200 | How long until your funds will be transferrable after unbonding. Note that the bonding duration is defined in eras, not directly by slots.                                                          |
-| Slash defer duration | 28 days | 403,200 | Prevents overslashing and validators "escaping" and getting their nominators slashed with no repercussions to themselves. Note that the bonding duration is defined in eras, not directly by slots. |
+| Term duration        | 1 Day   | 14_400  | The time for which a validator is in the set after being elected. Note, this duration can be shortened in the case that a validator misbehaves.                                                     |
+| Nomination period    | 1 Day   | 14_400  | How often a new validator set is elected according to Phragmén's method.                                                                                                                            |
+| Bonding duration     | 28 days | 403_200 | How long until your funds will be transferrable after unbonding. Note that the bonding duration is defined in eras, not directly by slots.                                                          |
+| Slash defer duration | 28 days | 403_200 | Prevents overslashing and validators "escaping" and getting their nominators slashed with no repercussions to themselves. Note that the bonding duration is defined in eras, not directly by slots. |
 
 ### Treasury
 
 | Treasury               | Time    | Slots   | Description                                                  |
 | ---------------------- | ------- | ------- | ------------------------------------------------------------ |
-| Periods between spends | 24 days | 345,600 | When the treasury can spend again after spending previously. |
+| Periods between spends | 24 days | 345_600 | When the treasury can spend again after spending previously. |
 
 Burn percentage is currently `1.00%`.
 
 ### Precision
 
-DOT have 10 decimals of precision. In other words, 10 \*\* 10 (10,000,000,000 or ten billion)
+DOT have 10 decimals of precision. In other words, 10 \*\* 10 (10_000_000_000 or ten billion)
 Plancks make up a DOT.
 
-The denomination of DOT was changed from 12 decimals of precision at block #1,248,328 in an event
+The denomination of DOT was changed from 12 decimals of precision at block #1_248_328 in an event
 known as _Denomination Day_. See [Redenomination](redenomination) for details.

--- a/docs/redenomination.md
+++ b/docs/redenomination.md
@@ -5,7 +5,7 @@ sidebar_label: Redenomination of DOT
 ---
 
 > Note: The DOT redenomination took place on 21 August, now known as Denomination Day, at block
-> #1,248,328.
+> #1_248_328.
 
 While [DOT](learn-dot) is the unit of currency on Polkadot that most people use when interacting
 with the system, the smallest unit of account is called the Planck. A Planck's relation to DOT is
@@ -26,7 +26,7 @@ denomination by a factor of one hundred.
 The overall effect of this change was that the number of Polkadot's smallest unit, the Planck,
 remained constant, while the DOT balance for all holders was increased by a factor of one hundred.
 As one can see from the example below, the number of Plancks that a user has does not change, only
-the number of Plancks that constitute a single DOT. A user with 1,000,000,000,000 Plancks still has
+the number of Plancks that constitute a single DOT. A user with 1_000_000_000_000 Plancks still has
 the same number of Plancks, but will have 100 DOT under the new denomination, as opposed to one DOT
 under the old denomination.
 
@@ -116,7 +116,7 @@ third of the total DOT in the network participated in the vote. The redenominato
 with 86% of the voters favoring a 100x factor increase (or two decimal places of precision loss).
 
 Polkadot's redenomination then took place on 21 August, now known as Denomination Day, at block
-#1,248,328.
+#1_248_328.
 
 ### What This Means for the Community
 


### PR DESCRIPTION
Based on @Swader 's earlier comment, this changes all commas used as thousands separators to underscores

I fixed a few typos while I was in here as well