### PR TITLE
Kusama endpoint link

### DIFF
--- a/docs/kusama-endpoints.md
+++ b/docs/kusama-endpoints.md
@@ -5,7 +5,7 @@ sidebar_label: Kusama Endpoints
 ---
 
 When interacting with the [Kusama network][] via [Polkadot-JS Apps][] or other UIs and programmatic
-methods, you'd ideally be running your own node ([text guide](maintain-sync),
+methods, you'd ideally be running your own node ([text guide](https://wiki.polkadot.network/docs/en/maintain-sync),
 [video guide](https://www.youtube.com/watch?v=31DdfcxbAVs)). Granted, that's not something everyone
 wants to do, so convenience trumps ideals in most cases. To facilitate this convenience, Kusama has
 several public endpoints you can use for your apps.


### PR DESCRIPTION
Kusama endpoint page with link to page to setup a full node is no longer available on Kusama.network guide, reference Polkadot instead.