### PR TITLE
Add Simple Analytics

### DIFF
--- a/kusama-guide/siteConfig.js
+++ b/kusama-guide/siteConfig.js
@@ -61,6 +61,11 @@ const siteConfig = {
     "/js/klaro.js",
     "/js/clipboard.min.js",
     "/js/copycode.js",
+    {
+      src: "https://apisa.web3.foundation/latest.js",
+      async: true,
+      defer: true,
+    },
   ],
 
   stylesheets: [

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -67,6 +67,11 @@ const siteConfig = {
     "/js/packaged/addressChanger.js",
     "/js/clipboard.min.js",
     "/js/copycode.js",
+    {
+      src: "https://apisa.web3.foundation/latest.js",
+      async: true,
+      defer: true,
+    },
   ],
 
   stylesheets: [


### PR DESCRIPTION
This PR adds Simple Analytics (cookieless) scripts to the `<head />` of both Polkadot and Kusama wiki websites via the site configuration. Will be added similarly to the PR https://github.com/w3f/polkadot-wiki/pull/2077 for migration to Docusaurus 2.