### PR TITLE
No longer a difference in secondary blocks

### DIFF
--- a/docs/learn-consensus.md
+++ b/docs/learn-consensus.md
@@ -107,16 +107,6 @@ either a _primary_ or a _secondary_ block, and no slots are ever skipped.
 For more details on BABE, please see the
 [BABE paper](https://research.web3.foundation/en/latest/polkadot/block-production/Babe.html).
 
-#### Difference of BABE secondary blocks between Kusama and Polkadot
-
-Both Kusama and Polkadot uses the BABE block production mechanism outlined above. However, there is
-a slight difference in the secondary blocks that are produced between the two networks. Polkadot
-attaches the VRF output to secondary blocks (and therefore every block contributes to the Epoch
-randomness), while Kusama keeps the VRF output off the secondary blocks (meaning only the primary
-blocks contribute to Epoch randomness). The Polkadot method should give stronger randomness as more
-inputs are collected during every Epoch. Eventually, this change should make its way into Kusama
-too.
-
 ### GRANDPA: Finality gadget
 
 GRANDPA (GHOST-based Recursive ANcestor Deriving Prefix Agreement) is the finality gadget that is


### PR DESCRIPTION
Both now use secondary VRF blocks - you can check this on-chain in babe.epochConfig storage entry.

They were necessary for parachain consensus (approval voting assignments) and were enabled a few months ago.