### PR TITLE
Update sidebar for how-to-dyor

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -15,7 +15,7 @@
       "ens",
       "learn-ledger",
       "learn-scams",
-      "learn-legitimate-projects",
+      "how-to-dyor",
       "faq"
     ],
     "Learn": [


### PR DESCRIPTION
Changed the ID of `learn-legitimate-projects` to `how-to-dyor`