### PR TITLE
replace self-referencing link

### DIFF
--- a/docs/maintain-polkadot-parameters.md
+++ b/docs/maintain-polkadot-parameters.md
@@ -12,7 +12,7 @@ at the [chain state](https://polkadot.js.org/apps/#/chainstate/constants) and/or
 ### Periods of common actions and attributes
 
 _NOTE: Polkadot generally runs at &frac14;th the speed of Kusama, except in the time slot duration itself. See
-[Kusama Parameters](https://guide.kusama.network/docs/kusama-parameters) for more details on how Polkadot's parameters
+[Kusama Parameters](kusama-parameters) for more details on how Polkadot's parameters
 differ from Kusama's._
 
 - Slot: 6 seconds \*(generally one block per slot, although see note below)

--- a/docs/maintain-polkadot-parameters.md
+++ b/docs/maintain-polkadot-parameters.md
@@ -11,9 +11,9 @@ at the [chain state](https://polkadot.js.org/apps/#/chainstate/constants) and/or
 
 ### Periods of common actions and attributes
 
-_NOTE: Kusama generally runs 4x as fast as Polkadot, except in the time slot duration itself. See
-[Polkadot Parameters](maintain-polkadot-parameters.md) for more details on how Kusama's parameters
-differ from Polkadot's._
+_NOTE: Polkadot generally runs at &frac14;th the speed of Kusama, except in the time slot duration itself. See
+[Kusama Parameters](https://guide.kusama.network/docs/kusama-parameters) for more details on how Polkadot's parameters
+differ from Kusama's._
 
 - Slot: 6 seconds \*(generally one block per slot, although see note below)
 - Epoch: 4 hours (2_400 slots x 6 seconds)


### PR DESCRIPTION
this document currently references itself in a link embedded in some text referencing kusama. possibly because it was at some point copied from another document describing kusama (see: https://guide.kusama.network/docs/kusama-parameters). this change alters the text to make the inverse comparison from a polkadot, rather than kusama perspective.