### PR TITLE
[CI] add staging server CICD and `prod` branch workflow

### DIFF
--- a/.github/workflows/deploy-kusama-prod.yml
+++ b/.github/workflows/deploy-kusama-prod.yml
@@ -1,0 +1,23 @@
+name: Kusama Prod
+
+on:
+  push:
+    branches:
+      - prod
+
+jobs:
+  build:
+    name: build and deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Publish
+        run: |
+          git config --global user.email "polkadot-wiki-deploy@users.noreply.github.com"
+          git config --global user.name "Polkadot Wiki CI"
+          echo "machine github.com login w3fdeploy password ${{ secrets.ACCESS_KEY }}" > ~/.netrc
+          yarn && yarn kusama2:build && GIT_USER=w3fdeploy PUBLISHING=true PROJECT_NAME=kusama-guide-hosting yarn run kusama2:publish-gh-pages

--- a/.github/workflows/deploy-kusama-staging.yml
+++ b/.github/workflows/deploy-kusama-staging.yml
@@ -1,6 +1,5 @@
-name: Deploy Kusama
+name: Kusama Staging
 
-# Triggered on commits to the main branch.
 on:
   push:
     branches:
@@ -12,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
 
       # - name: Clone and run the site
       #   run: |
@@ -46,4 +48,4 @@ jobs:
           git config --global user.email "polkadot-wiki-deploy@users.noreply.github.com"
           git config --global user.name "Polkadot Wiki CI"
           echo "machine github.com login w3fdeploy password ${{ secrets.ACCESS_KEY }}" > ~/.netrc
-          yarn && yarn kusama:build && GIT_USER=w3fdeploy PUBLISHING=true PROJECT_NAME=kusama-guide-hosting yarn run kusama:publish-gh-pages
+          yarn && yarn kusama2:build && GIT_USER=w3fdeploy PUBLISHING=true PROJECT_NAME=kusama-guide-staging yarn run kusama:publish-gh-pages

--- a/.github/workflows/deploy-polkadot-prod.yml
+++ b/.github/workflows/deploy-polkadot-prod.yml
@@ -1,0 +1,23 @@
+name: Polkadot Prod
+
+on:
+  push:
+    branches:
+      - prod
+
+jobs:
+  build:
+    name: build and deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          
+      - name: Publish
+        run: |
+          git config --global user.email "polkadot-wiki-deploy@users.noreply.github.com"
+          git config --global user.name "Polkadot Wiki CI"
+          echo "machine github.com login w3fdeploy password ${{ secrets.ACCESS_KEY }}" > ~/.netrc
+          yarn && yarn polkadot2:build && GIT_USER=w3fdeploy PUBLISHING=true yarn run polkadot2:publish-gh-pages

--- a/.github/workflows/deploy-polkadot-staging.yml
+++ b/.github/workflows/deploy-polkadot-staging.yml
@@ -1,6 +1,5 @@
-name: Deploy Polkadot
+name: Polkadot Staging
 
-# Triggered on commits to the main branch.
 on:
   push:
     branches:
@@ -61,4 +60,4 @@ jobs:
           git config --global user.email "polkadot-wiki-deploy@users.noreply.github.com"
           git config --global user.name "Polkadot Wiki CI"
           echo "machine github.com login w3fdeploy password ${{ secrets.ACCESS_KEY }}" > ~/.netrc
-          yarn && yarn polkadot:build && GIT_USER=w3fdeploy PUBLISHING=true yarn run polkadot:publish-gh-pages
+          yarn && yarn polkadot2:build && GIT_USER=w3fdeploy PUBLISHING=true PROJECT_NAME=polkadot-wiki-staging yarn run polkadot:publish-gh-pages


### PR DESCRIPTION
tl;dr: `master` doesn't deploy to prod anymore, `prod` does. `master` deploys to staging. Never merge anything other than `master` into `prod`. Or else.

---

Okay, we will now will have a staging server that we can test changes before we deploy to prod. Here is our new workflow (**new steps in bold**)

- New commits are done on a new branch off of `master` and pushed to `w3f/polkadot-wiki`
- A PR is put up for changes on that branch against `master`. Once approved etc, the changes are merged to `master`
- **CI/CD will automatically build and start the wiki on `master` viewable at https://w3f.github.io/polkadot-wiki-staging and https://w3f.github.io/kusama-guide-staging (these will be switched to https://staging.guide.kusama.network and https://staging.wiki.polkadot.network once I get DNS permissions). These changes will _not_ be reflected on https://wiki.polkadot.network or https://guide.kusama.network yet.**
    - Yes, the staging servers will look gross until get DNS figured out.
- **After testing the changes on the staging server, we can merge them into the `prod`. This can be most simply done via a PR from `master` to `prod` (also the best way if the rest of the team needs to see it), or this can just be merged and pushed locally.**
     - To do this locally, pull the latest `prod` and `master` branches, merge `master` into `prod`, and push `prod`. CICD will pickup this change on `prod`, and build appropriately.**

I have created a new repo called [w3f/polkadot-wiki-staging](https://github.com/w3f/polkadot-wiki-staging) that handles the hosting of the test server (just like how [w3f/kusama-guide-hosting](https://github.com/w3f/kusama-guide-hosting) hosts the Kusama Guide).

Still todo (but not blocking merge):
- [ ] Add CNAME DNS entries for https://staging.guide.kusama.network and https://staging.wiki.polkadot.network