### PR TITLE
Wiki link issues

### DIFF
--- a/website-v2/docusaurus.config.js
+++ b/website-v2/docusaurus.config.js
@@ -73,6 +73,12 @@ module.exports = {
     [
       "@docusaurus/plugin-client-redirects",
       {
+        redirects: [
+          {
+            to: '/',
+            from: '/en/latest',
+          },
+        ],
         createRedirects: function (existingPath) {
           if (existingPath.startsWith("/docs/")) {
             return [
@@ -80,13 +86,6 @@ module.exports = {
               existingPath.replace("/docs/", "/docs/zh-CN/"),
               existingPath.replace("/docs/", "/docs/ru-RU/"),
             ];
-          }
-          else if (existingPath.startsWith("/en/")) {
-            return [
-              existingPath.replace('/docs/getting-started/', "/en/"),
-              existingPath.replace('/docs/getting-started/', "/en/latest/"),
-            ];
-
           }
 
         },

--- a/website-v2/docusaurus.config.js
+++ b/website-v2/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports = {
         redirects: [
           {
             to: '/',
-            from: '/en/latest',
+            from: ['/en/latest','/en/'],
           },
         ],
         createRedirects: function (existingPath) {

--- a/website-v2/docusaurus.config.js
+++ b/website-v2/docusaurus.config.js
@@ -81,6 +81,7 @@ module.exports = {
               existingPath.replace("/docs/", "/docs/ru-RU/"),
             ];
           }
+          //placeholder for redirects to fix polkadot.network link issues
         },
       },
     ],

--- a/website-v2/docusaurus.config.js
+++ b/website-v2/docusaurus.config.js
@@ -81,7 +81,14 @@ module.exports = {
               existingPath.replace("/docs/", "/docs/ru-RU/"),
             ];
           }
-          //placeholder for redirects to fix polkadot.network link issues
+          else if (existingPath.startsWith("/en/")) {
+            return [
+              existingPath.replace('/docs/getting-started/', "/en/"),
+              existingPath.replace('/docs/getting-started/', "/en/latest/"),
+            ];
+
+          }
+
         },
       },
     ],


### PR DESCRIPTION
Final fix for redirecting below links to the wiki homepage. Right now, they give page not found error

https://wiki.polkadot.network/en

https://wiki.polkadot.network/en/latest