### PR TITLE
Replace tx with transaction in node interaction page

### DIFF
--- a/docs/build-node-interaction.md
+++ b/docs/build-node-interaction.md
@@ -384,7 +384,7 @@ Notice that some extrinsics do not have a signature. These are
 
 ### Submitting a Transaction
 
-Submit a serialized transaction using the `tx` endpoint with an HTTP POST request.
+Submit a serialized transaction using the `transaction` endpoint with an HTTP POST request.
 
 ```python
 import requests


### PR DESCRIPTION
In the [Submitting a Transaction](https://wiki.polkadot.network/docs/build-node-interaction#submitting-a-transaction) section of the Node Interaction page, a `tx` endpoint of the Substrate Sidecar API is mentioned, but looking at its [specification](https://paritytech.github.io/substrate-api-sidecar/dist/), looks like `tx` endpoints were replaced by `transaction` ones, hence the proposed change.