### PR TITLE
Fix link to Set up a Full Node

### DIFF
--- a/docs/maintain/maintain-index.md
+++ b/docs/maintain/maintain-index.md
@@ -11,7 +11,7 @@ guides to set up a node and run the network.
 
 - [Networks Guide](maintain-networks.md) - A list of the available Polkadot networks that you can
   connect to with a node.
-- [Set up a Full Node](maintain-sync.mdx) - Get up and started by syncing a full node for the Kusama
+- [Set up a Full Node](maintain-sync.md) - Get up and started by syncing a full node for the Kusama
   network. The steps in the guide will broadly apply also to any Substrate-based network (like
   Polkadot).
 - [Set up WSS using Nginx](maintain-wss.md) - Set up a Secure WebSockets server for your node's


### PR DESCRIPTION
Fixes a broken link to [Set up a Full Node](https://wiki.polkadot.network/docs/maintain-sync)