### PR TITLE
Update CI for Staging to Deploy on PRs

### DIFF
--- a/.github/workflows/deploy-kusama-staging.yml
+++ b/.github/workflows/deploy-kusama-staging.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/deploy-polkadot-staging.yml
+++ b/.github/workflows/deploy-polkadot-staging.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
PR being used as test

It's helpful to have the staging site updated when a change is requested so one is able to see their changes and make others as needed before it gets merged to master - master can serve as QA check before prod 