### PR TITLE
Fix link to research paper 

### DIFF
--- a/docs/general/research.md
+++ b/docs/general/research.md
@@ -26,7 +26,7 @@ Polkadot from a research or academic perspective.
   Lefteris Kokoris Kogias
 - [`A Verifiably Secure and Proportional Committee Election Rule`](https://arxiv.org/abs/2004.12990) -
   Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [`Network Time with a Consensus on Clock`](https://arxiv.org/abs/2007.01560) - Consensus on Clock
+- [`Network Time with a Consensus on Clock`](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock
   in Universally Composable Timing. Author: Handan Kılınç Alper
 - [`Delay Encryption`](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described
   as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and

--- a/polkadot-wiki/translated_docs/ar/research.md
+++ b/polkadot-wiki/translated_docs/ar/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/de/research.md
+++ b/polkadot-wiki/translated_docs/de/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/es-ES/research.md
+++ b/polkadot-wiki/translated_docs/es-ES/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/fi/research.md
+++ b/polkadot-wiki/translated_docs/fi/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/fil-PH/research.md
+++ b/polkadot-wiki/translated_docs/fil-PH/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/fr/research.md
+++ b/polkadot-wiki/translated_docs/fr/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/hi-IN/research.md
+++ b/polkadot-wiki/translated_docs/hi-IN/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/hr-HR/research.md
+++ b/polkadot-wiki/translated_docs/hr-HR/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/id-ID/research.md
+++ b/polkadot-wiki/translated_docs/id-ID/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/it/research.md
+++ b/polkadot-wiki/translated_docs/it/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/ja/research.md
+++ b/polkadot-wiki/translated_docs/ja/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/ko/research.md
+++ b/polkadot-wiki/translated_docs/ko/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/ms-MY/research.md
+++ b/polkadot-wiki/translated_docs/ms-MY/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/pt-BR/research.md
+++ b/polkadot-wiki/translated_docs/pt-BR/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/ru/research.md
+++ b/polkadot-wiki/translated_docs/ru/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/sk-SK/research.md
+++ b/polkadot-wiki/translated_docs/sk-SK/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/th-TH/research.md
+++ b/polkadot-wiki/translated_docs/th-TH/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/tr/research.md
+++ b/polkadot-wiki/translated_docs/tr/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/ur-IN/research.md
+++ b/polkadot-wiki/translated_docs/ur-IN/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/ur-PK/research.md
+++ b/polkadot-wiki/translated_docs/ur-PK/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/zh-CN/research.md
+++ b/polkadot-wiki/translated_docs/zh-CN/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs

--- a/polkadot-wiki/translated_docs/zh-TW/research.md
+++ b/polkadot-wiki/translated_docs/zh-TW/research.md
@@ -14,7 +14,7 @@ The following papers and articles may be of special interest for those intereste
 - [Intro to Nominated Proof of Stake](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html) - A description of the NPoS scheme which selects which validators are allowed to participate in the consensus protocol of Polkadot. Author: Alfonso Cevallos
 - [GRANDPA: A Byzantine Finality Gadget](https://arxiv.org/abs/2007.01560) - GHOST-based Recursive Ancestor Deriving Prefix Agreement, Polkadot's finality gadget. Authors: Alistair Stewart and Lefteris Kokoris Kogias
 - [A Verifiably Secure and Proportional Committee Election Rule](https://arxiv.org/abs/2004.12990) - Validator Election in Nominated Proof of Stake. Authors: Alfonso Cevallos and Alistair Stewart
-- [Network Time with a Consensus on Clock](https://arxiv.org/abs/2007.01560) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
+- [Network Time with a Consensus on Clock](https://eprint.iacr.org/2019/1348.pdf) - Consensus on Clock in Universally Composable Timing. Author: Handan Kılınç Alper
 - [Delay Encryption](https://eprint.iacr.org/2020/638) - Delay Encryption can roughly be described as “identity based encryption with slow derived private key issuance”. Authors: Jeff Burdges and Luca de Feo
 
 ## Research Blogs


### PR DESCRIPTION
Fix link to research paper titled `Network Time with a Consensus on Clock`. 
The fix has been applied across all translated docs as well.