### PR TITLE
Update "Treasury Funded Wallets" section

### DIFF
--- a/docs/build/build-wallets.md
+++ b/docs/build/build-wallets.md
@@ -31,14 +31,14 @@ contact the developers of that wallet.
 
 ### Treasury Funded Wallets
 
-These are wallets which have been supported by either the Polkadot or Kusama Treasury via Treasury Proposal. Links for the wallets below go to the Polkassembly post where the Treasury Proposal was discussed.
+These are wallets which have been supported by either the Polkadot or Kusama Treasury via Treasury Proposal. Links in the Proposals section go to the Polkassembly post where the Treasury Proposal was discussed.
 
-| Wallet Name                                               | Development State | Team Name      | Description  | Custody       | Supports |
-| --------------------------------------------------------- | ----------------- | -------------- | ------------ | ------------- | -------- |
-| [Fearless](https://kusama.polkassembly.io/treasury/102)   | Live              | Soramitsu      | iOS, Android | Non-custodial | Staking  |
-| [Klever](https://kusama.polkassembly.io/treasury/91)      | Live              | Klever         | iOS, Android | Non-custodial | Staking  |
-| [Polkawallet](https://kusama.polkassembly.io/treasury/41) | Live              | Polkawallet    | iOS, Android | Non-custodial | Staking  |
-| [Stylo](https://polkadot.polkassembly.io/treasury/39)     | Live              | Thibaut Sardan | Android      | Non-custodial | Staking  |
+| Wallet Name                                   | Proposals                                         | Development State | Team Name      | Description  | Custody       | Supports |
+| --------------------------------------------- | ------------------------------------------------- | ----------------- | -------------- | ------------ | ------------- | -------- |
+| [Fearless Wallet](https://fearlesswallet.io/) | [1](https://kusama.polkassembly.io/treasury/23), [2](https://kusama.polkassembly.io/treasury/34), [3](https://kusama.polkassembly.io/treasury/74), [4](https://kusama.polkassembly.io/treasury/102)      | Live    | SORAMITSU      | iOS, Android | Non-custodial | Staking  |
+| [Klever](https://klever.io/)                  | [1](https://kusama.polkassembly.io/treasury/91)   | Live              | Klever         | iOS, Android | Non-custodial | Staking  |
+| [Polkawallet](https://polkawallet.io/)        | [1](https://kusama.polkassembly.io/treasury/32), [2](https://kusama.polkassembly.io/treasury/41) | Live              | Polkawallet    | iOS, Android | Non-custodial | Staking  |
+| [Stylo](https://stylo-app.com/)               | [1](https://polkadot.polkassembly.io/treasury/39) | Live              | Thibaut Sardan | Android      | Non-custodial | Staking  |
 
 > NOTE: these third-party wallets have been funded by the community through either the Polkadot or Kusama [Treasury](learn-treasury). **Web 3.0 Technologies Foundation does not endorse these wallets, and you should use your own due diligence in researching them.** The official Polkadot Support cannot provide support for issues with these wallets or other non-Parity developed wallets.
 


### PR DESCRIPTION
* Formatting for Fearless Wallet (Fearless -> Fearless Wallet, Soramitsu -> SORAMITSU)
* Replaced Polkassembly links in "Wallet name" with project website links. Motivation: Users can visit the project's website with download links (AppStore & Google Play)
* Added section "Proposals" with links to treasury proposals for projects. Motivation: Previous approach was able to support only one link with one proposal, while some projects (Fearless Wallet & Polkawallet) have several of them.
* Updated description to match new table structure