### PR TITLE
Add escape characters to {{ polkadot_max_nominators }} 

### DIFF
--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -141,9 +141,9 @@ There is an additional factor to consider in terms of rewards. While there is no
 of nominators a validator may have, a validator does have a limit to how many nominators to which it
 can pay rewards.
 
-In Polkadot and Kusama, this limit is currently {{ polkadot_max_nominators }}, although this can be
-modified via runtime upgrade. A validator with more than {{ polkadot_max_nominators }} nominators is
-_oversubscribed_. When payouts occur, only the top {{ polkadot_max_nominators }} nominators as
+In Polkadot and Kusama, this limit is currently {{ polkadot\_max\_nominators }}, although this can be
+modified via runtime upgrade. A validator with more than {{ polkadot\_max\_nominators }} nominators is
+_oversubscribed_. When payouts occur, only the top {{ polkadot\_max\_nominators }} nominators as
 measured by amount of stake allocated to that validator will receive rewards. All other nominators
 are essentially "wasting" their stake - they used their nomination to elect that validator to the
 active stake, but receive no rewards in exchange for doing so.


### PR DESCRIPTION
Add escape characters to the {{ polkadot_max_nominators }} macro, to avoid:

<img width="803" alt="Screenshot 2021-08-27 at 09 28 44" src="https://user-images.githubusercontent.com/9308240/131089702-3ec05115-58ba-4e7b-b0e7-43684cf54417.png">