### PR TITLE
Give relationship between 3 APIs

### DIFF
--- a/docs/build/build-node-interaction.md
+++ b/docs/build/build-node-interaction.md
@@ -5,13 +5,17 @@ sidebar_label: Node Interaction
 slug: ../build-node-interaction
 ---
 
-This page will guide you through some basic interactions with your node. Always refer to the proper
-documentation for the tool you are using. This guide should _guide you to the proper tools,_ not be
-seen as canonical reference.
+This page will guide you through some basic interactions with your node. This guide should _guide you to the proper tools,_ not be
+seen as canonical reference. Always refer to the proper
+documentation for the tool you are using:
 
 - [Substrate RPC API](https://substrate.dev/rustdocs/latest/sc_rpc_api/index.html)
-- [Polkadot-JS RPC Documentation](https://polkadot.js.org/docs/substrate/rpc)
+- [Polkadot-JS RPC](https://polkadot.js.org/docs/substrate/rpc)
 - [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar)
+
+**Polkadot-JS RPC** is JavaScript library for interacting with **Substrate RPC API** endpoint, distributed as `@polkadot/api` Node.js package.  
+**Substrate API Sidecar** is using **Polkadot-JS RPC** to provide separately runnable REST service.
+
 
 ## Polkadot RPC
 

--- a/docs/build/build-node-interaction.md
+++ b/docs/build/build-node-interaction.md
@@ -13,7 +13,7 @@ documentation for the tool you are using:
 - [Polkadot-JS RPC](https://polkadot.js.org/docs/substrate/rpc)
 - [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar)
 
-**Polkadot-JS RPC** is JavaScript library for interacting with **Substrate RPC API** endpoint, distributed as `@polkadot/api` Node.js package.  
+**Polkadot-JS RPC** is a JavaScript library for interacting with the **Substrate RPC API** endpoint, distributed as `@polkadot/api` Node.js package.  
 **Substrate API Sidecar** is using the **Polkadot-JS RPC** to provide separately runnable REST services.
 
 

--- a/docs/build/build-node-interaction.md
+++ b/docs/build/build-node-interaction.md
@@ -14,7 +14,7 @@ documentation for the tool you are using:
 - [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar)
 
 **Polkadot-JS RPC** is JavaScript library for interacting with **Substrate RPC API** endpoint, distributed as `@polkadot/api` Node.js package.  
-**Substrate API Sidecar** is using **Polkadot-JS RPC** to provide separately runnable REST service.
+**Substrate API Sidecar** is using the **Polkadot-JS RPC** to provide separately runnable REST services.
 
 
 ## Polkadot RPC


### PR DESCRIPTION
It was hard to grasp at first site how these 3 API are different and if they are dependent.

This change gives relationship between 3 APIs on https://wiki.polkadot.network/docs/build-node-interaction :

> **Polkadot-JS RPC** is JavaScript library for interacting with **Substrate RPC API** endpoint, distributed as `@polkadot/api` Node.js package.  
> **Substrate API Sidecar** is using **Polkadot-JS RPC** to provide separately runnable REST service.