### PR TITLE
Correct `alertmanager` binary extract path

### DIFF
--- a/docs/maintain/maintain-guides-how-to-monitor-your-node.md
+++ b/docs/maintain/maintain-guides-how-to-monitor-your-node.md
@@ -308,7 +308,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```bash
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ar/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ar/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/de/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/de/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/es-ES/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/es-ES/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/fi/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/fi/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/fil-PH/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/fil-PH/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/fr/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/fr/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/hi-IN/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/hi-IN/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/hr-HR/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/hr-HR/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/id-ID/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/id-ID/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/it/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/it/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ja/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ja/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ko/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ko/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ms-MY/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ms-MY/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/pt-BR/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/pt-BR/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ru/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ru/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/sk-SK/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/sk-SK/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/th-TH/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/th-TH/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/tr/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/tr/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ur-IN/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ur-IN/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/ur-PK/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/ur-PK/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/zh-CN/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/zh-CN/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup

--- a/polkadot-wiki/translated_docs/zh-TW/maintain-guides-how-to-monitor-your-node.md
+++ b/polkadot-wiki/translated_docs/zh-TW/maintain-guides-how-to-monitor-your-node.md
@@ -260,7 +260,7 @@ First, download the latest binary of AlertManager and unzip it by running the co
 ```
 wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz)
 tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64.tar.gz/alertmanager /usr/local/bin/
+mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
 ```
 
 ### Gmail Setup


### PR DESCRIPTION
We're trying to move a binary here from the compressed archive rather than the extracted folder output