### PR TITLE
Fix wrong DOT value in tx construction page

### DIFF
--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -71,7 +71,7 @@ For example, let's send 0.5 DOT from `121X5bEgTZcGQx5NZjwuTjqqKoiG8B2wEAvrUFjuw2
 `15vrtLsCQFG3qRYUcaEeeEih4JwepocNJHkpsrqojqnZPc2y`.
 
 ```bash
-yarn run:signer submit --account 121X5bEgTZcGQx5NZjwuTjqqKoiG8B2wEAvrUFjuw24ZGZf2 --ws ws://127.0.0.1:9944 balances.transferKeepAlive 15vrtLsCQFG3qRYUcaEeeEih4JwepocNJHkpsrqojqnZPc2y 500000000000
+yarn run:signer submit --account 121X5bEgTZcGQx5NZjwuTjqqKoiG8B2wEAvrUFjuw24ZGZf2 --ws ws://127.0.0.1:9944 balances.transferKeepAlive 15vrtLsCQFG3qRYUcaEeeEih4JwepocNJHkpsrqojqnZPc2y 5000000000
 ```
 
 This will return a payload to sign and an input waiting for a signature. Take this payload and use
@@ -120,7 +120,7 @@ import { methods } from "@substrate/txwrapper-polkadot";
 const unsigned = methods.balances.transferKeepAlive(
   {
     dest: "15vrtLsCQFG3qRYUcaEeeEih4JwepocNJHkpsrqojqnZPc2y",
-    value: 500000000000,
+    value: 5000000000,
   },
   {
     address: "121X5bEgTZcGQx5NZjwuTjqqKoiG8B2wEAvrUFjuw24ZGZf2",


### PR DESCRIPTION
Hello! I couldn't find any more info about this apart from the ["What is DOT?"](https://wiki.polkadot.network/docs/learn-DOT#polkadot) page, so please let me know if I'm mistaken.

This changes a command line example available on the page, that shows how to create a raw transfer transaction. More specifically, this changes the amount to be transferred. The page mentions that 0.5 DOT will be transferred, but the value passed to the `submit` command is of `500000000000` (plancks?), which according to the "What is DOT?" page, corresponds to 50 DOT.
Because of this, this PR replaces the value `500000000000` by `5000000000` in the text.