### PR TITLE
Fixed typos and grammatical errors in the polkadot consensus wiki page

### DIFF
--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -126,8 +126,8 @@ For more details on BABE, please see the
 
 BADASS BABE is an extention of BABE and acts as a constant-time block production protocol.
 This approach tries to address the shortcomings of BABE by ensuring that exactly one
-block is produced with time-constant intervals. The protocol utiliies zk-SNARKs to construct a
-ring-VRF and is a work in progres. This section will be updated as progress progresses.
+block is produced with time-constant intervals. The protocol utilizes zk-SNARKs to construct a
+ring-VRF and is a work in progress. This section will be updated as progress progresses.
 
 ## Finality Gadget: GRANDPA
 

--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -127,7 +127,7 @@ For more details on BABE, please see the
 BADASS BABE is an extention of BABE and acts as a constant-time block production protocol.
 This approach tries to address the shortcomings of BABE by ensuring that exactly one
 block is produced with time-constant intervals. The protocol utilizes zk-SNARKs to construct a
-ring-VRF and is a work in progress. This section will be updated as progress progresses.
+ring-VRF and is a work in progress. This section will be updated as progress ensues.
 
 ## Finality Gadget: GRANDPA
 


### PR DESCRIPTION
**Typos:**
utiliies => utilizes
progres => progress

**Progress progresses?**
Its self-explanatory and redundant to say `... as progress progresses`. 
`As progress ensues` would be a better-sounding alternative. 