### PR TITLE
Updated zero downtime upgrade guide

### DIFF
--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -36,7 +36,7 @@ Default keystore path - `/home/polkadot/.local/share/polkadot/chains/<chain>/key
 
 ## Steps
 
-This following steps require a second validator which will be referred to as `Validator B`, the original server that is in the active set will be referred to as `Validator A`.
+The following steps require a second validator which will be referred to as `Validator B`; the original server that is in the active set will be referred to as `Validator A`.
 
 ### Session `N`
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -8,7 +8,7 @@ slug: ../maintain-guides-how-to-upgrade
 
 Validators perform critical functions for the network, and as such, have strict uptime requirements. Validators may have to go offline for short-periods of time to upgrade client software or to upgrade the host machine. Usually, standard client upgrades will only require you to stop the service, replace the binary and restart the service.  This operation can be executed within a session and if performed correctly will not produce a slashable event.
 
-Validators may also need to perform long-lead maintenance tasks that will span more than one session.  Under these circumstances an active validator may chill his stash and be removed from the active set of validators.  Alternatively, the validator may substitue the active validator server with another allowing the former to undergo maintainance activities.
+Validators may also need to perform long-lead maintenance tasks that will span more than one session.  Under these circumstances, an active validator may chill their stash and be removed from the active validator set.  Alternatively, the validator may substitute the active validator server with another allowing the former to undergo maintenance activities.
 
 This guide will provide an option for validators to seamlessly substitute an active validator server to allow for maintenance operations. 
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -42,7 +42,7 @@ The following steps require a second validator which will be referred to as `Val
 
 1. Start a second node. Once it is synced, use the `--validator` flag. This is now "Validator B."
 2. Generate Session keys for **Validator B**.
-3. Submit a `set_key` extrinsic from your Controller account with the session key generated from Validator B.
+3. Submit a `set_key` extrinsic from your Controller account with the session key generated from **Validator B**.
 4. Take note of the Session that this extrinsic was executed in.
 5. Allow the current session to elapse and then wait two full sessions
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -55,7 +55,7 @@ Validator B is now acting as your validator. You can safely perform operations o
 When you are ready to restore Validator A
 
 1. Start Validator A, sync the database and ensure that it is operating with the `--validator` flag.
-2. Generate new Session keys for Validator A.
+2. Generate new Session keys for **Validator A**.
 3. Submit a `set_key` extrinsic from your Controller account with the session key generated from **Validator A**.
 4. Take note of the Session that this extrinsic was executed in.
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -56,7 +56,7 @@ When you are ready to restore Validator A
 
 1. Start Validator A, sync the database and ensure that it is operating with the `--validator` flag.
 2. Generate new Session keys for Validator A.
-3. Submit a `set_key` extrinsic from your Controller account with the session key generated from Validator A.
+3. Submit a `set_key` extrinsic from your Controller account with the session key generated from **Validator A**.
 4. Take note of the Session that this extrinsic was executed in.
 
 **Again, it is imperative that Validator B is kept running until the current session finishes and two further full sessions have elapsed.**

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -32,7 +32,6 @@ For this reason, it is advised that validators DO NOT CLONE or COPY the *keystor
 
 Default keystore path - `/home/polkadot/.local/share/polkadot/chains/<chain>/keystore`
    
-[More info about equivocation.](../learn/learn-staking.md/#slashing)
 
 ## Steps
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -44,7 +44,7 @@ The following steps require a second validator which will be referred to as `Val
 2. Generate Session keys for **Validator B**.
 3. Submit a `set_key` extrinsic from your Controller account with the session key generated from **Validator B**.
 4. Take note of the Session that this extrinsic was executed in.
-5. Allow the current session to elapse and then wait two full sessions
+5. Allow the current session to elapse and then wait for two full sessions. 
 
 **It is imperative that you keep Validator A running during this time.** `set_key` does not have an immediate effect and requires two full sessions to elapse before it does.  If you do switch off Validator A too early you may risk being chilled and face a fault within the Thousand Validator Programme.
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -49,7 +49,7 @@ The following steps require a second validator which will be referred to as `Val
 
 ### Session `N+2`
 
-Validator B is now acting as your validator. You can safely perform operations on Validator A. See note at bottom.
+**Validator B** is now acting as your validator - you can safely perform operations on **Validator A**.
 
 When you are ready to restore Validator A
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -63,7 +63,7 @@ When you are ready to restore Validator A
 
 Once this time has elapsed Validator A will take over. You can safely stop Validator B.
 
-**NOTE:** To verify that the Session has changed, make sure that a block in the new Session is finalized. You should see log messages like this to indicate the change:
+**NOTE:** To verify that the Session has changed, make sure that a block in the new Session is finalised. You should see log messages like the ones below to confirm the change:
 
 ```
 2019-10-28 21:44:13 Applying authority set change scheduled at block #450092

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -26,7 +26,7 @@ Session keys are stored in the client and used to sign validator operations. The
 
 ### Keystore
 
-Each validator server contains essential private keys in a folder called the keystore. These keys are used by a validator to sign transactions at the network level.  If two or more validators sign certain transactions using the same keys it can lead to an equivocation slash.
+Each validator server contains essential private keys in a folder called the *keystore*. These keys are used by a validator to sign transactions at the network level.  If two or more validators sign certain transactions using the same keys, it can lead to an [equivocation slash](../learn/learn-staking.md/#slashing).
 
 For this reason, it is advised that validators DO NOT CLONE or COPY the *keystore* folder and instead generate session keys for each new validator instance.
 

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -53,7 +53,7 @@ The following steps require a second validator which will be referred to as `Val
 
 When you are ready to restore **Validator A**:
 
-1. Start Validator A, sync the database and ensure that it is operating with the `--validator` flag.
+1. Start **Validator A**, sync the database and ensure that it is operating with the `--validator` flag.
 2. Generate new Session keys for **Validator A**.
 3. Submit a `set_key` extrinsic from your Controller account with the session key generated from **Validator A**.
 4. Take note of the Session that this extrinsic was executed in.

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -28,7 +28,7 @@ Session keys are stored in the client and used to sign validator operations. The
 
 Each validator server contains essential private keys in a folder called the keystore. These keys are used by a validator to sign transactions at the network level.  If two or more validators sign certain transactions using the same keys it can lead to an equivocation slash.
 
-For this reason it is advised that validators DO NOT CLONE or COPY the keystore folder and instead generate session keys for each new validator instance.
+For this reason, it is advised that validators DO NOT CLONE or COPY the *keystore* folder and instead generate session keys for each new validator instance.
 
 Default keystore path - `/home/polkadot/.local/share/polkadot/chains/<chain>/keystore`
    

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -6,15 +6,13 @@ descriptions: Steps on how to upgrade your validator node.
 slug: ../maintain-guides-how-to-upgrade
 ---
 
-Validators perform critical functions for the network, and as such, have strict uptime requirements.
-Validators may have to go offline for periods of time to upgrade the client software or the host
-machine. Usually, standard upgrades will only require you to stop your server, replace the binary
-and spin it up again. Validators may also need to perform maintenance, such as resizing a disk,
-where you cannot continue running the node on the current server. This guide will walk you through
-upgrading your machine and keeping your validator online.
+Validators perform critical functions for the network, and as such, have strict uptime requirements. Validators may have to go offline for short-periods of time to upgrade client software or to upgrade the host machine. Usually, standard client upgrades will only require you to stop the service, replace the binary and restart the service.  This operation can be executed within a session and if performed correctly will not produce a slashable event.
 
-The process can take several hours, so make sure you understand the instructions first and plan
-accordingly.
+Validators may also need to perform long-lead maintenance tasks that will span more than one session.  Under these circumstances an active validator may chill his stash and be removed from the active set of validators.  Alternatively, the validator may substitue the active validator server with another allowing the former to undergo maintainance activities.
+
+This guide will provide an option for validators to seamlessly substitute an active validator server to allow for maintenance operations. 
+
+The process can take several hours, so make sure you understand the instructions first and plan accordingly.
 
 > Note: keep an eye out on new releases from the community and upgrade/downgrade accordingly.
 
@@ -22,56 +20,54 @@ accordingly.
 
 ### Session Keys
 
-Session keys are stored in the client and used to sign validator operations. They are what link your
-validator node to your Controller account. You cannot change them mid-Session.
+Session keys are stored in the client and used to sign validator operations. They are what link your validator node to your Controller account. If you change them within a session you will have to wait for the current session to finish and a further two sessions to elapse before they are applied.
 
 [More info about keys in Polkadot.](../learn/learn-keys.md)
 
-### Database
+### Keystore
 
-Validators keep a database with all of their votes. If two machines have the same Session keys but
-different databases, they risk equivocating. For this reason, we will generate new Session keys each
-time we change machines.
+Each validator server contains essential private keys in a folder called the keystore. These keys are used by a validator to sign transactions at the network level.  If two or more validators sign certain transactions using the same keys it can lead to an equivocation slash.
 
+For this reason it is advised that validators DO NOT CLONE or COPY the keystore folder and instead generate session keys for each new validator instance.
+
+Default keystore path - `/home/polkadot/.local/share/polkadot/chains/<chain>/keystore`
+   
 [More info about equivocation.](../learn/learn-staking.md/#slashing)
 
 ## Steps
 
-You will need to start a second validator to operate while you upgrade your primary. Throughout
-these steps, we will refer to the validator that you are upgrading as "Validator A" and the second
-one as "Validator B."
+This following steps require a second validator which will be referred to as `Validator B`, the original server that is in the active set will be referred to as `Validator A`.
 
 ### Session `N`
 
-1. Start a second node. Once it is synced, use the `--validator` flag. This is "Validator B."
-2. Generate Session keys in Validator B.
-3. Submit a `set_key` extrinsic from your Controller account with your new Session keys.
+1. Start a second node. Once it is synced, use the `--validator` flag. This is now "Validator B."
+2. Generate Session keys for Validator B.
+3. Submit a `set_key` extrinsic from your Controller account with the session key generated from Validator B.
+4. Take note of the Session that this extrinsic was executed in.
+5. Allow the current session to elapse and then wait two full sessions
+
+**It is imperative that you keep Validator A running during this time.** `set_key` does not have an immediate effect and requires two full sessions to elapse before it does.  If you do switch off Validator A too early you may risk being chilled and face a fault within the Thousand Validator Programme.
+
+### Session `N+2`
+
+Validator B is now acting as your validator. You can safely perform operations on Validator A. See note at bottom.
+
+When you are ready to restore Validator A
+
+1. Start Validator A, sync the database and ensure that it is operating with the `--validator` flag.
+2. Generate new Session keys for Validator A.
+3. Submit a `set_key` extrinsic from your Controller account with the session key generated from Validator A.
 4. Take note of the Session that this extrinsic was executed in.
 
-**It is imperative that your Validator A keep running in this Session.** `set_key` only takes effect
-in the next Session.
+**Again, it is imperative that Validator B is kept running until the current session finishes and two further full sessions have elapsed.**
 
-### Session `N+1`
+Once this time has elapsed Validator A will take over. You can safely stop Validator B.
 
-Validator B is now acting as your validator. You can safely take Validator A offline. See note at
-bottom.
-
-1. Stop Validator A.
-1. Perform your system or client upgrade.
-1. Start Validator A and sync the database.
-1. Generate new Session keys in Validator A.
-1. Submit a `set_key` extrinsic from your Controller account with your new Session keys for
-   Validator A.
-1. Take note of the Session that this extrinsic was executed in.
-
-**Again, it is imperative that Validator B keep running until the next Session.**
-
-Once the Session changes, Validator A will take over. You can safely stop Validator B.
-
-**NOTE:** To verify that the Session has changed, make sure that a block in the new Session is
-finalized. You should see log messages like this to indicate the change:
+**NOTE:** To verify that the Session has changed, make sure that a block in the new Session is finalized. You should see log messages like this to indicate the change:
 
 ```
 2019-10-28 21:44:13 Applying authority set change scheduled at block #450092
 2019-10-28 21:44:13 Applying GRANDPA set change to new set with 20 authorities
 ```
+
+

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -51,7 +51,7 @@ The following steps require a second validator which will be referred to as `Val
 
 **Validator B** is now acting as your validator - you can safely perform operations on **Validator A**.
 
-When you are ready to restore Validator A
+When you are ready to restore **Validator A**:
 
 1. Start Validator A, sync the database and ensure that it is operating with the `--validator` flag.
 2. Generate new Session keys for **Validator A**.

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -41,7 +41,7 @@ The following steps require a second validator which will be referred to as `Val
 ### Session `N`
 
 1. Start a second node. Once it is synced, use the `--validator` flag. This is now "Validator B."
-2. Generate Session keys for Validator B.
+2. Generate Session keys for **Validator B**.
 3. Submit a `set_key` extrinsic from your Controller account with the session key generated from Validator B.
 4. Take note of the Session that this extrinsic was executed in.
 5. Allow the current session to elapse and then wait two full sessions

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -70,4 +70,3 @@ Once this time has elapsed Validator A will take over. You can safely stop Valid
 2019-10-28 21:44:13 Applying GRANDPA set change to new set with 20 authorities
 ```
 
-

--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -61,7 +61,7 @@ When you are ready to restore Validator A
 
 **Again, it is imperative that Validator B is kept running until the current session finishes and two further full sessions have elapsed.**
 
-Once this time has elapsed Validator A will take over. You can safely stop Validator B.
+Once this time has elapsed, **Validator A** will take over. You can safely stop Validator B.
 
 **NOTE:** To verify that the Session has changed, make sure that a block in the new Session is finalised. You should see log messages like the ones below to confirm the change:
 


### PR DESCRIPTION
To my knowledge two full sessions are required before new session keys are applied and not simply the next session.  If someone follows these instructions they could fall victim for a chill as they would have turned their validator offline too early.

Additionally and again to my knowledge, the database has nothing to do with equivocation.  Validators frequently use a shared DB for polkashots.io without issue, equivocation relates to the copying/cloning of the keys used to sign BABE/GRANDPA related network transactions.

If I am mistaken please reach out to me on element.  I'll gladly appreciate correction so that my thoughts are properly aligned.