### PR TITLE
Fix XCVM. Cross-Chain to Cross-Consensus

### DIFF
--- a/docs/learn/learn-cross-consensus.md
+++ b/docs/learn/learn-cross-consensus.md
@@ -46,7 +46,7 @@ of deployment.
   includes a native asset that can be used as a reserve for that asset. Then, the derivative form of the
   asset on each of those chains would be fully backed, allowing the derivative asset to be exchanged for the underlying asset on the reserve chain backing it.
 
-### XCVM (Cross-Chain Virtual Machine)
+### XCVM (Cross-Consensus Virtual Machine)
 
 An ultra-high level non-Turing-complete computer whose instructions are designed in a way to be roughly at
 the same level as transactions.


### PR DESCRIPTION
Hello!
The XCVM description was wrong and has been corrected.

[XCM: The Cross-Consensus Message Format | by Gavin Wood | Polkadot Network | Sep, 2021 | Medium](https://medium.com/polkadot-network/xcm-the-cross-consensus-message-format-3b77b1373392)
> At the core of the XCM format lies the XCVM. Contrary to how it might look to some, this is not a (valid) roman numeral (though if it were, it’d probably mean 905). In fact this stands for Cross-Consensus Virtual Machine.

✗ Cross-Chain Virtual Machine
○ Cross-Consensus Virtual Machine