### PR TITLE
Updated N+2 to N+3

### DIFF
--- a/docs/maintain/maintain-guides-how-to-upgrade.md
+++ b/docs/maintain/maintain-guides-how-to-upgrade.md
@@ -47,7 +47,7 @@ The following steps require a second validator which will be referred to as `Val
 
 **It is imperative that you keep Validator A running during this time.** `set_key` does not have an immediate effect and requires two full sessions to elapse before it does.  If you do switch off Validator A too early you may risk being chilled and face a fault within the Thousand Validator Programme.
 
-### Session `N+2`
+### Session `N+3`
 
 **Validator B** is now acting as your validator - you can safely perform operations on **Validator A**.
 


### PR DESCRIPTION
If the session keys are applied to a new server in session N, that session must elapse and 2 FULL sessions must complete before the validator A can be switched off.  This would be possible in session N+3 and not N+2.

e.g.

Keys applied in session 2, wait out session 2, session 3 (1st full session), session 4 (2nd full session), session 5 (keys are applied).