### PR TITLE
fix `kusama:build` and injection issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^17.0.2",
     "remarkable-katex": "^1.1.8",
     "shx": "^0.3.3",
-    "unist-util-visit": "4.1.0",
+    "unist-util-visit": "2.0.1",
     "yargs": "^17.2.1"
   },
   "dependencies": {

--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -1,89 +1,90 @@
-const { baseUrlPattern } = require("../scripts/utils");
-const i18n = require("./i18n");
+const { baseUrlPattern } = require('../scripts/utils');
+const { injectPlugin } = require('../scripts/injectPlugin');
+const i18n = require('./i18n');
 
-const isBuilding = process.env.BUILDING === "true";
-const isPublishing = process.env.PUBLISHING === "true";
+const isBuilding = process.env.BUILDING === 'true';
+const isPublishing = process.env.PUBLISHING === 'true';
 
 module.exports = {
-  title: "Polkadot Wiki",
-  tagline:
-    "The hub for those interested in learning, building, or running a node on Polkadot.",
-  titleDelimiter: "·",
-  url: "https://wiki.polkadot.network",
-  baseUrl: "/",
-  projectName: "polkadot-wiki",
-  organizationName: "w3f",
+  title: 'Polkadot Wiki',
+  tagline: 'The hub for those interested in learning, building, or running a node on Polkadot.',
+  titleDelimiter: '·',
+  url: 'https://wiki.polkadot.network',
+  baseUrl: '/',
+  projectName: 'polkadot-wiki',
+  organizationName: 'w3f',
   scripts: [
-    "https://buttons.github.io/buttons.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.js",
-    "https://unpkg.com/aos@next/dist/aos.js",
+    'https://buttons.github.io/buttons.js',
+    'https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.js',
+    'https://unpkg.com/aos@next/dist/aos.js',
     {
-      src: "https://unpkg.com/vanilla-back-to-top@7.2.1/dist/vanilla-back-to-top.min.js",
-      onload: "addBackToTop()",
+      src: 'https://unpkg.com/vanilla-back-to-top@7.2.1/dist/vanilla-back-to-top.min.js',
+      onload: 'addBackToTop()',
       defer: true,
     },
     {
-      src: "https://apisa.web3.foundation/latest.js",
+      src: 'https://apisa.web3.foundation/latest.js',
       async: true,
       defer: true,
     },
-    "../js/custom.js",
-    "../js/packaged/addressChanger.js",
-    "../js/clipboard.min.js",
-    "../js/copycode.js",
+    '../js/custom.js',
+    '../js/packaged/addressChanger.js',
+    '../js/clipboard.min.js',
+    '../js/copycode.js',
   ],
   stylesheets: [
-    "https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css",
-    "https://fonts.googleapis.com/css?family=Work+Sans:400,700&display=swap",
-    "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css",
-    "https://unpkg.com/aos@next/dist/aos.css",
-    "https://fonts.googleapis.com/icon?family=Material+Icons",
+    'https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css',
+    'https://fonts.googleapis.com/css?family=Work+Sans:400,700&display=swap',
+    'https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css',
+    'https://unpkg.com/aos@next/dist/aos.css',
+    'https://fonts.googleapis.com/icon?family=Material+Icons',
   ],
   i18n,
-  favicon: "img/favicon.ico",
+  favicon: 'img/favicon.ico',
   trailingSlash: false,
-  onBrokenLinks: "log",
-  onBrokenMarkdownLinks: "log",
-  onDuplicateRoutes: "log",
+  onBrokenLinks: 'log',
+  onBrokenMarkdownLinks: 'log',
+  onDuplicateRoutes: 'log',
   presets: [
     [
-      "@docusaurus/preset-classic",
+      '@docusaurus/preset-classic',
       {
         docs: {
           editUrl: ({ docPath }) =>
             `https://github.com/w3f/polkadot-wiki/edit/master/docs/${docPath}`,
-          path: "../docs",
+          path: '../docs',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
-          sidebarPath: require.resolve("./sidebars.js"),
-          routeBasePath: "docs",
+          sidebarPath: require.resolve('./sidebars.js'),
+          routeBasePath: 'docs',
+          remarkPlugins: [injectPlugin({ isPolkadot: true })],
         },
         theme: {
           customCss: [
-            require.resolve("./static/css/custom.css"),
-            require.resolve("./static/css/copycode.css"),
-            require.resolve("./static/css/socicon.css"),
+            require.resolve('./static/css/custom.css'),
+            require.resolve('./static/css/copycode.css'),
+            require.resolve('./static/css/socicon.css'),
           ],
         },
       },
     ],
   ],
   plugins: [
-    "remark-docusaurus-tabs",
-    "@docusaurus/theme-live-codeblock",
+    'remark-docusaurus-tabs',
+    '@docusaurus/theme-live-codeblock',
     [
-      "@docusaurus/plugin-client-redirects",
+      '@docusaurus/plugin-client-redirects',
       {
         redirects: [
           {
-            to: "/",
+            to: '/',
 
-            from: ["/en/latest", "/en/"],
+            from: ['/en/latest', '/en/'],
           },
         ],
         createRedirects: function (existingPath) {
-          if (existingPath.startsWith("/docs/")) {
-            return [existingPath.replace("/docs/", "/docs/en/")];
+          if (existingPath.startsWith('/docs/')) {
+            return [existingPath.replace('/docs/', '/docs/en/')];
           }
         },
       },
@@ -94,61 +95,61 @@ module.exports = {
       disableSwitch: true,
     },
     prism: {
-      theme: require("prism-react-renderer/themes/github"),
+      theme: require('prism-react-renderer/themes/github'),
     },
     liveCodeBlock: {
       /**
        * The position of the live playground, above or under the editor
        * Possible values: "top" | "bottom"
        */
-      playgroundPosition: "bottom",
+      playgroundPosition: 'bottom',
     },
     navbar: {
       logo: {
-        src: "img/logo_polkadot_wiki.svg",
+        src: 'img/logo_polkadot_wiki.svg',
       },
       items: [
         {
-          to: "docs/getting-started",
-          label: "Get Started",
-          position: "right",
+          to: 'docs/getting-started',
+          label: 'Get Started',
+          position: 'right',
         },
         {
-          to: "docs/learn-launch",
-          label: "Learn",
-          position: "right",
+          to: 'docs/learn-launch',
+          label: 'Learn',
+          position: 'right',
         },
         {
-          to: "docs/build-index",
-          label: "Build",
-          position: "right",
+          to: 'docs/build-index',
+          label: 'Build',
+          position: 'right',
         },
         {
-          to: "docs/maintain-index",
-          label: "Maintain ",
-          position: "right",
+          to: 'docs/maintain-index',
+          label: 'Maintain ',
+          position: 'right',
         },
         {
-          href: "https://guide.kusama.network",
-          label: "Kusama",
-          position: "right",
+          href: 'https://guide.kusama.network',
+          label: 'Kusama',
+          position: 'right',
         },
         {
-          type: "search",
-          position: "right",
+          type: 'search',
+          position: 'right',
         },
         {
-          to: "docs/contributing",
-          label: "Contribute",
-          position: "right",
+          to: 'docs/contributing',
+          label: 'Contribute',
+          position: 'right',
         },
         {
-          type: "localeDropdown",
-          position: "right",
+          type: 'localeDropdown',
+          position: 'right',
           dropdownItemsAfter: [
             {
-              to: "https://crowdin.com/project/polkadot-wiki",
-              label: "Help us translate",
+              to: 'https://crowdin.com/project/polkadot-wiki',
+              label: 'Help us translate',
             },
           ],
         },
@@ -157,14 +158,14 @@ module.exports = {
     footer: {
       copyright: `© ${new Date().getFullYear()} Web3 Foundation`,
       logo: {
-        src: "img/logo-polkadot-light.svg",
+        src: 'img/logo-polkadot-light.svg',
       },
     },
     algolia: {
-      apiKey: "8bfa06b56bb8f33e5698c7f40b00b38f",
-      indexName: "polkadot",
+      apiKey: '8bfa06b56bb8f33e5698c7f40b00b38f',
+      indexName: 'polkadot',
       algoliaOptions: {
-        facetFilters: ["language:LANGUAGE"],
+        facetFilters: ['language:LANGUAGE'],
       },
     },
     docsSideNavCollapsible: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10026,11 +10026,6 @@ unist-util-is@^4.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
   integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
 
-unist-util-is@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
-  integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
-
 unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
@@ -10065,13 +10060,14 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit-parents@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz#44bbc5d25f2411e7dfc5cecff12de43296aa8521"
-  integrity sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==
+unist-util-visit@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.1.tgz#b4e1c1cb414250c6b3cb386b8e461d79312108ae"
+  integrity sha512-bEDa5S/O8WRDeI1mLaMoKuFFi89AjF+UAoMNxO+bbVdo06q+53Vhq4iiv1PenL6Rx1ZxIpXIzqZoc5HD2I1oMA==
   dependencies:
     "@types/unist" "^2.0.0"
-    unist-util-is "^5.0.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit-parents "^3.0.0"
 
 unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.1, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
@@ -10081,15 +10077,6 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.1, unist-
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
-
-unist-util-visit@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.0.tgz#f41e407a9e94da31594e6b1c9811c51ab0b3d8f5"
-  integrity sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^5.0.0"
-    unist-util-visit-parents "^5.0.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This should fix `kusama:build`, and the injection issues in both kusama-guide and polkadot-wiki

- adds injection back into `polkadot-wiki/docusaurus.config.js`. Relevant line is on line 60, ignore all the linting.
- downgrades `unist-util-visit` to older version. We can upgrade if/when we decide to migrate all the JS files from CommonJS to ESM. 