### PR TITLE
Add the CryptoLab website introduction

### DIFF
--- a/docs/learn/learn-validator.md
+++ b/docs/learn/learn-validator.md
@@ -81,3 +81,5 @@ Validators perform two functions:
   effort.
 - [Subscan Validators Page](https://kusama.subscan.io/validator) - Displays information on the
   current validators - not as tailored for validators as the other sites.
+- [CryptoLab](https://www.cryptolab.network) - The CryptoLab is built to create stable staking
+  yields, including portfolio performance and management tools.


### PR DESCRIPTION
Hi, 
We just released our official CryptoLab website a few days ago. 
Is it possible to add our website introduction to the Validator Stats section?
Thanks.

Yaohsin, 
CryptoLab Team