### PR TITLE
Remove hanging backtick

### DIFF
--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -96,7 +96,7 @@ values={[
 - Then, run:
 
   ```bash
-  brew install openssl cmake llvm`
+  brew install openssl cmake llvm
   ```
 
 - Install Rust in your terminal by running:


### PR DESCRIPTION
Hanging back tick '`' causes error when running `brew install openssl cmake llvm`