### PR TITLE
redirects for Kusama pages

### DIFF
--- a/kusama-guide/docusaurus.config.js
+++ b/kusama-guide/docusaurus.config.js
@@ -65,6 +65,20 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    'remark-docusaurus-tabs',
+    '@docusaurus/theme-live-codeblock',
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects: function (existingPath) {
+          if (existingPath.startsWith('/docs/')) {
+            return [existingPath.replace('/docs/', '/docs/en/')];
+          }
+        },
+      },
+    ],
+  ],
   themeConfig: {
     colorMode: {
       defaultMode: "light",


### PR DESCRIPTION
Issue identified for this URL - https://guide.kusama.network/docs/en/kusama-claims

The Wiki repo was restructured after migrating to docusaurus v2, breaking links on external websites. Redirects were already implemented for Polkadot docs