### PR TITLE
Update learn-architecture.md

### DIFF
--- a/docs/learn/learn-architecture.md
+++ b/docs/learn/learn-architecture.md
@@ -37,7 +37,7 @@ of the parachain. Some parachains may be specific to a particular application, o
 specific features like smart contracts, privacy, or scalability &mdash; still, others might be
 experimental architectures that are not necessarily blockchain in nature.
 
-Polkadot provides many ways to secure a slot for a parachain slot for a particular length of time.
+Polkadot provides many ways to secure a slot for a parachain for a particular length of time.
 Parathreads are part of a pool that shares slots and must-win auctions for individual blocks.
 Parathreads and parachains have the same API; their difference is economic. Parachains will have to
 reserve DOT for the duration of their slot lease; parathreads will pay on a per-block basis.


### PR DESCRIPTION
The sentence
**[...] many ways to secure a slot for a parachain slot [...]**
contains the word "slot" twice, which I think is suboptimal.

Could be improved by writing either
*many ways to secure a slot for a parachain*
or
*many ways to secure a parachain slot*