### PR TITLE
Update learn-architecture.md

### DIFF
--- a/docs/learn/learn-architecture.md
+++ b/docs/learn/learn-architecture.md
@@ -50,7 +50,7 @@ Polkadot has a shared state between the Relay Chain and all of the connected par
 Relay Chain must revert for any reason, then all of the parachains would also revert. This is to
 ensure that the validity of the entire system can persist and no individual part is corruptible.
 
-The shared state makes it so that the trust assumptions when using Polkadot parachains are only
+The shared state ensures that the trust assumptions when using Polkadot parachains are only
 those of the Relay Chain validator set and no other. Since the validator set on the Relay Chain is
 expected to be secure with a large amount of stake put up to back it, parachains should benefit from
 this security.


### PR DESCRIPTION
The sentence
**The shared state makes it so that the trust assumptions [...]**
Could be formulated more precisely by changing it to
*The shared state ensures that the trust assumptions [...]*