### PR TITLE
Adding info on unbonding some of the tokens

### DIFF
--- a/docs/maintain/maintain-guides-how-to-unbond.md
+++ b/docs/maintain/maintain-guides-how-to-unbond.md
@@ -12,6 +12,10 @@ period_, which serves as a cooldown. You will not be able to transfer your token
 has elapsed, and you will not receive any staking rewards during this period (as you are not
 nominating any validators).
 
+Below are the steps you need to follow to unbond **all** of your bonded tokens.
+
+**Skip Step 1 and directly go to Step 2** if you like to **unbond a fraction of your bonded tokens**
+
 ### Step 1: Stop Nominating
 
 On the [Polkadot-JS Apps][] navigate to the "Staking" tab.


### PR DESCRIPTION
The article suggests that the stop button needs to be clicked before unbonding tokens. This is needed only when trying to unbond all of the tokens. This step can be skipped if trying to unbond only part of the bonded tokens