### PR TITLE
Mark ECC memory a requirement for validator setup

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -78,7 +78,7 @@ For the full details of the standard hardware please see
 - **Storage** - A NVMe solid state drive. Should be reasonably sized to deal with blockchain growth.
   Starting around 80GB - 160GB will be okay for the first six months of Polkadot, but will need to
   be re-evaluated every six months.
-- **Memory** - 64GB.
+- **Memory** - 64GB ECC.
 
 The specs posted above are by no means the minimum specs that you could use when running a
 validator, however you should be aware that if you are using less you may need to toggle some extra


### PR DESCRIPTION
Single-bit flip can happen and [does happen](https://www.youtube.com/watch?v=aT7mnSstKGs) (a lot) in reality. Those who think otherwise either don't check their hardware error logs, or are not using ECC at all. For a secure validator setup, ECC is a must.