### PR TITLE
Revert "Bump chalk from 4.1.2 to 5.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@polkadot/api": "^6.9.2",
     "@polkadot/keyring": "^7.3.1",
     "axios": "^0.24.0",
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "cross-env": "^7.0.3",
     "fs-extra": "^10.0.0",
     "husky": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,11 +3531,6 @@ chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
-  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
-
 character-entities-legacy@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"


### PR DESCRIPTION
Reverts w3f/polkadot-wiki#2839