### PR TITLE
Update unstable Polka-dot JS url (https://polkadot.js.org/apps/)

### DIFF
--- a/docs/learn/learn-account-generation.md
+++ b/docs/learn/learn-account-generation.md
@@ -173,8 +173,9 @@ feasible in your situation.
 
 ### Go to Polkadot-JS Apps
 
-Navigate to [Polkadot-JS Apps](https://polkadot.js.org/apps) or https://dotapps.io/ and click on "Accounts" underneath the
-Accounts tab. It is located in the navigation bar at the top of your screen.
+Navigate to [Polkadot-JS Apps](https://polkadot.js.org/apps) (or [dotapps.io](https://dotapps.io/)) 
+and click on "Accounts" underneath the Accounts tab. It is located in the navigation bar at the top 
+of your screen.
 
 ![pjs-01](../assets/accounts/polkadot_js_01.png)
 

--- a/docs/learn/learn-account-generation.md
+++ b/docs/learn/learn-account-generation.md
@@ -173,7 +173,7 @@ feasible in your situation.
 
 ### Go to Polkadot-JS Apps
 
-Navigate to [Polkadot-JS Apps](https://polkadot.js.org/apps) and click on "Accounts" underneath the
+Navigate to [Polkadot-JS Apps](https://dotapps.io/) and click on "Accounts" underneath the
 Accounts tab. It is located in the navigation bar at the top of your screen.
 
 ![pjs-01](../assets/accounts/polkadot_js_01.png)

--- a/docs/learn/learn-account-generation.md
+++ b/docs/learn/learn-account-generation.md
@@ -173,7 +173,7 @@ feasible in your situation.
 
 ### Go to Polkadot-JS Apps
 
-Navigate to [Polkadot-JS Apps](https://dotapps.io/) and click on "Accounts" underneath the
+Navigate to [Polkadot-JS Apps](https://polkadot.js.org/apps) or https://dotapps.io/ and click on "Accounts" underneath the
 Accounts tab. It is located in the navigation bar at the top of your screen.
 
 ![pjs-01](../assets/accounts/polkadot_js_01.png)


### PR DESCRIPTION
Previous : https://polkadot.js.org/apps/
New : https://dotapps.io/ 

Update unstable URL( https://polkadot.js.org/apps/ ) to the stable URL ( https://dotapps.io/ ) as mentioned in the core repository https://github.com/polkadot-js/dotapps.io