### PR TITLE
Add Page for Polkadot-JS

### DIFF
--- a/docs/learn/learn-polkadotjs.md
+++ b/docs/learn/learn-polkadotjs.md
@@ -27,7 +27,7 @@ and sending or receiving transactions.
 
 ### [Polkadot-JS Extension](https://polkadot.js.org/extension/)
 
-The extension is a simple proof-of-concept for managing accounts in a browser extension and allowing 
+The extension is a simple tool for managing accounts in a browser extension and allowing 
 the signing of extrinsics using these accounts. The Polkadot-JS extension is not made for users to 
 interact with on-chain functions as one would find through a wallet app. The extension acts as 
 a robust key-store and thus acts as an account manager for Substrate-based accounts.
@@ -46,8 +46,9 @@ A JavaScript API allowing for programs to interface with the functionality of Po
 
 ## Polkadot-JS Apps
 
-Polkadot-JS Apps is the native Polkadot/Kusama/Substrate UI for interacting with a node, allowing access to 
-all features available on Substrate chains.
+Polkadot-JS Apps is the native Polkadot/Kusama/Substrate UI for interacting with a node, allowing access 
+to all features available on Substrate chains. Polkadot-JS Apps also allows developers to to interface with 
+a local node.
 
 > Note that the UI may not precisely align with the functionality of individual parachains.
 
@@ -59,6 +60,7 @@ Among other things, Polkadot-JS Apps allows a user to:
 - [Auctions](learn-auction.md)
 - Query chain metadata
 - Query on-chain data using RPC calls
+- Call extrinsics using your account
 
 ### Developers
 

--- a/docs/learn/learn-polkadotjs.md
+++ b/docs/learn/learn-polkadotjs.md
@@ -97,6 +97,7 @@ For more user-friendly wallets, check out the supported and treasury-funded wall
 
 - [Introduction to Polkadot-JS](https://www.youtube.com/watch?v=4EQqwGFV1D8)
 - [Create an account using Polkadot-JS](https://www.youtube.com/watch?v=sy7lvAqyzkY)
+[Network Explorer on Polkadot-JS UI](https://www.youtube.com/watch?v=g4b4IWR6OrE)
 
 ### Documentation
 

--- a/docs/learn/learn-polkadotjs.md
+++ b/docs/learn/learn-polkadotjs.md
@@ -1,0 +1,102 @@
+---
+id: learn-polkadotjs
+title: PolkadotJS
+sidebar_label: PolkadotJS
+description: Learn about PolkadotJS
+slug: ../learn-polkadotjs
+---
+
+<!-- This page is a WIP -->
+<!-- The first version of this page takes motivation from Emre's ELI5 on Polkadot-JS -->
+
+Polkadot-JS is a collection of tools that interfaces with the Polkadot blockchain in a granular 
+way. 
+
+## Primary Implementation
+
+Polkadot-JS as a term has multiple moving parts that are worth mentioning.
+
+### [Polkadot-JS UI](polkadot.js.org)
+
+The Polkadot-JS UI is a hosted application that loads in your browser. The UI has a standard DNS hosted
+version, which always has the latest features, and an IPFS version that is less frequently updated but 
+is more decentralized. This is also often referred to as Polkadot-JS Apps, or the Apps UI.
+
+Polkadot-JS Apps has many capabilities that go beyond basic wallet functions such as account creation 
+and sending or receiving transactions. 
+
+### [Polkadot-JS Extension](https://polkadot.js.org/extension/)
+
+The extension is a simple proof-of-concept for managing accounts in a browser extension and allowing 
+the signing of extrinsics using these accounts. The Polkadot-JS extension is not made for users to 
+interact with on-chain functions as one would find through a wallet app. The extension acts as 
+a robust key-store and thus acts as an account manager for Substrate-based accounts.
+
+However, it also provides a simple interface for interacting with extension-compliant dApps. 
+
+#### [Polkadot-JS Phishing List](polkadot.js.org/phishing/)
+
+The phishing list website is a community-driven curation of less-than-honest operators. The Polkadot-JS 
+extension uses this list to warn a user about suspicious URLs and addresses that are part of the list, and 
+automatically blocks the account address. 
+
+### [Polkadot-JS API](github.com/polkadot-js/api)
+
+A JavaScript API allowing for programs to interface with the functionality of Polkadot.
+
+## Polkadot-JS Apps
+
+Polkadot-JS Apps is the native Polkadot/Kusama/Substrate UI for interacting with a node, allowing access to 
+all features available on Substrate chains.
+
+> Note that the UI may not precisely align with the functionality of individual parachains.
+
+Among other things, Polkadot-JS Apps allows a user to:
+
+- [Staking](learn-staking.md) 
+- [Governance](learn-governance.md)
+- [Crowdloans](learn-crowdloans.md)
+- [Auctions](learn-auction.md)
+- Query chain metadata
+- Query on-chain data using RPC calls
+
+### Developers
+
+A developer can utilize Polkadot-JS Apps to test your code's functionality. Interacting with the Polkadot-JS 
+comes down to either querying on-chain data or issuing an extrinsic. 
+
+#### Querying on-chain data
+
+To populate the Apps UI, the web app queries the Polkadot-JS API. The API then queries a 
+Polkadot node and uses JavaScript to return information that the UI will display on the screen. 
+You can choose which node to connect to by changing it in the upper-left-hand corner of the screen.
+
+#### Issuing an extrinsic 
+
+Extrinsics are pieces of information that come from outside the chain and are included in a block. 
+Extrinsics can be one of three types: inherents, signed, and unsigned transactions. 
+
+Most extrinsics displayed on Polkadot-JS Apps are signed transactions. 
+Inherits are non-signed and non-gossiped pieces of information included in blocks by the block author, 
+such as timestamps, which are “true” because a sufficient number of validators have agreed about validity. 
+
+Unsigned transactions are information that does not require a signature but will require some sort of 
+spam prevention, whereas signed transactions are issued by the originator account of a transaction which 
+contains a signature of that account, which will be subject to a fee to include it on the chain. 
+
+### Considerations
+
+For more user-friendly wallets, check out the supported and treasury-funded wallets on the 
+[Wallets Page](../build/build-wallets.md)
+
+## Resources
+
+### Beginner's Guide to Polkadot-JS
+
+- [Introduction to Polkadot-JS](https://www.youtube.com/watch?v=4EQqwGFV1D8)
+- [Create an account using Polkadot-JS](https://www.youtube.com/watch?v=sy7lvAqyzkY)
+
+### Documentation
+
+- [Official polkadot{.js} docs](https://polkadot.js.org/docs/)
+- [Substrate docs on Polkadot-JS](https://docs.substrate.io/v3/integration/polkadot-js/)

--- a/kusama-guide/sidebars.js
+++ b/kusama-guide/sidebars.js
@@ -7,6 +7,7 @@ module.exports = {
         "general/kusama/kusama-getting-started",
         "general/kusama/kusama-coc",
         "general/kusama/kusama-claims",
+        "learn/learn-polkadotjs",
         "learn/learn-balance-transfers",
         "learn/learn-auction",
         "learn/learn-parachains",

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -35,6 +35,7 @@ module.exports = {
             "learn/learn-accounts",
             "learn/learn-account-generation",
             "learn/learn-account-restore",
+            "learn/learn-polkadotjs",
             "learn/learn-assets",
             "learn/learn-nft",
             "learn/learn-DOT",


### PR DESCRIPTION
Adding this so we have something on the Wiki.

- Adds basic information for Polkadot-JS on a dedicated page. 
- Will be revisited/updated as part reviewal for wiki revamp.

Most of the features that can be done on the Apps UI are described on other pages. If we want to include a basic breakdown of the UI we can do so, or at least the key parts of it. Same with the extension and JS library. Would also be open to having this page updated with screenshots as part of https://github.com/w3f/polkadot-wiki/issues/2390

Resolves #2441