### PR TITLE
Fix conditional rendering in validator community overview page

### DIFF
--- a/docs/maintain/maintain-guides-validator-community.md
+++ b/docs/maintain/maintain-guides-validator-community.md
@@ -141,7 +141,8 @@ distro-packaged libraries, any server hardening practices, etc.
 
 #### Specs
 
-Are you running the recommended Standard Hardware for {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}? Can you ensure that machines have
+Are you running the recommended Standard Hardware for 
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}? Can you ensure that machines have
 enough processing power, memory, file storage, and network connectivity? It's helpful for nominators
 to know the specs of the machines a validator uses as to assess how they may perform in the network.
 If a validator is running underpowered machines, they may not want to nominate them, as these can

--- a/docs/maintain/maintain-guides-validator-community.md
+++ b/docs/maintain/maintain-guides-validator-community.md
@@ -141,8 +141,7 @@ distro-packaged libraries, any server hardening practices, etc.
 
 #### Specs
 
-Are you running the recommended Standard Hardware for {{ polkadot: Polkadot :polkadot}} 
-{{ kusama: Kusama :kusama}}? Can you ensure that machines have
+Are you running the recommended Standard Hardware for {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}? Can you ensure that machines have
 enough processing power, memory, file storage, and network connectivity? It's helpful for nominators
 to know the specs of the machines a validator uses as to assess how they may perform in the network.
 If a validator is running underpowered machines, they may not want to nominate them, as these can


### PR DESCRIPTION
I noticed that the conditional rendering syntax was incorrect, so the page did not render correctly. I just fixed it by adding a space before the closing curly braces.