### PR TITLE
Add "Serialized transaction format" subsection to "Transaction Format"

### DIFF
--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -51,6 +51,10 @@ Before being submitted, transactions are serialized. Serialized transactions are
   - 1 byte: the pallet index the transaction is calling into.
   - 1 byte: the function in the pallet the transaction is calling.
   - variable: the SCALE-encoded parameters required by the function being called.
+- 4 bytes: Spec version of the runtime.
+- 4 bytes: Transaction version of the runtime.
+- 32 bytes: Genesis hash of the chain.
+- 32 bytes: Block hash serving as the era reference. If the transaction is immortal, then this would be the genesis hash.
  
 The metadata provides you with all of the information required to know how to construct the serialized call data specific to your transaction. You can read more about the metadata, its format and how to get it in the [Substrate documentation](https://docs.substrate.io/v3/runtime/metadata/).
 

--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -36,6 +36,7 @@ function from the Balances pallet will take:
 - `#[compact] value`: Number of tokens (compact encoding)
 
 **Serialized transaction format**
+
 Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes with the following format:
 - Compact encoded number of SCALE-encoded bytes following this.
 - 1 bit: it is a 0 if no signature is present, or a 1 if it is.
@@ -44,8 +45,8 @@ Before being submitted, transactions are serialized. Serialized transactions are
   - a SCALE encoded `sp_runtime::MultiAddress::Id<AccountId32, u32>` indicating the signer(s) of the transaction.
   - a SCALE encoded `sp_runtime::MultiSignature::S225519` with the signature.
   - a SCALE encoded `sp_runtime::generic::Era` indicationg for how long this transaction will live in the pool.
-  - Compact encoded u32 with the nonce.
-  - Compact encoded u128 with the tip paid to the block producer.
+  - Compact encoded `u32` with the nonce.
+  - Compact encoded `u128` with the tip paid to the block producer.
 - The specific transaction parameters or call data, which consists of:
   - 1 byte: the pallet index the transaction is calling into.
   - 1 byte: the function in the pallet the transaction is calling.

--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -38,23 +38,25 @@ function from the Balances pallet will take:
 **Serialized transaction format**
 
 Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes. The specific serialization is defined in the runtime and can change if the runtime is upgraded, but in general the serialization format can be described as follows:
-- Compact encoded number of SCALE-encoded bytes following this.
+- Compact encoded number of SCALE encoded bytes following this.
 - 1 bit: it is a 0 if no signature is present, or a 1 if it is.
-- 7 bits: the extrinsic version, it is equal to 4 in decimal.
+- 7 bits: the extrinsic version, it is equal to 4 in decimal.\- 4 bytes: Spec version of the runtime.
+- 4 bytes: Transaction version of the runtime.
+- 32 bytes: Genesis hash of the chain.
+- 32 bytes: Block hash serving as the era reference. If the transaction is immortal, then this would be the genesis hash.
 - If there is a signature:
   - a SCALE encoded `sp_runtime::MultiAddress::Id<AccountId32, u32>` indicating the signer(s) of the transaction.
   - a SCALE encoded `sp_runtime::MultiSignature::{SigningScheme}` with the signature\*.
-  - a SCALE encoded `sp_runtime::generic::Era` indicating for how long this transaction is valid.
+  - a SCALE encoded `sp_runtime::generic::Era` indicating for how long this transaction is valid:
+    - If the transaction is immortal, the Era would be simply 0.
+    - Otherwise, it would be a `Vec[u64, u64]` comprising the period and the phase.  
   - Compact encoded `u32` with the nonce.
   - Compact encoded `u128` with the tip paid to the block producer.
+  - a SCALE encoded `sp_runtime::traits::SignedExtension<Vec<Text>>` with the additional data and logic associated with this transaction.
 - The specific transaction parameters or call data, which consists of:
   - 1 byte: the pallet index the transaction is calling into.
   - 1 byte: the function in the pallet the transaction is calling.
   - variable: the SCALE-encoded parameters required by the function being called.
-- 4 bytes: Spec version of the runtime.
-- 4 bytes: Transaction version of the runtime.
-- 32 bytes: Genesis hash of the chain.
-- 32 bytes: Block hash serving as the era reference. If the transaction is immortal, then this would be the genesis hash.
  
 The metadata provides you with all of the information required to know how to construct the serialized call data specific to your transaction. You can read more about the metadata, its format and how to get it in the [Substrate documentation](https://docs.substrate.io/v3/runtime/metadata/).
 

--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -37,13 +37,13 @@ function from the Balances pallet will take:
 
 **Serialized transaction format**
 
-Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes with the following format:
+Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes. The specific serialization is defined in the runtime and can change if the runtime is upgraded, but in general the serialization format can be described as follows:
 - Compact encoded number of SCALE-encoded bytes following this.
 - 1 bit: it is a 0 if no signature is present, or a 1 if it is.
-- 7 bits: the transaction protocol version.
+- 7 bits: the transaction version.
 - If there is a signature:
   - a SCALE encoded `sp_runtime::MultiAddress::Id<AccountId32, u32>` indicating the signer(s) of the transaction.
-  - a SCALE encoded `sp_runtime::MultiSignature::S225519` with the signature.
+  - a SCALE encoded `sp_runtime::MultiSignature::{SigningScheme}` with the signature\*.
   - a SCALE encoded `sp_runtime::generic::Era` indicationg for how long this transaction will live in the pool.
   - Compact encoded `u32` with the nonce.
   - Compact encoded `u128` with the tip paid to the block producer.
@@ -52,7 +52,9 @@ Before being submitted, transactions are serialized. Serialized transactions are
   - 1 byte: the function in the pallet the transaction is calling.
   - variable: the SCALE-encoded parameters required by the function being called.
  
-The metadata provides you with all of the information required to know how to construct the serialized call data specific to your transaction. You can read more about the metadata, its format and how to get it in the [Substrate documentation](https://docs.substrate.io/v3/runtime/metadata/). 
+The metadata provides you with all of the information required to know how to construct the serialized call data specific to your transaction. You can read more about the metadata, its format and how to get it in the [Substrate documentation](https://docs.substrate.io/v3/runtime/metadata/).
+
+\* Polkadot supports sr25519, ed25519, and ECDSA as signing schemes. 
 
 **Summary**
 

--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -38,6 +38,7 @@ function from the Balances pallet will take:
 **Serialized transaction format**
 
 Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes. The specific serialization is defined in the runtime and can change if the runtime is upgraded, but in general the serialization format can be described as follows:
+
 - Compact encoded number of SCALE encoded bytes following this.
 - 1 bit: it is a 0 if no signature is present, or a 1 if it is.
 - 7 bits: the extrinsic version, it is equal to 4 in decimal.\- 4 bytes: Spec version of the runtime.
@@ -49,7 +50,7 @@ Before being submitted, transactions are serialized. Serialized transactions are
   - a SCALE encoded `sp_runtime::MultiSignature::{SigningScheme}` with the signature\*.
   - a SCALE encoded `sp_runtime::generic::Era` indicating for how long this transaction is valid:
     - If the transaction is immortal, the Era would be simply 0.
-    - Otherwise, it would be a `Vec[u64, u64]` comprising the period and the phase.  
+    - Otherwise, it would be a `Vec[u64, u64]` comprising the period and the phase.
   - Compact encoded `u32` with the nonce.
   - Compact encoded `u128` with the tip paid to the block producer.
   - a SCALE encoded `sp_runtime::traits::SignedExtension<Vec<Text>>` with the additional data and logic associated with this transaction.
@@ -57,10 +58,10 @@ Before being submitted, transactions are serialized. Serialized transactions are
   - 1 byte: the pallet index the transaction is calling into.
   - 1 byte: the function in the pallet the transaction is calling.
   - variable: the SCALE-encoded parameters required by the function being called.
- 
+
 The metadata provides you with all of the information required to know how to construct the serialized call data specific to your transaction. You can read more about the metadata, its format and how to get it in the [Substrate documentation](https://docs.substrate.io/v3/runtime/metadata/).
 
-\* Polkadot supports sr25519, ed25519, and ECDSA as signing schemes. 
+\* Polkadot supports sr25519, ed25519, and ECDSA as signing schemes.
 
 **Summary**
 

--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -40,11 +40,11 @@ function from the Balances pallet will take:
 Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes. The specific serialization is defined in the runtime and can change if the runtime is upgraded, but in general the serialization format can be described as follows:
 - Compact encoded number of SCALE-encoded bytes following this.
 - 1 bit: it is a 0 if no signature is present, or a 1 if it is.
-- 7 bits: the transaction version.
+- 7 bits: the extrinsic version, it is equal to 4 in decimal.
 - If there is a signature:
   - a SCALE encoded `sp_runtime::MultiAddress::Id<AccountId32, u32>` indicating the signer(s) of the transaction.
   - a SCALE encoded `sp_runtime::MultiSignature::{SigningScheme}` with the signature\*.
-  - a SCALE encoded `sp_runtime::generic::Era` indicationg for how long this transaction will live in the pool.
+  - a SCALE encoded `sp_runtime::generic::Era` indicating for how long this transaction is valid.
   - Compact encoded `u32` with the nonce.
   - Compact encoded `u128` with the tip paid to the block producer.
 - The specific transaction parameters or call data, which consists of:

--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -35,6 +35,26 @@ function from the Balances pallet will take:
 - `dest`: Destination address
 - `#[compact] value`: Number of tokens (compact encoding)
 
+**Serialized transaction format**
+Before being submitted, transactions are serialized. Serialized transactions are hex encoded SCALE-encoded bytes with the following format:
+- Compact encoded number of SCALE-encoded bytes following this.
+- 1 bit: it is a 0 if no signature is present, or a 1 if it is.
+- 7 bits: the transaction protocol version.
+- If there is a signature:
+  - a SCALE encoded `sp_runtime::MultiAddress::Id<AccountId32, u32>` indicating the signer(s) of the transaction.
+  - a SCALE encoded `sp_runtime::MultiSignature::S225519` with the signature.
+  - a SCALE encoded `sp_runtime::generic::Era` indicationg for how long this transaction will live in the pool.
+  - Compact encoded u32 with the nonce.
+  - Compact encoded u128 with the tip paid to the block producer.
+- The specific transaction parameters or call data, which consists of:
+  - 1 byte: the pallet index the transaction is calling into.
+  - 1 byte: the function in the pallet the transaction is calling.
+  - variable: the SCALE-encoded parameters required by the function being called.
+ 
+The metadata provides you with all of the information required to know how to construct the serialized call data specific to your transaction. You can read more about the metadata, its format and how to get it in the [Substrate documentation](https://docs.substrate.io/v3/runtime/metadata/). 
+
+**Summary**
+
 Once you have all the necessary information, you will need to:
 
 1. Construct an unsigned transaction.


### PR DESCRIPTION
- Added a subsection to "Transaction Format" section to add details about the actual format of a serialized transaction.
- Added the "Summary" subsection so it is clear the enumeration of the transaction process refers to the whole section.

The info for this update has been mainly take from [this example](https://github.com/paritytech/polkadot-interaction-examples-rs/blob/main/src/bin/05_transfer_balance.rs).