### PR TITLE
`learn-implementations.md`: small typo s/bassd/based

### DIFF
--- a/docs/learn/learn-implementations.md
+++ b/docs/learn/learn-implementations.md
@@ -15,7 +15,7 @@ piece of software, and its formal implementation depends on being built on top o
 
 > This page will focus on implementations of **Polkadot's underlying infrastructure** (i.e. runtime, host).
 
-## A Wasm-Bassd Meta-Protocol
+## A Wasm-Based Meta-Protocol
 
 Polkadot uses WebAssembly ([Wasm](learn-wasm.md)) as a "meta-protocol". This allows for the use of 
 any programming language that can be interpreted or compiled into Wasm - being the driver for 

--- a/docs/learn/learn-implementations.md
+++ b/docs/learn/learn-implementations.md
@@ -15,7 +15,7 @@ piece of software, and its formal implementation depends on being built on top o
 
 > This page will focus on implementations of **Polkadot's underlying infrastructure** (i.e. runtime, host).
 
-## A Wasm-Based Meta-Protocol
+## A Wasm-based Meta Protocol
 
 Polkadot uses WebAssembly ([Wasm](learn-wasm.md)) as a "meta-protocol". This allows for the use of 
 any programming language that can be interpreted or compiled into Wasm - being the driver for 


### PR DESCRIPTION
Was reading [this page](https://wiki.polkadot.network/docs/learn-implementations) and say a typo.