### PR TITLE
Issues with Kusama Getting Started Page

### DIFF
--- a/docs/general/kusama/kusama-getting-started.md
+++ b/docs/general/kusama/kusama-getting-started.md
@@ -36,7 +36,7 @@ everything else.
 
 <tr class="cards-container">
   <td>
-    <a class="guide-link" href="../learn-account-generation">
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-account-generation">
       <img src="/img/kusama-guide/Account.png" alt="Drawing" width="250" height="150"/>
         <div class="cards-body">
             <h5 class="cards-title">Creating an Account</h5>
@@ -44,7 +44,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../learn-balance-transfers">
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-balance-transfers">
       <img src="/img/kusama-guide/Transfer.png" alt="Drawing" width="250" height="150"/>
         <div class="cards-body">
             <h5 class="cards-title">Balance Transfers</h5>
@@ -52,7 +52,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../learn-staking">
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-staking">
       <img class="guide-image" src="/img/kusama-guide/Stake.png" alt="Drawing" width="250" height="150" />
               <div class="cards-body">
                   <h5 class="cards-title">Staking</h5>
@@ -65,7 +65,7 @@ everything else.
 
 <tr class="cards-container">
   <td>
-    <a class="guide-link" href="../learn-parachains">  
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-parachains">  
       <img class="guide-image" src="/img/kusama-guide/Parachain.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Parachains</h5>
@@ -73,7 +73,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../learn-bridges">  
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-bridges">  
       <img class="guide-image" src="/img/kusama-guide/Bridges.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Bridges</h5>
@@ -81,7 +81,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../maintain-guides-how-to-vote-councillor">
+    <a class="guide-link" href="https://guide.kusama.network/docs/maintain-guides-how-to-vote-councillor">
       <img class="guide-image" src="/img/kusama-guide/Voting.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Vote for Councilors</h5>
@@ -94,7 +94,7 @@ everything else.
 
 <tr class="cards-container">
   <td>
-  <a class="guide-link" href="../learn-treasury#creating-the-proposal">
+  <a class="guide-link" href="https://guide.kusama.network/docs/learn-treasury#creating-the-proposal">
     <img class="guide-image" src="/img/kusama-guide/Proposal.png" alt="Drawing" width="250" height="150"/>
             <div class="cards-body">
                 <h5 class="cards-title">Make Proposals</h5>
@@ -102,7 +102,7 @@ everything else.
   </a>
   </td>
   <td>
-    <a class="guide-link" href="../maintain-guides-how-to-join-council#submit-candidacy">  
+    <a class="guide-link" href="https://guide.kusama.network/docs/maintain-guides-how-to-join-council#submit-candidacy">  
       <img class="guide-image" src="/img/kusama-guide/Council.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Council Candidacy</h5>
@@ -110,7 +110,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../learn-treasury">  
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-treasury">  
       <img class="guide-image" src="/img/kusama-guide/Treasury.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Treasury</h5>
@@ -123,7 +123,7 @@ everything else.
 
 <tr class="cards-container">
   <td>
-    <a class="guide-link" href="../learn-identity">
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-identity">
       <img class="guide-image" src="/img/kusama-guide/Identity.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                  <h5 class="cards-title">Set an Identity</h5>
@@ -131,7 +131,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../maintain-guides-how-to-nominate-kusama">
+    <a class="guide-link" href="https://guide.kusama.network/docs/maintain-guides-how-to-nominate-kusama">
       <img class="guide-image" src="/img/kusama-guide/Nominate.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                  <h5 class="cards-title">Become a Nominator</h5>
@@ -139,7 +139,7 @@ everything else.
     </a>
   </td>
   <td>
-    <a class="guide-link" href="../learn-proxies">
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-proxies">
       <img class="guide-image" src="/img/kusama-guide/Proxy.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Proxy Accounts</h5>
@@ -152,7 +152,7 @@ everything else.
 
 <tr class="cards-container">
   <td>
-    <a class="guide-link" href="../learn-crowdloans/">
+    <a class="guide-link" href="https://guide.kusama.network/docs/learn-crowdloans/">
       <img class="guide-image" src="/img/kusama-guide/Crowdloans.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Participate in Crowdloans</h5>
@@ -160,7 +160,7 @@ everything else.
     </a>
   </td>
   <td>
-  <a class="guide-link" href="../maintain-guides-society-kusama">  
+  <a class="guide-link" href="https://guide.kusama.network/docs/maintain-guides-society-kusama">  
     <img class="guide-image" src="/img/kusama-guide/Kusama-Society.png" alt="Drawing" width="250" height="150"/>
             <div class="cards-body">
                 <h5 class="cards-title">Join Kappa Sigma Mu</h5>
@@ -168,7 +168,7 @@ everything else.
   </a>
   </td>
   <td>
-    <a class="guide-link" href="../ambassadors">  
+    <a class="guide-link" href="https://guide.kusama.network/docs/ambassadors">  
       <img class="guide-image" src="/img/kusama-guide/Ambassadors.png" alt="Drawing" width="250" height="150"/>
               <div class="cards-body">
                   <h5 class="cards-title">Become an Ambassador</h5>


### PR DESCRIPTION
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/86818441/167578358-6d6f82b5-5215-4ac3-a864-1d81e4253f0f.png"> https://github.com/w3f/polkadot-wiki/pull/2921

Instead of letting Docusaurus resolving the links to the pages, we can avoid the issues by pointing the hyperlinks to the actual Kusama guide pages

<img width="922" alt="image" src="https://user-images.githubusercontent.com/86818441/167578911-e551deb9-66b9-403f-a38c-be77ee2eb84b.png">

