### PR TITLE
Remove locales

### DIFF
--- a/kusama-guide/i18n.js
+++ b/kusama-guide/i18n.js
@@ -1,13 +1,10 @@
 const defaultLocale = "en";
 
-const locales = ["en", "zh-CN"];
+const locales = ["en"];
 
 const localeConfigs = {
   en: {
     label: "English",
-  },
-  "zh-CN": {
-    label: "中文",
   },
 };
 

--- a/polkadot-wiki/i18n.js
+++ b/polkadot-wiki/i18n.js
@@ -1,16 +1,10 @@
 const defaultLocale = "en";
 
-const locales = ["en", "zh-CN", "ru-RU"];
+const locales = ["en"];
 
 const localeConfigs = {
   en: {
     label: "English",
-  },
-  "ru-RU": {
-    label: "Русский",
-  },
-  "zh-CN": {
-    label: "中文",
   },
 };
 


### PR DESCRIPTION
The locales were dysfunctional for a while and unnecessarily bloat the size and build time of the Wiki. Removing them for now. Can be included after translation efforts are back in place.

"ru-RU": {
    label: "Русский",
  },
  "zh-CN": {
    label: "中文",
  },