### PR TITLE
Bump node to v18, current stable version

### DIFF
--- a/.github/workflows/deploy-kusama-staging.yml
+++ b/.github/workflows/deploy-kusama-staging.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "18"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/deploy-polkadot-staging.yml
+++ b/.github/workflows/deploy-polkadot-staging.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "18"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/scripts/fetch.mjs
+++ b/scripts/fetch.mjs
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import yargs from "yargs";
 import { ApiPromise, WsProvider } from "@polkadot/api";
-import replacements from "./inject-dict.json";
+import replacements from "./inject-dict.json" assert {type: "json"};
 import * as computed from "./computed.mjs";
 
 const argv = yargs(process.argv)

--- a/scripts/inject.mjs
+++ b/scripts/inject.mjs
@@ -1,6 +1,6 @@
 import replace from "replace-in-file";
 import yargs from "yargs";
-import replacements from "./inject-dict.json";
+import replacements from "./inject-dict.json" assert {type: "json"};
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import * as computed from "./computed.mjs";
 


### PR DESCRIPTION
Test bumping node to current version on staging to fix dependabot CI/CD issues. 