### PR TITLE
Fix broken links on grants.md

### DIFF
--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -45,9 +45,9 @@ If you are interested in obtaining KSM for building or research, you can apply t
 
 Below is a list of other grant programs in the Polkadot/Substrate ecosystem:
 
-- [Darwinia Grants Program](https://docs.darwinia.network/docs/en/dev-bounty#grant-program)
+- [Darwinia Grants Program](https://docs.darwinia.network/developers/dev-bounty#grant-program)
 - [Moonbeam Grants Program](https://moonbeam.network/community/grants/)
 - [Edgeware Grants and Bounties](https://github.com/edgeware-builders/construction-projects)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)
 - [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal)
-- [Plasm Network Builders Program](https://github.com/PlasmNetwork/Builders-Program)
+- [Plasm Network Builders Program](https://docs.astar.network/ecosystem/builders-program)

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -50,4 +50,4 @@ Below is a list of other grant programs in the Polkadot/Substrate ecosystem:
 - [Edgeware Grants and Bounties](https://github.com/edgeware-builders/construction-projects)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)
 - [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal)
-- [Plasm Network Builders Program](https://docs.astar.network/ecosystem/builders-program)
+- [Astar (formerly Plasm) Grants Program](https://docs.astar.network/ecosystem/builders-program)


### PR DESCRIPTION
Darwinia Grants Program link is broken
Plasma Network Builders Program link is pointing to a github link which inturn refers to a link for official docs. Changing the link to point to official docs