### PR TITLE
Explain Staking Targets Table in Polkadot-JS App

### DIFF
--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -234,7 +234,7 @@ each.
 
   - You may want to be cautious of validators with a high number of subscribers. A validator is
     considered oversubscribed when more than 256 'active' nominators are assigned to the validator. In this
-    scenario only the top 256 nominators will receive rewards. The remaining subscribers will
+    scenario only the top 256 nominators will receive rewards. The remaining nominators will
     recieve nothing, however they can also be slashed in the event that the validator commits a
     slashable offence.
   - Every nominator can select up to a maxium of 16 validators, which contributes towards maximizing

--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -235,7 +235,7 @@ each.
   - You may want to be cautious of validators with a high number of subscribers. A validator is
     considered oversubscribed when more than 256 'active' nominators are assigned to the validator. In this
     scenario only the top 256 nominators will receive rewards. The remaining nominators will
-    recieve nothing, however they can also be slashed in the event that the validator commits a
+    recieve nothing, however they can be slashed in the event that validator commits a
     slashable offence.
   - Every nominator can select up to a maxium of 16 validators, which contributes towards maximizing
     the probability of having the nominators stake applied to the validators active set. Having too

--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -233,7 +233,7 @@ each.
   2) Total amount of nominators that nominated that validator.
 
   - You may want to be cautious of validators with a high number of subscribers. A validator is
-    considered oversubscribed when more than 256 nominators have nominated the validator. In this
+    considered oversubscribed when more than 256 'active' nominators are assigned to the validator. In this
     scenario only the top 256 nominators will receive rewards. The remaining subscribers will
     recieve nothing, however they can also be slashed in the event that the validator commits a
     slashable offence.

--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -239,10 +239,10 @@ each.
     slashable offence.
   - Every nominator can select up to a maxium of 16 validators, which contributes towards maximizing
     the probability of having the nominators stake applied to the validators active set. Nominating too
-    few validators could results in the nominator being excluded from the active set. This behaviour
-    is a result of the election algorithm attempting to maximize the overall network stake, while
-    minimizing the variance of the active stake across the validators. For additional information on
-    the selection process checkout the research behind
+    few validators could result in the nominators losing their rewards when none of them make it to active set or 
+    when those Validator nodes stop validating. The election algorithm attempts to maximize the overall network 
+    stake, while minimizing the variance of the active stake across the validators. For additional information on
+    the election process checkout the research behind
     [nominated proof-of-stake](https://research.web3.foundation/en/latest/polkadot/NPoS/1.%20Overview.html#polkadot-npos-1-overview--page-root).
   - _example_: If nominator X has nominated validators A, B, C and D, but is actively only
     nominating validator B. The `active` count (left number) for nominator X is 1, counting B

--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -238,7 +238,7 @@ each.
     recieve nothing, however they can be slashed in the event that validator commits a
     slashable offence.
   - Every nominator can select up to a maxium of 16 validators, which contributes towards maximizing
-    the probability of having the nominators stake applied to the validators active set. Having too
+    the probability of having the nominators stake applied to the validators active set. Nominating too
     few validators could results in the nominator being excluded from the active set. This behaviour
     is a result of the election algorithm attempting to maximize the overall network stake, while
     minimizing the variance of the active stake across the validators. For additional information on

--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -219,13 +219,53 @@ more information and instructions for claiming rewards.
 
 ### What to Take Into Consideration When Nominating
 
-One thing to keep in mind as a nominator is the validator's commission. The commission is the
-percentage of the validator reward which is taken by the validator before the rewards are split
-among the nominators. As a nominator, you may think that the lowest commission is best. However,
-this is not always true. Validators must be able to run at break-even in order to sustainably
-continue operation. Independent validators that rely on the commission to cover their server costs
-help to keep the network decentralized. Commission is just one piece of the puzzle that you should
-consider when picking validators to nominate.
+There are many factors to consider when deciding which validator's to nominate. One useful tool for
+assisting in this process is the Staking [Targets](https://polkadot.js.org/apps/#/staking/targets)
+table. This displays potential validators in a table that can be evaluated and sorted using various
+metrics. Outlined below are the relevant columns to consider, followed by a brief description of
+each.
+
+- **payout**: How recently the validator has made it's last reward payout to nominators.
+- **nominators**: This column consists of two number values.
+
+  1) Amount of nominators currently bonded in the current era and considered `active`.
+
+  2) Total amount of nominators that nominated that validator.
+
+  - You may want to be cautious of validators with a high number of subscribers. A validator is
+    considered oversubscribed when more than 256 nominators have nominated the validator. In this
+    scenario only the top 256 nominators will receive rewards. The remaining subscribers will
+    recieve nothing, however they can also be slashed in the event that the validator commits a
+    slashable offence.
+  - Every nominator can select up to a maxium of 16 validators, which contributes towards maximizing
+    the probability of having the nominators stake applied to the validators active set. Having too
+    few validators could results in the nominator being excluded from the active set. This behaviour
+    is a result of the election algorithm attempting to maximize the overall network stake, while
+    minimizing the variance of the active stake across the validators. For additional information on
+    the selection process checkout the research behind
+    [nominated proof-of-stake](https://research.web3.foundation/en/latest/polkadot/NPoS/1.%20Overview.html#polkadot-npos-1-overview--page-root).
+  - _example_: If nominator X has nominated validators A, B, C and D, but is actively only
+    nominating validator B. The `active` count (left number) for nominator X is 1, counting B
+    exclusively. The total or `all` count (right number) is 4, counting A, B, C and D.
+
+    | validator | payout   | nominators             |
+    | --------- | -------- | ---------------------- |
+    | _example_ | recently | 1 (`active`) 4 (`all`) |
+
+- **comm.**: Total commission kept by the validator (100% means nominators will not receive a
+  reward).
+- **total stake**: The total amount of DOT tokens staked by all parties.
+- **own stake**: The amount of DOT tokens the validator has put up as a stake.
+- **return**: How profitable the validator has been.
+
+A validator's commission is the percentage of the validator reward which is taken by the validator
+before the rewards are split among the nominators. As a nominator, you may think that the lowest
+commission is best. However, this is not always true. Validators must be able to run at break-even
+in order to sustainably continue operation. Independent validators that rely on the commission to
+cover their server costs help to keep the network decentralized. Some validators, operated by
+central exchanges etc., keep 100% of the commission to payout their staking service clients and
+therefore do not provide any rewards to external nominators. Commission is just one piece of the
+puzzle that you should consider when picking validators to nominate.
 
 ![Staking Returns](../assets/staking/polkadotjs_nominators_target.png)
 

--- a/docs/maintain/maintain-guides-how-to-nominate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-nominate-polkadot.md
@@ -66,7 +66,9 @@ The "Payouts" subsection ([link](https://polkadot.js.org/apps/#/staking/payouts)
 claim rewards from staking.
 
 The "Targets" subsection ([link](https://polkadot.js.org/apps/#/staking/targets)) will help you
-estimate your earnings and this is where it's good to start picking favorites.
+estimate your earnings and this is where it's good to start picking favorites. For additional
+information on content provided in this table checkout
+[What to take into consideration when nominating](learn-nominator#what-to-take-into-consideration-when-nominating).
 
 The "Waiting" subsection ([link](https://polkadot.js.org/apps/#/staking/waiting)) lists all pending
 validators that are awaiting more nominations to enter the active validator set. Validators will


### PR DESCRIPTION
# Explain Staking Targets Table in Polkadot-JS App

### Task
This PR addresses #3240 and was ported from PR #3412 which was created on a fork.

### Acceptance Criteria

- [x] Add descriptions of what all the [columns](https://polkadot.js.org/apps/#/staking/targets) mean in the Targets table:
    - [x] `payout`
    - [x] `nominators` (active and all)
        - [x] explanation for each
        - [x] example for each
    - [x] `comm.`
    - [x] `total stake`
    - [x] `own stake`
    - [ ] ~~`other stake`~~
    - [x] `return`
- [x] New information is added or linked to the following existing resources:
    - [x] [maintain-guides-how-to-nominate-polkadot](https://wiki.polkadot.network/docs/maintain-guides-how-to-nominate-polkadot)
    - [x] [learn-nominator](https://wiki.polkadot.network/docs/learn-nominator)
    - [ ] ~~[how-do-i-know-which-validators-to-choose](https://support.polkadot.network/support/solutions/articles/65000150130-how-do-i-know-which-validators-to-choose-)~~
- [x] Screenshots/imagery is updated on existing resources (if required)

### Questions

1. `other stake` is mentioned in original task but I no longer see this option in the chart header.  Was it possibly removed or am I missing something?

2. Where is the code for `support.polkadot.network` hosted?

3. If it is not too difficult we could follow-up with adding or requesting to **add the Target column definitions as tooltips when hovered**?  Difficulty likely depends on how much effort is required for localization.