### PR TITLE
[WIP] Fix Wiki Layout Bug

### DIFF
--- a/polkadot-wiki/static/css/custom.css
+++ b/polkadot-wiki/static/css/custom.css
@@ -17,7 +17,7 @@
   --docsearch-searchbox-shadow: var(--snowColor);
 
   --custom-code-block-background: #f6f8fa;
-  --custom-content-max-width: 1920px;
+  --custom-content-max-width: 3840px;
 }
 
 body {

--- a/polkadot-wiki/static/css/custom.css
+++ b/polkadot-wiki/static/css/custom.css
@@ -17,7 +17,7 @@
   --docsearch-searchbox-shadow: var(--snowColor);
 
   --custom-code-block-background: #f6f8fa;
-  --custom-content-max-width: 3840px;
+  --custom-content-max-width: none;
 }
 
 body {


### PR DESCRIPTION
Changed max-width value to accommodate for larger screen sizes. (Value comes from the largest breakpoint available on Browserstack)
It also works if we remove the --custom-content-max-width variable from the docs container all together as well. 
@rmnprkrl 