### PR TITLE
Fix broken markdown links outlined in build console output

### DIFF
--- a/docs/build/build-wallets.md
+++ b/docs/build/build-wallets.md
@@ -32,7 +32,7 @@ post where the Treasury Proposal was discussed.
 :::caution Web3 Technologies Foundation does not endorse these wallets
 
 These third-party wallets have been funded by the community through either the Polkadot or Kusama 
-[Treasury](learn-treasury.md). You should use your own due diligence in researching and using them.
+[Treasury](learn-treasury). You should use your own due diligence in researching and using them.
 The official Polkadot Support cannot provide support for issues with 
 these wallets or other non-Parity developed wallets.
 
@@ -57,7 +57,7 @@ double-check the wallet website URLs through official channels (most projects ha
 :::note **Tip from the Treasury
 
 This third-party wallet was not funded by a Treasury Proposal and instead received a tip from the Treasury. Unlike a Treasury Proposal, tipping is a separate 
-system that the council members individually participate in to collectively decide on the value of the tip. Learn more about tipping on the [Treasury Page](../learn/learn-treasury.md##tipping).
+system that the council members individually participate in to collectively decide on the value of the tip. Learn more about tipping on the [Treasury Page](learn-treasury#tipping).
 
 :::
 

--- a/docs/general/kusama/kusama-getting-started.md
+++ b/docs/general/kusama/kusama-getting-started.md
@@ -197,14 +197,14 @@ Learn more about how you can create and send Kusama Gifts [here](https://polkado
 
 While Kusama does not support smart contracts natively, building apps on it is still possible
 (e.g. [RMRK.app](https://rmrk.app)). If you're interested in diving deeper into *proper* development, 
-however, check out the [builders guide][].
+however, check out the [builders guide](./../build/build-index.md).
 
-[mooc]: https://mooc.web3.foundation/course/blockchain-fundamentals/
-[medium]: https://medium.com/polkadot-network/kusama-network-7446706b8f4c
-[claims]: kusama-claims.md
-[endpoints]: kusama-endpoints.md
-[tokens]: https://claim.kusama.network/
-[validator]: ../../maintain/kusama/mirror-maintain-guides-how-to-validate-kusama.md
-[nominator]: ../../maintain/kusama/mirror-maintain-guides-how-to-nominate-kusama.md
-[polkadot wiki]: https://wiki.polkadot.network/
-[builders guide]: ../../build/build-index.md
+Additional Resources:
+- [mooc](https://mooc.web3.foundation/course/blockchain-fundamentals/)
+- [medium](https://medium.com/polkadot-network/kusama-network-7446706b8f4c)
+- [claims](kusama-claims)
+- [endpoints](kusama-endpoints)
+- [tokens](https://claim.kusama.network/)
+- [validator](../../maintain/kusama/mirror-maintain-guides-how-to-validate-kusama.md)
+- [nominator](../../maintain/kusama/mirror-maintain-guides-how-to-nominate-kusama.md)
+- [polkadot wiki](https://wiki.polkadot.network/)


### PR DESCRIPTION
Addresses #3449 

- [x] All links that were displaying in the console have been repaired and verified