### PR TITLE
Remove "--unsafe-pruning" flag from the docs

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -327,11 +327,6 @@ If you've already synced the chain not in archive mode, you must first remove th
 database with `polkadot purge-chain` and then ensure that you run Polkadot with 
 the `--pruning=archive` option.
 
-You may run a validator node in non-archive mode by adding the following flags:
-`--unsafe-pruning --pruning <NUM OF BLOCKS>`, a reasonable value being 1000. Note that an archive
-node and non-archive node's databases are not compatible with each other, and to switch you will
-need to purge the chain data.
-
 :::
 
 You can begin syncing your node by running the following command:


### PR DESCRIPTION
```
// according to https://github.com/substrate/issues/8103;
warn!(
   "WARNING: \"--unsafe-pruning\" CLI-flag is deprecated and has no effect. \
   In future builds it will be removed, and providing this flag will lead to an error."
);
```