### PR TITLE
Consolidate mirror logic and append 'mirror-' to page slugs

### DIFF
--- a/scripts/mirror.mjs
+++ b/scripts/mirror.mjs
@@ -1,163 +1,106 @@
-import fs from "fs";
+import { existsSync, readFileSync, writeFileSync} from "fs";
 
-/**
- * The wiki hosts both the Polkadot Wiki and the Kusama User Guide. This means
- * that we can "mirror" the same document between the two. However, due to
- * a peculiarity in Docusaurus, when we put the same document into both sub-wikis
- * in `website/sidebars.json` only the most recent entry is read.
- *
- * To solve this, we create an explicit mirror of the document. The process for
- * adding content to both wikis is as follows:
- *
- * 1) Create the source document and put it under the relevant sidebar in the
- *    Polkadot wiki configuration in `sidebars.json`.
- * 2) Add the source document's name to the `mirrored` array below.
- * 3) Run `node mirror.js`.
- * 4) Add `mirror-DOCUMENT_NAME` to the sidebar for Kusama in `sidebars.json`.
- *
+/*
+  The wiki hosts both the Polkadot Wiki and the Kusama User Guide. This means
+  that we can "mirror" the same document between the two. However, due to
+  a peculiarity in Docusaurus, when we put the same document into both sub-wikis
+  in `website/sidebars.json` only the most recent entry is read.
+
+  To solve this, we create an explicit mirror of the document. The process for
+  adding content to both wikis is as follows:
+ 
+  1) Create the source document and put it under the relevant sidebar in the
+     Polkadot wiki configuration in `sidebars.json`.
+  2) Add the source document's name to the `mirrored` array below.
+  3) Run `node mirror.js` which duplicates the original markdown file and
+     appends 'mirror-' to the file's id and slug to prevent duplicate routes.
+  4) Add `mirror-DOCUMENT_NAME` to the sidebar for Kusama in `sidebars.json`.
  */
 
 // List of mirrored files that should be in both the Polkadot wiki and the Kusama
 // user guide.
 
-const mirrored_general = ["ens", "thousand-validators"];
-
-const mirrored_learn = [
-  "learn-identity",
-  "learn-balance-transfers",
-  "learn-governance",
-  "learn-treasury",
-  "learn-registrar",
-  "learn-auction",
-  "learn-parachains",
-  "learn-parathreads",
-  "learn-crowdloans",
-];
-
-const mirrored_build = [
-  "build-guide", 
-  "build-parachains",
-  "build-storage",
-  "build-smart-contracts",
-  "build-oracle",
-  "build-wallets",
-  "build-tools-index",
-  "build-hackathon",
-];
-
-const mirrored_maintain = [
-  "maintain-guides-how-to-stop-validating",
-  "maintain-errors",
-  "maintain-guides-validator-community",
-];
-
-const mirrored_maintain_kusama = [
-  "maintain-guides-how-to-nominate-kusama",
-  "maintain-guides-how-to-validate-kusama",
-];
-
-// Mirror general docs
-for (const file of mirrored_general) {
-  const doc = "./docs/general/" + file + ".md";
-  const mirror = "./docs/general/mirror-" + file + ".md";
-  if (!fs.existsSync(doc)) {
-    throw new Error(`${doc} doesn't exist!`);
-  }
-
-  const content = fs.readFileSync(doc, "utf8");
-  const mirroredContent = content
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("id:")) {
-        const [before, after] = line.split(" ");
-        return before + " mirror-" + after;
-      } else return line;
-    })
-    .join("\n");
-
-  fs.writeFileSync(mirror, mirroredContent);
+const mirroredDocs = {
+  general: [
+    "ens",
+    "thousand-validators"
+  ],
+  learn: [
+    "learn-identity",
+    "learn-balance-transfers",
+    "learn-governance",
+    "learn-treasury",
+    "learn-registrar",
+    "learn-auction",
+    "learn-parachains",
+    "learn-parathreads",
+    "learn-crowdloans",
+  ],
+  build: [
+    "build-guide", 
+    "build-parachains",
+    "build-storage",
+    "build-smart-contracts",
+    "build-oracle",
+    "build-wallets",
+    "build-tools-index",
+    "build-hackathon",
+  ],
+  maintain: [
+    "maintain-guides-how-to-stop-validating",
+    "maintain-errors",
+    "maintain-guides-validator-community",
+  ],
+  "maintain/kusama": [
+    "maintain-guides-how-to-nominate-kusama",
+    "maintain-guides-how-to-validate-kusama",
+  ]
 }
-// Mirror learn docs
-for (const file of mirrored_learn) {
-  const doc = "./docs/learn/" + file + ".md";
-  const mirror = "./docs/learn/mirror-" + file + ".md";
-  if (!fs.existsSync(doc)) {
-    throw new Error(`${doc} doesn't exist!`);
-  }
 
-  const content = fs.readFileSync(doc, "utf8");
-  const mirroredContent = content
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("id:")) {
-        const [before, after] = line.split(" ");
-        return before + " mirror-" + after;
-      } else return line;
-    })
-    .join("\n");
-
-  fs.writeFileSync(mirror, mirroredContent);
+for (const [key, value] of Object.entries(mirroredDocs)) {
+  buildMirrors(key, value)
 }
-// Mirror build docs
-for (const file of mirrored_build) {
-  const doc = "./docs/build/" + file + ".md";
-  const mirror = "./docs/build/mirror-" + file + ".md";
-  if (!fs.existsSync(doc)) {
-    throw new Error(`${doc} doesn't exist!`);
-  }
 
-  const content = fs.readFileSync(doc, "utf8");
-  const mirroredContent = content
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("id:")) {
-        const [before, after] = line.split(" ");
-        return before + " mirror-" + after;
-      } else return line;
-    })
-    .join("\n");
+function buildMirrors(dir, fileNames) {
+  fileNames.forEach(file => {
+    // Define origin and mirror paths
+    const doc = `./docs/${dir}/${file}.md`;
+    const mirror = `./docs/${dir}/mirror-${file}.md`;
+    
+    // Make sure origin file exists
+    if (!existsSync(doc)) {
+      throw new Error(`${doc} doesn't exist!`);
+    }
 
-  fs.writeFileSync(mirror, mirroredContent);
-}
-// Mirror maintain docs
-for (const file of mirrored_maintain) {
-  const doc = "./docs/maintain/" + file + ".md";
-  const mirror = "./docs/maintain/mirror-" + file + ".md";
-  if (!fs.existsSync(doc)) {
-    throw new Error(`${doc} doesn't exist!`);
-  }
+    // Read origin
+    const content = readFileSync(doc, "utf8");
 
-  const content = fs.readFileSync(doc, "utf8");
-  const mirroredContent = content
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("id:")) {
-        const [before, after] = line.split(" ");
-        return before + " mirror-" + after;
-      } else return line;
-    })
-    .join("\n");
-
-  fs.writeFileSync(mirror, mirroredContent);
-}
-// Mirror kusama maintain docs
-for (const file of mirrored_maintain_kusama) {
-  const doc = "./docs/maintain/kusama/" + file + ".md";
-  const mirror = "./docs/maintain/kusama/mirror-" + file + ".md";
-  if (!fs.existsSync(doc)) {
-    throw new Error(`${doc} doesn't exist!`);
-  }
-
-  const content = fs.readFileSync(doc, "utf8");
-  const mirroredContent = content
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("id:")) {
-        const [before, after] = line.split(" ");
-        return before + " mirror-" + after;
-      } else return line;
-    })
-    .join("\n");
-
-  fs.writeFileSync(mirror, mirroredContent);
+    // Modify content
+    const mirroredContent = content
+      .split("\n")
+      .map((line) => {
+        // Append mirror- to id
+        if (line.startsWith("id:")) {
+          const [before, after] = line.split(" ");
+          return `${before} mirror-${after}`;
+        }
+        // Append mirror- to slug
+        else if (line.startsWith("slug:")) {
+          let route = line.split("/");
+          const trailingRoute = route[route.length - 1];
+          const trailingMirrorRoute = `mirror-${trailingRoute}`;
+          route.pop();
+          route.push(trailingMirrorRoute);
+          const slug = route.join('/');
+          return slug;
+        } else {
+          // Keep line as-is
+          return line;
+        }
+      })
+      .join("\n");
+    
+    // Write mirror
+    writeFileSync(mirror, mirroredContent);
+  });
 }


### PR DESCRIPTION
### Description
This PR addresses #3448 

It was determined that the duplicate route errors we were seeing were due to the implementation of `mirror.mjs`.  This file runs during builds to created duplicate pages to avoid some [restrictions of Docusaurus](https://github.com/w3f/polkadot-wiki/blob/master/scripts/mirror.mjs#L4).  The issue is that these duplicate mirrored pages share the same `slug` as the original pages.

The top of each markdown doc contains some metadata.  One of the properties in this metadata is the `slug`, which determines the route that will be used for that page.  `mirror.mjs` updates the `id` property only and keeps the route the same.  This is the source of the errors, 2 pages now share the same `slug`.

The router detects this, generating one set of errors and the redirect code throws again for the same reason (100+ lines of errors in console).  Since these pages share the same `slug`, whichever page is compiled later gets rendered for that route.  This isn't a big issue because the content is the same but it will always trigger the console errors.

### Current Solution
Append the same 'mirror-' prefix to the slug of the mirrored page.  All errors go away but mirror pages now have their own routes.  For example:

`docs/learn-crowdloans` and `docs/mirror-learn-crowdloans` would both be valid routes.

~~It's a bit strange to have both pages.  For example, how does this play with analytics.~~
^After looking into this more, I don't think this is a big issues.  The mirror pages are only ever used for Kusama content.  So for example, a Polkadot route in the docs could be 

`https://wiki.polkadot.network/docs/build-pdk`

while the Kusama route would be:

`https://guide.kusama.network/docs/mirror-build-pdk`

but

`https://wiki.polkadot.network/docs/mirror-build-pdk`

and 

`https://guide.kusama.network/docs/build-pdk`

would technically exist but never be referenced in the docs so a user would have to manually type out these type of routes.  For the purposes of analytics, it's very low likelihood that both routes would get regular hits and cause any confusion.  The `mirror-` prefix could be changed to `kusama-` for our purposes but then `https://wiki.polkadot.network/docs/kusama-build-pdk` would exists too, although never referenced.

### Alternative
Turn-off duplicate page errors in the `docusaurus.config.js` files via the `onDuplicateRoutes` property and still deal with the errors surfacing again at the [redirect code](https://github.com/w3f/polkadot-wiki/blob/master/polkadot-wiki/docusaurus.config.js#L84).  This risk here is hiding real errors.

**With either solution we should merge this PR as it consolidates `mirror.mjs`.  If we don't want the additional routes, the `else if` condition in the `BuildMirrors` function can be removed.**