### PR TITLE
Clean up Grants page and refs

### DIFF
--- a/docs/build/build-index.md
+++ b/docs/build/build-index.md
@@ -38,7 +38,8 @@ This section of the wiki is divided into the following parts:
 
 ### Grants
 
-- [Grants](../general/grants.md) - A list of all Polkadot-related projects given grants by the Web3 Foundation.
+- [Grants](../general/grants.md) - Information regarding grants and funding sources available in 
+  the Polkadot ecosystem.
 
 ### PSPs
 

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -10,10 +10,10 @@ slug: ../grants
 ## Web3 Foundation Grants
 
 Web3 Foundation offers grants for open source software development and research around Substrate,
-Polkadot, and Kusama. Applications and deliveries are tracked transparently on GitHub. Information 
-regarding requirements, the application process, deliveries, etc., can be found in the
-[Grants Program README](https://github.com/w3f/Open-Grants-Program). For guidance, there is also a list of
-[previously accepted applications](https://github.com/w3f/Grants-Program/blob/master/docs/accepted_grant_applications.md)
+Polkadot, Kusama and ink!. Applications and deliveries are tracked transparently on GitHub. Information 
+regarding requirements, the application process, deliveries, etc. can be found in the
+[Grants Program README](https://github.com/w3f/Grants-Program#web3-foundation-grants-program). For guidance, there is also a list of
+[previously accepted applications](https://github.com/w3f/Grants-Program/blob/master/docs/accepted_grant_applications.md#accepted-grant-applications-)
 and a list of [frequently asked questions](https://github.com/w3f/Grants-Program/blob/master/docs/faq.md).
 
 ## Alternative Funding Sources

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -50,6 +50,7 @@ If you are interested in obtaining KSM for building or research, you can apply t
 
 Below is a list of other grant programs in the Polkadot/Substrate ecosystem.
 
+- [Darwinia Grants Program](https://github.com/darwinia-network/collaboration/blob/master/grant/README.md#grant-program)
 - [Moonbeam Grants Program](https://moonbeam.foundation/grants/)
 - [Edgeware Grants and Bounties](https://gov.edgewa.re/discussion/1132-edgeware-proposal-process-and-template)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -22,7 +22,7 @@ and a list of [frequently asked questions](https://github.com/w3f/Grants-Program
 
 Check the 
 [alternative funding sources](https://github.com/w3f/Grants-Program/blob/master/README.md#rocket-alternative-funding-sources) 
-section on Web3 Foundation grants repo for comprehensive information.
+section on the Web3 Foundation grants repo for comprehensive information.
 
 :::
 

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -18,6 +18,14 @@ and a list of [frequently asked questions](https://github.com/w3f/Grants-Program
 
 ## Alternative Funding Sources
 
+:::info
+
+Check the 
+[alternative funding sources](https://github.com/w3f/Grants-Program/blob/master/README.md#rocket-alternative-funding-sources) 
+section on Web3 Foundation grants repo for comprehensive information.
+
+:::
+
 ### Polkadot Treasury
 
 The Polkadot Treasury is a pot of on-chain funds collected through transaction fees, slashing,
@@ -42,12 +50,15 @@ If you are interested in obtaining KSM for building or research, you can apply t
 
 Below is a list of other grant programs in the Polkadot/Substrate ecosystem.
 
-- [Moonbeam Grants Program](https://moonbeam.network/community/grants/)
-- [Edgeware Grants and Bounties](https://github.com/edgeware-builders/construction-projects)
+- [Darwinia Grants Program](https://github.com/darwinia-network/collaboration/blob/master/grant/README.md#grant-program)
+- [Moonbeam Grants Program](https://moonbeam.foundation/grants/)
+- [Edgeware Grants and Bounties](https://gov.edgewa.re/discussion/1132-edgeware-proposal-process-and-template)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)
-- [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal)
-- [Astar (formerly Plasm) Grants Program](https://docs.astar.network/ecosystem/builders-program)
+- [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal/)
+- [Astar / Shiden Network Builders Program](https://github.com/PlasmNetwork/Builders-Program)
+- [Picasso / Composable Grants Program](https://grants.composable.finance)
+- [SubQuery Grants Programme](https://subquery.network/grants)
+- [Acala Grants Program](https://acala.network/ecosystem-program)
+- [OAK’s Developer Grants](https://oak.tech/community/grants/)
 
-Check [other grant programs](https://github.com/w3f/Grants-Program#other-grant-programs) section on
-Web3 Foundation grants repo for more information.
 

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -40,10 +40,14 @@ If you are interested in obtaining KSM for building or research, you can apply t
 
 ### Other Grant Programs
 
-Below is a list of other grant programs in the Polkadot/Substrate ecosystem:
+Below is a list of other grant programs in the Polkadot/Substrate ecosystem.
 
 - [Moonbeam Grants Program](https://moonbeam.network/community/grants/)
 - [Edgeware Grants and Bounties](https://github.com/edgeware-builders/construction-projects)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)
 - [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal)
 - [Astar (formerly Plasm) Grants Program](https://docs.astar.network/ecosystem/builders-program)
+
+Check [other grant programs](https://github.com/w3f/Grants-Program#other-grant-programs) section on
+Web3 Foundation grants repo for more information.
+

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -50,12 +50,11 @@ If you are interested in obtaining KSM for building or research, you can apply t
 
 Below is a list of other grant programs in the Polkadot/Substrate ecosystem.
 
-- [Darwinia Grants Program](https://github.com/darwinia-network/collaboration/blob/master/grant/README.md#grant-program)
 - [Moonbeam Grants Program](https://moonbeam.foundation/grants/)
 - [Edgeware Grants and Bounties](https://gov.edgewa.re/discussion/1132-edgeware-proposal-process-and-template)
 - [Crust Grants Program](https://github.com/crustio/Crust-Grants-Program)
 - [HydraDX Grants and Bounties](https://docs.hydradx.io/new_deal/)
-- [Astar / Shiden Network Builders Program](https://github.com/PlasmNetwork/Builders-Program)
+- [Astar / Shiden Network Builders Program](https://astar.network/builders-program/)
 - [Picasso / Composable Grants Program](https://grants.composable.finance)
 - [SubQuery Grants Programme](https://subquery.network/grants)
 - [Acala Grants Program](https://acala.network/ecosystem-program)

--- a/docs/general/grants.md
+++ b/docs/general/grants.md
@@ -1,20 +1,17 @@
 ---
 id: grants
-title: Web3 Foundation Grants
+title: Grants
 sidebar_label: Grants
-description: Learn about Web3 Foundation's Grant Program and how you can benefit from it.
+description: Learn about Grant Programs in the Polkadot ecosystem
 keywords: [grants program, grants, funding]
 slug: ../grants
 ---
 
+## Web3 Foundation Grants
+
 Web3 Foundation offers grants for open source software development and research around Substrate,
-Polkadot, and Kusama.
-
-Applications and deliveries are tracked transparently on GitHub and disbursed in BTC, USDT or DAI. However,
-you can also apply in private, get paid out in fiat and seek funding above the regular limits ($30,000 for
-first-time applications and $100,000 for follow-up ones), if needed.
-
-More information regarding requirements, the application process, deliveries, etc., can be found in the
+Polkadot, and Kusama. Applications and deliveries are tracked transparently on GitHub. Information 
+regarding requirements, the application process, deliveries, etc., can be found in the
 [Grants Program README](https://github.com/w3f/Open-Grants-Program). For guidance, there is also a list of
 [previously accepted applications](https://github.com/w3f/Grants-Program/blob/master/docs/accepted_grant_applications.md)
 and a list of [frequently asked questions](https://github.com/w3f/Grants-Program/blob/master/docs/faq.md).


### PR DESCRIPTION
The grants page has to be made generic, providing information on all the funding sources available in the ecosystem