### PR TITLE
Run Jest tests weekly instead of on PRs

### DIFF
--- a/.github/workflows/jest-testing-coverage.yml
+++ b/.github/workflows/jest-testing-coverage.yml
@@ -1,8 +1,8 @@
 name: Jest Testing Coverage
 on:
-  pull_request:
-    branches:
-      - master
+  schedule:
+    - cron: '0 0 * * 1' # Once a week
+  workflow_dispatch:
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/tests/rpc.test.js
+++ b/tests/rpc.test.js
@@ -29,6 +29,7 @@ test("Human readable filter with float value", async () => {
 	await waitFor(() => expect(screen.getByText("20.258 DOT")).toBeInTheDocument(), { timeout: 5000 });
 });
 
+/*
 // Set max test duration before failing (2 min)
 jest.setTimeout(120000);
 
@@ -126,3 +127,4 @@ test("All leveraged RPC paths are valid", async () => {
 	// All RPC paths should return valid responses
 	expect(attemptedConnections === successfulResponses).toEqual(true);
 });
+*/


### PR DESCRIPTION
This PR puts the Jest tests on a cron job instead of the PR trigger.  This makes more sense for the type of tests we have in the suite right now.  I hope we can add more general tests in the future and can revisit this topic.  The tests can also be invoked manually from the actions UI if desired for testing a PR:

![image](https://user-images.githubusercontent.com/13341935/182867397-6cf26013-839e-45a9-9bb4-6fd56f434493.png)

 It also comments-out one long running test.  In general Jest encourages writing short running operations.  Running over a minute starts to get a bit excessive/flaky.