### PR TITLE
Updated voting Councillor voting constants

### DIFF
--- a/docs/maintain/maintain-guides-how-to-vote-councillor.md
+++ b/docs/maintain/maintain-guides-how-to-vote-councillor.md
@@ -16,8 +16,8 @@ councillors in the elections.
 ## Voting for Councillors
 
 Voting for councillors requires you to reserve 
-{{ polkadot: ~20 DOT :polkadot }}{{ kusama: ~0.063 KSM :kusama }} 
-(a base amount + a per vote amount). You can then bond whatever amount you wish to put 
+{{ polkadot: ~20.064 DOT :polkadot }}{{ kusama: ~0.067 KSM :kusama }} as a base amount
+and an amount per vote {{ polkadot: ~0.032 DOT :polkadot }}{{ kusama: ~0.00011 KSM :kusama }}. You can then bond whatever amount you wish to put 
 behind your vote. See the [democracy guide](maintain-guides-democracy.md) for more information.
 
 :::info Voting and staking locks can overlap

--- a/docs/maintain/maintain-guides-how-to-vote-councillor.md
+++ b/docs/maintain/maintain-guides-how-to-vote-councillor.md
@@ -7,6 +7,8 @@ keywords: [council, vote, councillors]
 slug: ../maintain-guides-how-to-vote-councillor
 ---
 
+import RPC from "./../../components/RPC-Connection"
+
 The council is an elected body of on-chain accounts that are intended to represent the passive
 stakeholders of Polkadot and/or Kusama. The council has two major tasks in governance: proposing
 referenda and vetoing dangerous or malicious referenda. For more information on the council, see the
@@ -15,10 +17,12 @@ councillors in the elections.
 
 ## Voting for Councillors
 
-Voting for councillors requires you to reserve 
-{{ polkadot: ~20.064 DOT :polkadot }}{{ kusama: ~0.067 KSM :kusama }} as a base amount
-and an amount per vote {{ polkadot: ~0.032 DOT :polkadot }}{{ kusama: ~0.00011 KSM :kusama }}. You can then bond whatever amount you wish to put 
-behind your vote. See the [democracy guide](maintain-guides-democracy.md) for more information.
+Voting for councillors requires you to reserve
+{{ polkadot: <RPC network="polkadot" path="consts.phragmenElection.votingBondBase" defaultValue={200640000000} filter = "humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.phragmenElection.votingBondBase" defaultValue={66879997200} filter = "humanReadable"/> :kusama }}
+as a base amount and an amount of
+{{ polkadot: <RPC network="polkadot" path="consts.phragmenElection.votingBondFactor" defaultValue={320000000} filter = "humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.phragmenElection.votingBondFactor" defaultValue={106665600} filter = "humanReadable"/> :kusama }}
+per vote. You can then bond whatever amount you wish to put behind your vote. See the
+[democracy guide](maintain-guides-democracy.md) for more information.
 
 :::info Voting and staking locks can overlap
 


### PR DESCRIPTION
I updated the base amounts for both Kusama and Polkadot using the constant phragmenElection.votingBondBase .  To avert users from encountering insufficient funds errors I rounded up.  

As an addition, I've added amounts for each vote sourced from phragmenElection.votingBondFactor.  I tried to keep the significant numbers to the same degree but in some cases the numbers were too round to allow for this.