### PR TITLE
Remove Staging build CI for PRs

### DIFF
--- a/.github/workflows/deploy-kusama-staging.yml
+++ b/.github/workflows/deploy-kusama-staging.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/deploy-polkadot-staging.yml
+++ b/.github/workflows/deploy-polkadot-staging.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build:


### PR DESCRIPTION
To give a better context -

We needed the staging sites to check the redirects feature on Docusaurus that could only be tested on deployed sites. Other than that, this CI check is redundant as rest of the features can be tested on a local machine.

Solution - Just run the CI for staging websites when a PR is merged to the master branch.