### PR TITLE
Suggestion on toggle to unbond all funds

### DIFF
--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -119,7 +119,7 @@ At any point in time after joining the pool, a member can start the process of e
 `unbond` will unbond part or all of the member's funds.
 
 On Polkadot JS Apps UI, navigate to Network > Staking > Accounts > Pooled and click on the three
-vertical dots and click on Unbond funds.
+vertical dots and click on Unbond funds.  In the event that you would like to unbond all funds, it is highly recommended that you use the 'all unbonded' toggle.  Doing so ensures that all funds are unbonded even some that may not display due to rounding by the UI.  
 
 ### Withdraw unbonded funds
 
@@ -134,8 +134,9 @@ vertical dots and click on Withdraw unbonded.
 
 - A member cannot vote (e.g. in Referenda or for Council members) with their nominated funds. This
   may be changed in the future once accounts are afforded the ability to split votes.
-- In order for a member to switch pools they must wait for the normal 28 era unbonding process.
+- In order for a member to switch pools all funds from the account must be unbonded.  This process takes 28 eras.
 - A member can partially unbond the staked funds in the pool (at most 16 partial unbonds).
+
 
 :::info Kusama Pool Stats
 - There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPoolMembers" defaultValue={65536} /> members (there are currently <RPC network="kusama" path="query.nominationPools.counterForPoolMembers" defaultValue={149} /> members).


### PR DESCRIPTION
Sorry to be the Wiki pest these days...

We were troubleshooting an issue with a user on discord and through this discussion I'm making some of these updates.  It appears the user manually typed in the amount to unbond leaving some trace KSM in the pool.  The pool still recognized him as a member and didn't allow him to join another.  

While I didn't make the adjustment, could you please confirm under limitations that a member can have 16 partial unbonds, I think this might be 8 but I am not confident.

```
//! In order to leave, a member must take two steps.
//!
//! First, they must call [`Call::unbond`]. The unbond extrinsic will start the unbonding process by
//! unbonding all or a portion of the members funds.
//!
//! > A member can have up to [`Config::MaxUnbonding`] distinct active unbonding requests.
//!
//! Second, once [`sp_staking::StakingInterface::bonding_duration`] eras have passed, the member can
//! call [`Call::withdraw_unbonded`] to withdraw any funds that are free.

pub static MaxUnbonding: u32 = 8
```
[Link to code reference](https://github.com/paritytech/substrate/blob/4a19d408095ebcb47840ad1f2f086f53a0020cb7/frame/nomination-pools/src/mock.rs#L31)