### PR TITLE
Update refs to Max Validators in Active set

### DIFF
--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -666,8 +666,8 @@ return will be less, encouraging some users to withdraw.
 
 ## How many validators does Polkadot have?
 
-Polkadot started with 20 open validator positions and has increased gradually to
-<RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/>
+Polkadot started with 20 open validator positions and has increased gradually 
+to <RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/>.
 The top bound on the number of validators has not been determined yet, but should only be limited by 
 the bandwidth strain of the network due to peer-to-peer message passing. The estimate of the number of
 validators that Polkadot will have at maturity is around 1000. Kusama, Polkadot's canary network, currently 

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -667,11 +667,11 @@ return will be less, encouraging some users to withdraw.
 ## How many validators does Polkadot have?
 
 Polkadot started with 20 open validator positions and has increased gradually to
-{{ polkadot: <RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/> :polkadot }}
+<RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/>
 The top bound on the number of validators has not been determined yet, but should only be limited by 
 the bandwidth strain of the network due to peer-to-peer message passing. The estimate of the number of
 validators that Polkadot will have at maturity is around 1000. Kusama, Polkadot's canary network, currently 
-has {{ kusama: <RPC network="kusama" path="query.staking.validatorCount" defaultValue={1000}/> :kusama }} 
+has <RPC network="kusama" path="query.staking.validatorCount" defaultValue={1000}/>
 validator slots in the active set.
 
 ## Resources

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -666,11 +666,13 @@ return will be less, encouraging some users to withdraw.
 
 ## How many validators does Polkadot have?
 
-Polkadot started with 20 open validator positions and has increased gradually to 297. The top bound
-on the number of validators has not been determined yet, but should only be limited by the bandwidth
-strain of the network due to peer-to-peer message passing. The estimate of the number of validators
-that Polkadot will have at maturity is around 1000. Kusama, Polkadot's canary network, currently has
-900 validator slots in the active set.
+Polkadot started with 20 open validator positions and has increased gradually to
+{{ polkadot: <RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/> :polkadot }}
+The top bound on the number of validators has not been determined yet, but should only be limited by 
+the bandwidth strain of the network due to peer-to-peer message passing. The estimate of the number of
+validators that Polkadot will have at maturity is around 1000. Kusama, Polkadot's canary network, currently 
+has {{ kusama: <RPC network="kusama" path="query.staking.validatorCount" defaultValue={1000}/> :kusama }} 
+validator slots in the active set.
 
 ## Resources
 


### PR DESCRIPTION
The values were hard coded earlier. This will enable the number to be fetched from the chain state directly