### PR TITLE
Remove "undetected" when discussing the Monero inflation bug

### DIFF
--- a/polkadot-wiki/translated_docs/ar/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ar/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/de/learn-keys.md
+++ b/polkadot-wiki/translated_docs/de/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/es-ES/learn-keys.md
+++ b/polkadot-wiki/translated_docs/es-ES/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/fi/learn-keys.md
+++ b/polkadot-wiki/translated_docs/fi/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/fil-PH/learn-keys.md
+++ b/polkadot-wiki/translated_docs/fil-PH/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/fr/learn-keys.md
+++ b/polkadot-wiki/translated_docs/fr/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/hi-IN/learn-keys.md
+++ b/polkadot-wiki/translated_docs/hi-IN/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/hr-HR/learn-keys.md
+++ b/polkadot-wiki/translated_docs/hr-HR/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/id-ID/learn-keys.md
+++ b/polkadot-wiki/translated_docs/id-ID/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/it/learn-keys.md
+++ b/polkadot-wiki/translated_docs/it/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/ja/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ja/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/ko/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ko/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/ms-MY/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ms-MY/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/pt-BR/learn-keys.md
+++ b/polkadot-wiki/translated_docs/pt-BR/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/pt-PT/learn-keys.md
+++ b/polkadot-wiki/translated_docs/pt-PT/learn-keys.md
@@ -60,7 +60,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/ru/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ru/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/sk-SK/learn-keys.md
+++ b/polkadot-wiki/translated_docs/sk-SK/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/th-TH/learn-keys.md
+++ b/polkadot-wiki/translated_docs/th-TH/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/tr/learn-keys.md
+++ b/polkadot-wiki/translated_docs/tr/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/ur-IN/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ur-IN/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/ur-PK/learn-keys.md
+++ b/polkadot-wiki/translated_docs/ur-PK/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 

--- a/polkadot-wiki/translated_docs/zh-CN/learn-keys.md
+++ b/polkadot-wiki/translated_docs/zh-CN/learn-keys.md
@@ -61,7 +61,7 @@ BABE 需要适用于[可验证随机函数 (VRF)](learn-randomness#vrfs)以及�
 
 ### 什么是 `sr25519` 并它是从何而来?
 
-某些情况下: Twisted Edward's 曲线 25519 上的 Schnorr 签名被认为是安全，但是 Ed25519 并没有完全解决其错误。最值得注意的是，[ Monero 和所有其他 CryptoNote 货币](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html)很容易受到双花的利用，这有可能导致未被发现的无限通胀。
+某些情况下: Twisted Edward's 曲线 25519 上的 Schnorr 签名被认为是安全，但是 Ed25519 并没有完全解决其错误。最值得注意的是，[ Monero 和所有其他 CryptoNote 货币](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html)很容易受到双花的利用，这有可能导致未的无限通胀。
 
 这些漏洞的源于是由于 Ed25519 中的特点，即其 8 的协因子。曲线的协因子是深奥的细节，这可能对更复杂协议的安全实现产生可怕的后果。
 

--- a/polkadot-wiki/translated_docs/zh-TW/learn-keys.md
+++ b/polkadot-wiki/translated_docs/zh-TW/learn-keys.md
@@ -61,7 +61,7 @@ But ultimately the benefits of using Schnorr signatures outweigh the tradeoffs, 
 
 ### What is `sr25519` and where did it come from?
 
-Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to undetected, infinite inflation.
+Some context: The Schnorr signatures over the Twisted Edward's Curve25519 are considered secure, however Ed25519 has not been completely devoid of its bugs. Most notably, [Monero and all other CryptoNote currencies](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html) were vulnerable to a double spend exploit that could have potentially led to infinite inflation.
 
 These exploits were due to one peculiarity in Ed25519, which is known as its cofactor of 8. The cofactor of a curve is an esoteric detail that could have dire consequences for the security of implementation of more complex protocols.
 


### PR DESCRIPTION
The presence of torsion is detectable, and the Monero blockchain has 
been confirmed to have not been exploited. This statement, as-is, casted 
doubt onto the current legitimacy of its monetary status with a faulty 
premise.

I do not speak Chinese and used Google Translate to remove characters in 
a similar location until Google Translate no longer said "undetected". I 
cannot confirm I did it properly, nor can I confirm the Chinese is 
correct in general. Google Translate claims it's all present tense, 
despite this being a historical footnote (and a valuable one at that).