### PR TITLE
Bump status badge dependecy version

### DIFF
--- a/.github/workflows/status-badges.yml
+++ b/.github/workflows/status-badges.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check and update badges
-        uses: w3f/status-badges@v1.1
+        uses: w3f/status-badges@v1.2
         with:
           path: 'docs/build/build-open-source.md'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrade to support the latest changes from https://github.com/lucasvanmol/status-badges/pull/13