### PR TITLE
Add workflow_dispatch trigger for Polkadot & Kusama staging build actions

### DIFF
--- a/.github/workflows/deploy-kusama-staging.yml
+++ b/.github/workflows/deploy-kusama-staging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deploy-polkadot-staging.yml
+++ b/.github/workflows/deploy-polkadot-staging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
With `workflow_dispatch` enabled, the GitHub Actions menu provides you with a UI to manually run the action on a specific branch.  This will allow you to manually select/deploy a specific branch to staging for the Polkadot Wiki or Kusama Guide.

Here is a sample from the `Update Status Badge` action that already has this feature enabled:

![image](https://user-images.githubusercontent.com/13341935/186245953-cd12097b-7fdd-4294-a1df-13d45251efc0.png)
