### PR TITLE
Added tip link & reorg tipping example

### DIFF
--- a/docs/learn/learn-treasury.md
+++ b/docs/learn/learn-treasury.md
@@ -27,9 +27,9 @@ Treasury payout is an automatic process:
 percentage of its funds - thereby causing deflationary pressure. This encourages the spending of the 
 funds in the Treasury by Polkadot's governance system. 
 {{ polkadot: This percentage is currently at 1%
-on Polkadot. :polkadot }}{{ kusama: This percentage is currently 0.2% on Kusama, with the amount currently 
+on Polkadot :polkadot }}{{ kusama: This percentage is currently 0.2% on Kusama, with the amount currently 
 going to [Society](https://guide.kusama.network/docs/maintain-guides-society-kusama) rather than being
-burned. :kusama }}.
+burned :kusama }}.
 
 When a stakeholder wishes to propose a spend from the Treasury, they must reserve a deposit of at
 least 5% of the proposed spend (see below for variations). This deposit will be slashed if the
@@ -150,7 +150,7 @@ You will notice the "spend period" at the top of the Treasury UI.
 
 Next to the proposals process, a separate system for making tips exists for the Treasury. Tips can
 be suggested by anyone and are supported by members of the Council. Tips do not have any definite
-value; the final value of the tip is decided based on the median of all tips issued by the tippers.
+value, and the final value of the tip is decided based on the median of all tips issued by the tippers.
 
 Currently, the tippers are the same as the members of the Council. However, being a tipper is not
 the direct responsibility of the Council, and at some point the Council and the tippers may be
@@ -161,16 +161,22 @@ tip. During that time frame, the other members of the tipping group can still is
 do not have to. Once the window closes, anyone can call the `close_tip` extrinsic, and the tip will
 be paid out.
 
-There are two types of tips: public and tipper-initiated. With public tips, a small bond is required
+There are two types of tips: 
+
+- public: A small bond is required
 to place them. This bond depends on the tip message length, and a fixed bond constant defined on
 chain, currently 
 {{ polkadot: <RPC network="polkadot" path="consts.tips.tipReportDepositBase" defaultValue={10000000000} filter="humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.tips.tipReportDepositBase" defaultValue={166000000000} filter="humanReadable"/> :kusama }}.
 Public tips carry a finder's fee of
 {{ polkadot: <RPC network="polkadot" path="consts.tips.tipFindersFee" defaultValue={20}/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.tips.tipFindersFee" defaultValue={20}/> :kusama }}% 
-which is paid out from the total amount. Tipper-initiated tips, i.e. tips
+which is paid out from the total amount.
+- tipper-initiated: Tips
 that a Council member published, do not have a finder's fee or a bond.
 
-To better understand the process a tip goes through until it is paid out, let's consider an example.
+:::info For information about how to submit a tip from the Treasury you can read [this support article](https://support.polkadot.network/support/solutions/articles/65000181971).
+:::
+
+To better understand the process a tip goes through until it is paid out, let's consider the example below.
 
 ### Example
 
@@ -179,7 +185,7 @@ Alice has noticed this and decides to report Bob as deserving a tip from the Tre
 is composed of three members Charlie, Dave, and Eve.
 
 Alice begins the process by issuing the `report_awesome` extrinsic. This extrinsic requires two
-arguments, a reason and the address to tip. Alice submits Bob's address with the reason being a
+arguments, a reason and the beneficiary. Alice submits Bob's address with the reason being a
 UTF-8 encoded URL to a post on
 {{ polkadot: [Polkassembly](https://polkadot.polkassembly.io) :polkadot }}
 {{ kusama: [Polkassembly](https://kusama.polkassembly.io) :kusama }} that explains her reasoning for
@@ -188,21 +194,13 @@ why Bob deserves the tip.
 As mentioned above, Alice must also lock up a deposit for making this report. The deposit is the
 base deposit as set in the chain's parameter list, plus the additional deposit per byte contained in
 the reason. This is why Alice submitted a URL as the reason instead of the explanation directly: it
-was cheaper for her to do so.
-
-For her trouble, Alice is able to claim the eventual finder's fee if the tip is approved by the
+was cheaper for her to do so. For her trouble, Alice is able to claim the eventual finder's fee if the tip is approved by the
 tippers.
 
 Since the tipper group is the same as the Council, the Council must now collectively (but also
-independently) decide on the value of the tip that Bob deserves.
-
-Charlie, Dave, and Eve all review the report and make tips according to their personal valuation of
-the benefit Bob has provided to Kusama.
-
-For example:
-
-Charlie tips {{ polkadot: 10 DOT :polkadot }}{{ kusama: 1 KSM :kusama }}. Dave tips
-{{ polkadot: 30 DOT :polkadot }}{{ kusama: 3 KSM :kusama }}. Eve tips
+independently) decide on the value of the tip that Bob deserves. Charlie, Dave, and Eve all review the report and make tips according to their personal valuation of
+the benefit Bob has provided to {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}. Charlie tips {{ polkadot: 10 DOT :polkadot }}{{ kusama: 1 KSM :kusama }}, Dave tips
+{{ polkadot: 30 DOT :polkadot }}{{ kusama: 3 KSM :kusama }}, and Eve tips
 {{ polkadot: 100 DOT :polkadot }}{{ kusama: 10 KSM :kusama }}.
 
 The tip could have been closed out with only two of the three tippers. Once more than half of the
@@ -210,10 +208,8 @@ tippers group have issued tip valuations, the countdown to close the tip will be
 the third tipper issued their tip before the end of the closing period, so all three were able to
 make their tip valuations known.
 
-Now the actual tip that will be paid out to Bob is the median of these tips, so Bob will be paid out
-{{ polkadot: 30 DOT :polkadot }}{{ kusama: 3 KSM :kusama }} from the Treasury.
-
-In order for Bob to be paid his tip, some account must call the `close_tip` extrinsic at the end of
+The actual tip that will be paid out to Bob is the median of these tips, so Bob will be paid out
+{{ polkadot: 30 DOT :polkadot }}{{ kusama: 3 KSM :kusama }} from the Treasury. In order for Bob to be paid his tip, some account must call the `close_tip` extrinsic at the end of
 the closing period for the tip. This extrinsic may be called by anyone.
 
 ## Bounties Spending


### PR DESCRIPTION
Added link to the support page about how to tip from the treasury. Reorganised the tipping example.