### PR TITLE
Update migrated support content for Parachain Slots Auction

### DIFF
--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -69,8 +69,14 @@ propagating through the entire ending period, where a snapshot is taken at each 
 ending period to capture the winners for that given block. At the end of the period, one of the
 snapshots is randomly selected to determine the winner of the auction.
 
-This process executes in the next epoch after the ending period. **The parachain candidate with the
-highest bid at the ending time chosen by the VRF wins the slot auction**.
+:::info The parachain candidate with the highest bid at the ending time chosen by the Verifiable Random Function wins the slot auction.
+
+:::
+
+A parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts exactly
+one week from the start: 1 day and 18 hours for the starting period,
+{{ polkadot: <RPC network="polkadot" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :kusama }}
+days for the ending period (candle auction phase) and 6 hours for determining the auction winner.
 
 :::info
 
@@ -78,12 +84,6 @@ highest bid at the ending time chosen by the VRF wins the slot auction**.
 during these six hours when the winning block for the auction is being determined on-chain.
 
 :::
-
-With 1 day and 18 hours for the starting period,
-{{ polkadot: <RPC network="polkadot" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :kusama }}
-days for the ending period (candle auction phase) and 6 hours for determining the auction winner, a
-parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts exactly
-one week from the start.
 
 More details on this are available in the [Network Implementation](#network-implementation) section.
 

--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -6,18 +6,18 @@ description: Learn about slot auctions.
 keywords: [auction, slot auctions, parachain, bidding]
 slug: ../learn-auction
 ---
+import RPC from "./../../components/RPC-Connection"
 
-For a [parachain](learn-parachains.md) to be added to Polkadot it must inhabit one of the available
-parachain slots. A parachain slot is a scarce resource on Polkadot and only a limited number will be
-available. As parachains ramp up, there may only be a few slots that are unlocked every few months.
+For a [parachain](learn-parachains.md) to be added to {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} it must inhabit one of the available
+parachain slots. A parachain slot is a scarce resource on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} as only a limited number are
+available. As parachains ramp up, there may only be a few slots unlocked every few months.
 The goal is to eventually have 100 parachain slots available on {{ polkadot: Polkadot :polkadot }}
 {{ kusama: Kusama :kusama }} (these will be split between parachains and the
 [parathread pool](learn-parathreads.md)). If a parachain wants to have guaranteed block inclusion at
 every Relay Chain block, it must acquire a parachain slot.
 
 The parachain slots will be leased according to an unpermissioned
-[candle auction](https://en.wikipedia.org/wiki/Candle_auction) that has been slightly modified to be
-secure on a blockchain.
+[candle auction](https://en.wikipedia.org/wiki/Candle_auction), with several alterations related to improving security while operating on a blockchain. See [Rationale](#rationale) for additional details.
 
 :::info Auction Schedule
 
@@ -31,36 +31,33 @@ on the auctions page of the {{ polkadot: [Polkadot website](https://polkadot.net
 ## Mechanics of a Candle Auction
 
 Candle auctions are a variant of open auctions where bidders submit bids that are increasingly
-higher and the highest bidder at the conclusion of the auction is considered the winner.
+higher. The highest bidder at the conclusion of the auction is considered the winner.
 
-Candle auctions were originally employed in 16th century for the sale of ships and get their name
-from the "inch of a candle" that determined the open period of the auction. When the flame
-extinguished and the candle went out, the auction would suddenly terminate and the standing bid at
-that point would win.
+Candle auctions were originally employed in the 16th century for the sale of ships. The name is derived from the system by which the auction length was determined. The phrase "inch of a candle" refers to the length of time required for a candle to burn down 1 inch. When the flame
+extinguishes and the candle goes out, the auction terminates and the standing bid at
+that point in time prevails the winner.
 
 When candle auctions are used online, they require a random number to decide the moment of
 termination. Parachain slot auctions differ slightly from a normal candle auction in that they do
 not randomly terminate the auction. Instead, they run for an entire fixed duration and the winner is
 randomly chosen retroactively.
 
-The candle auction on Polkadot is split into two parts: the _opening period_ which is in effect
-immediately after the auction starts. This period lasts for one day and eighteen hours and serves as
-a buffer time for parachain candidates to setup their initial bids, and likely start executing their
-strategy on how to win the slot auction. During the opening phase, bids will continue to be
-accepted, but they do not have any effect on the outcome of the auction.
+The candle auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} is split into two parts: 
 
-The opening period then transitions into an _ending period_ of five days, where the auction is
-subject to end based on the candle auction mechanism.
+1. The *opening period* which is in effect immediately after the auction starts. This period lasts for one day and eighteen hours and serves as a buffer time for parachain candidates to setup their initial bids, and likely start executing their
+strategy on how to win the slot auction. During the opening phase, bids will continue to be accepted, but they do not have any effect on the outcome of the auction.
 
-The auction’s ending time can be any time within this ending period, and is automatically and
-randomly chosen by the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The probability
-of winning the auction is equal to the number of blocks with a winning bid divided by the total
+2. The _ending period_ follows the opening period for five additional days, where the auction is subject to end based on the candle auction mechanism.
+
+The auction’s ending time can occur any time within the ending period.
+This time is automatically and randomly chosen by the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The probability
+of winning the auction is equal to the number of blocks that contain a winning bid, divided by the total
 number of blocks in the ending period. The random ending is managed by propagating through the
 entire ending period, where a snapshot is taken at each block within the ending period to capture
-the winners during that block. At the end of the period, one of the snapshots is randomly selected
+the winners for that given block. At the end of the period, one of the snapshots is randomly selected
 to determine the winner of the auction.
 
-This process executes in the next epoch (which lasts for six hours on Polkadot) after the ending
+This process executes in the next epoch after the ending
 period. **The parachain candidate with the highest bid at the ending time chosen by the VRF wins the
 slot auction**.
 
@@ -71,12 +68,12 @@ during these six hours when the winning block for the auction is being determine
 
 :::
 
-With one day and eighteen hours for the starting period, five days for the ending period (candle
-auction phase) and six hours for determining the auction winner, a parachain auction on Polkadot
-lasts exactly one week from the start.
+With 1 day and 18 hours for the starting period,
+{{ polkadot: <RPC network="polkadot" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :kusama }}
+days for the ending period (candle auction phase) and 6 hours for determining the auction winner,
+a parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts exactly one week from the start.
 
-More details on this is available in the [Polkadot Implementation](#polkadot-implementation)
-section.
+More details on this are available in the [Network Implementation](#network-implementation) section.
 
 ### [Randomness](learn-randomness.md) in action
 
@@ -98,7 +95,7 @@ or during the auction.
 
   :::
 
-- The winning sample during the ending period turned out to have the `index 1078`.
+- The winning sample during the ending period had the `index 1078`.
   
   :::note Sample 1078 is the winner
 
@@ -107,16 +104,16 @@ or during the auction.
 
   :::
 
-- The parent block was a new BABE session in the 'Logs', which updated the randomness that was used
+- The parent block was a new BABE session in the `Logs`, which updated the randomness that was used
   to select that [sample index](https://kusama.subscan.io/block/9434277).
 
   :::note Inspecting the block state
 
-  You'd be able to inspect the state at the end of `block 9434277` and see the sample indices with
-  an [archive node](../maintain/maintain-sync.md####types-of-nodes). The digest in the 'Logs' of
+  You can inspect the state at the end of `block 9434277` to see the sample indices with
+  an [archive node](../maintain/maintain-sync.md####types-of-nodes). The digest in the `Logs` of
   `9434277` is decodable and contains the random value as well as the BABE authorities.
 
-- As a result, the winner of this auction did not turn out to be the highest bid during the full
+- As a result, the winner of this auction was not the highest bid during the full
   duration.
 
 :::
@@ -139,45 +136,41 @@ auction mechanism is sub-optimal because it has not discovered the true price of
 item has not gone to the actor who valued it the most.
 
 On blockchains this problem may be even worse, since it potentially gives the producer of the block
-an opportunity to snipe any auction at the last concluding block by adding it themselves and/or
+an opportunity to snipe any auction at the last concluding block by adding it themselves while
 ignoring other bids. There is also the possibility of a malicious bidder or a block producer trying
 to _grief_ honest bidders by sniping auctions.
 
-For this reason, [Vickrey auctions](https://en.wikipedia.org/wiki/Vickrey_auction), a variant of
-second price auction in which bids are hidden and only revealed in a later phase, have emerged as a
-well-regarded mechanic. For example, it is implemented as the mechanism to auction human readable
-names on the [ENS](../general/ens.md). The Candle auction is another solution that does not need the
-two-step commit and reveal schemes (a main component of Vickrey auctions), and for this reason
+For this reason, [Vickrey auctions](https://en.wikipedia.org/wiki/Vickrey_auction), a type of sealed-bid auction where bids are hidden and only revealed at a later phase, have emerged as a
+well-regarded mechanic. For example, this mechanism is leveraged to auction human readable
+names on the [ENS](../general/ens.md). The Candle auction is another solution that does not require a
+two-step commit and reveal schemes (a main component of Vickrey auctions), which
 allows smart contracts to participate.
 
-Candle auctions allow everyone to always know the states of the bid, but not when the auction will
-be determined to have ended. This helps to ensure that bidders are willing to bid their true bids
-early. Otherwise, they might find themselves in the situation that the auction was determined to
-have ended before they even bid.
+Candle auctions allow everyone to always know the states of the bid, but they do not reveal when the auction has officially ended. This helps to ensure that bidders are willing to make their true bids
+early. Otherwise, they may find themselves in a situation where the auction was determined to
+have ended before having an opportunity to bid.
 
-## Polkadot Implementation
+## Network Implementation
 
-Polkadot will use a _random beacon_ based on the VRF that's used also in other places of the
-protocol. The VRF will provide the base of the randomness, which will retroactively determine the
-end-time of the auction.
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} will use a *random beacon* based on the [Verifiable Random Function (VRF)](learn-randomness.md##vrf).
+The VRF will provide the base of the randomness, which will retroactively determine the end-time of the auction.
 
 The slot durations are capped to {{ polkadot: 2 years and divided into 3-month periods :polkadot }}
 {{ kusama: 1 year and divided into 6-week periods :kusama }}; Parachains may lease a slot for any
 combination of periods of the slot duration. Parachains may lease more than one slot over time,
-meaning that they could extend their lease to Polkadot past the maximum duration by leasing a
+meaning that they could extend their lease to the network past the maximum duration by leasing a
 contiguous slot.
 
 :::note Individual parachain slots are fungible. 
 
-This means that parachains do not need to always inhabit the same slot, but as long as a 
-parachain inhabits any slot it can continue as a parachain.
+This means that parachains do not need to always inhabit the same slot, however they always must maintain a slot to remain a parachain.
 
 :::
 
 ## Bidding
 
-Parachains, or parachain teams, can bid in the auction by specifying the slot range that they want
-to lease as well as the number of tokens they are willing to reserve. Bidders can be either ordinary
+Parachains or parachain teams, bid in the auction by specifying the slot range that they want
+to lease and the number of tokens they are willing to reserve. Bidders can be either ordinary
 accounts, or use the [crowdloan functionality](learn-crowdloans.md) to source tokens from the
 community.
 
@@ -202,7 +195,8 @@ _Each period of the range 1 - 4 represents a
 
 Bidders will submit a configuration of bids specifying the token amount they are willing to bond and
 for which periods. The slot ranges may be any of the periods 1 - `n`, where `n` is the number of
-periods available for a slot (`n` will be 8 for both Polkadot and Kusama).
+periods available for a slot.
+(`n`={{ polkadot: <RPC network="polkadot" path="consts.auctions.leasePeriodsPerSlot" defaultValue={8}/> for Polkadot :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.leasePeriodsPerSlot" defaultValue={8}/> for Kusama :kusama }})
 
 :::note
 
@@ -239,12 +233,11 @@ amount of tokens held over the entire lease duration of the parachain slot. This
 highest bidder for any given slot lease period might not always win (see the
 [example below](#examples)).
 
-A random number, which is based on the VRF used by Polkadot, is determined at each block.
+A random number, which is based on the [VRF](learn-randomness.md##vrf) used by {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, is determined at each block.
 Additionally, each auction will have a threshold that starts at 0 and increases to 1. The random
 number produced by the VRF is examined next to the threshold to determine if that block is the end
-of the auction within the so-called _ending period_. Additionally, the VRF will pick a block from
-the last epoch to take the state of bids from (to mitigate some types of attacks from malicious
-validators).
+of the auction within the so-called *ending period*. Additionally, the VRF will pick a block from
+the last epoch to access the state of bids which can help aid in mitigating some types of attacks from malicious validators.
 
 ### Examples
 
@@ -267,7 +260,7 @@ Emily - 40 \* 4 = 160 for range 1 - 4
 
 Although Dave had the highest bid in accordance to token amount, when we do the calculations we see
 that since he only bid for a range of 4, he would need to share the slot with Emily who bid much
-less. Together Dave's and Emily's bids only equals a valuation of `560`.
+less. Together Dave and Emily's bids only equals a valuation of `560`.
 
 Charlie's valuation for the entire range is `600`. Therefore Charlie is awarded the complete range
 of the parachain slot.
@@ -278,20 +271,24 @@ Before the slot lease expires, parachains have to bid and win another auction fo
 lease. To avoid any downtime in connectivity and minimize the risk of losing a subsequent auction, 
 parachain teams need to plan ahead to bid for the lease extension before their current 
 lease period ends. Explained in the section above, each auction lets you bid for 8 LPs
-(Lease Periods) which enables two scenarios for the parachain's lease extension -
+(Lease Periods) which enables two scenarios for the parachain's lease extension.
 
 ### Lease Extension with Overlapping Slots
 
-Acquire a slot where the first LP is before the last LP of the current slot.
+Acquire a slot where the first lease period is before the last lease period of the current slot.
 
-- Register a new 'paraId'
-- Win a slot auction with the new 'paraId'
+- Register a new `paraId`
+- Win a slot auction with the new `paraId`
 
-The parachain team has access to two slots: one that will end soon, and one that just started.
+The parachain team has access to two slots: 
+
+- one that will end soon
+- one that just started
+
 Both slots have at least one LP in common. When the old slot transitions to their last LP, 
 the parachain can [swap](https://github.com/paritytech/polkadot/pull/4772) the slots. This can be 
-done via [on-chain governance](https://kusama.polkassembly.io/post/1491). The 'swap'
-call is available in the 'registrar' pallet. 
+done via [on-chain governance](https://kusama.polkassembly.io/post/1491). The `swap`
+call is available in the `registrar` pallet. 
 
 ![Parachain Slot Swap](../assets/para-swap.png)
 
@@ -308,7 +305,7 @@ on the old slot, thus ensuring continuity of the lease.
 ### Lease Extension with Non-Overlapping Slots
 
 Acquire a slot where the first LP starts right after the end of the last LP of the current slot.
-In this case, the parachain can bid directly with their current 'paraId', and it will be automatically 
+In this case, the parachain can bid directly with their current `paraId`, and it will be automatically 
 extended without the need of swapping. This method has the advantage of not having superfluous LP's on 
 different slots owned by the same team, however it has the disadvantage of losing flexibility on when 
 to win a new slot: if the team does not win the exact slot, then it will suffer some downtime until 
@@ -318,39 +315,36 @@ it wins a new slot.
 
 ### Why doesn't everyone bid for the max length?
 
-For the duration of the slot the tokens bid in the auction will be locked up. This means that there
-are opportunity costs from the possibility of using those tokens for something else. For parachains
-that are beneficial to Polkadot, this should align the interests between parachains and the Polkadot
-Relay Chain.
+For the duration of the slot, the tokens used for bidding in the auction are locked up. This suggests there is an opportunity cost associated with bidding, as the tokens could have been leveraged for something else.
 
 ### How does this mechanism help ensure parachain diversity?
 
 The method for dividing the parachain slots into intervals was partly inspired by the desire to
-allow for a greater amount of parachain diversity, and prevent particularly large and well-funded
+allow for a greater amount of parachain diversity, while preventing particularly large and well-funded
 parachains from hoarding slots. By making each period a {{ polkadot: three-month duration but the
 overall slot a 2-year duration :polkadot }}{{ kusama: 6-week duration but the overall slot a 1-year
-duration :kusama }}, the mechanism can cope with well-funded parachains that will ensure they secure
+duration :kusama }}, the mechanism can cope with well-funded parachains, ensuring they secure
 a slot at the end of their lease, while gradually allowing other parachains to enter the ecosystem
 to occupy the durations that are not filled. For example, if a large, well-funded parachain has
 already acquired a slot for range 1 - 8, they would be very interested in getting the next slot that
-would open for 2 - 9. Under this mechanism that parachain could acquire just the period 9 (since
-that is the only one it needs) and allow range 2 - 8 of the second parachain slot to be occupied by
-another.
+would open for 2 - 9. Under this mechanism, that parachain could acquire just period 9 (since
+that is the only one required) and allow the 2 - 8  range of the second parachain slot to be occupied by
+another party.
 
 ### Why is randomness difficult on blockchains?
 
-Randomness is problematic for blockchain systems. Generating a random number trustlessly on a
-transparent and open network in which other parties must be able to verify opens the possibility for
+Generating a random number trustlessly on a
+transparent and open network opens up the possibility for bad
 actors to attempt to alter or manipulate the randomness. There have been a few solutions that have
-been put forward, including hash-onions like [RANDAO](https://github.com/randao/randao) and
+been proposed, including hash-onions like [RANDAO](https://github.com/randao/randao) and
 [verifiable random functions](https://en.wikipedia.org/wiki/Verifiable_random_function) (VRFs). The
-latter is what Polkadot uses as a base for its randomness.
+latter is what {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses as a base for its randomness.
 
 ### Are there other ways of acquiring a slot besides the candle auction?
 
-Another way, besides the candle auction, to acquire a parachain slot is through a secondary market
-where an actor who has already won a parachain slot can resell the slot along with the associated
-deposit of tokens that is locked up to another buyer. This would allow the seller to get liquid
+Aa parachain slot can also be acquired through a secondary market
+where a 3rd party has already won a parachain slot and has the ability to resell the slot along with the associated
+deposit of tokens that are locked up to another buyer. This would allow the seller to get liquid
 tokens in exchange for the parachain slot and the buyer to acquire the slot as well as the deposited
 tokens.
 
@@ -365,7 +359,7 @@ their slots as they would be considered essential to the ecosystem's future.
 The parachain slot auctions are scheduled through the governance. At least 2/3 of the Council can 
 initiate an auction, however, Root origin (via referendum) is needed to cancel an auction. Here is a
 proposal that gives a glimpse of what goes into planning auctions schedule - 
-[Proposed Polkadot Auction Schedule 2022](https://polkadot.polkassembly.io/post/863)
+[Proposed Polkadot Auction Schedule 2022](https://polkadot.polkassembly.io/post/863).
 
 ## Resources
 

--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -363,6 +363,7 @@ proposal that gives a glimpse of what goes into planning auctions schedule -
 
 ## Resources
 
+- [How do Parachain Slot Auctions Work](https://support.polkadot.network/support/solutions/articles/65000182287-how-does-a-parachain-slots-auction-work-)
 - [Parachain Allocation](https://w3f-research.readthedocs.io/en/latest/polkadot/overview/3-parachain-allocation.html) -
   W3F research page on parachain allocation that goes more in depth to the mechanism
 - [Research Update: The Case for Candle Auctions](https://polkadot.network/blog/research-update-the-case-for-candle-auctions/) -

--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -8,8 +8,9 @@ slug: ../learn-auction
 ---
 import RPC from "./../../components/RPC-Connection"
 
-For a [parachain](learn-parachains.md) to be added to {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} it must inhabit one of the available
-parachain slots. A parachain slot is a scarce resource on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} as only a limited number are
+For a [parachain](learn-parachains.md) to be added to {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} 
+it must inhabit one of the available parachain slots. A parachain slot is a scarce resource 
+on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} as only a limited number are
 available. As parachains ramp up, there may only be a few slots unlocked every few months.
 The goal is to eventually have 100 parachain slots available on {{ polkadot: Polkadot :polkadot }}
 {{ kusama: Kusama :kusama }} (these will be split between parachains and the
@@ -17,7 +18,8 @@ The goal is to eventually have 100 parachain slots available on {{ polkadot: Pol
 every Relay Chain block, it must acquire a parachain slot.
 
 The parachain slots will be leased according to an unpermissioned
-[candle auction](https://en.wikipedia.org/wiki/Candle_auction), with several alterations related to improving security while operating on a blockchain. See [Rationale](#rationale) for additional details.
+[candle auction](https://en.wikipedia.org/wiki/Candle_auction), with several alterations related to 
+improving security while operating on a blockchain. See [Rationale](#rationale) for additional details.
 
 :::info Auction Schedule
 
@@ -33,8 +35,10 @@ on the auctions page of the {{ polkadot: [Polkadot website](https://polkadot.net
 Candle auctions are a variant of open auctions where bidders submit bids that are increasingly
 higher. The highest bidder at the conclusion of the auction is considered the winner.
 
-Candle auctions were originally employed in the 16th century for the sale of ships. The name is derived from the system by which the auction length was determined. The phrase "inch of a candle" refers to the length of time required for a candle to burn down 1 inch. When the flame
-extinguishes and the candle goes out, the auction terminates and the standing bid at
+Candle auctions were originally employed in the 16th century for the sale of ships. 
+The name is derived from the system by which the auction length was determined. 
+The phrase "inch of a candle" refers to the length of time required for a candle to burn down 1 inch. 
+When the flame extinguishes and the candle goes out, the auction terminates and the standing bid at
 that point in time prevails the winner.
 
 When candle auctions are used online, they require a random number to decide the moment of
@@ -44,15 +48,18 @@ randomly chosen retroactively.
 
 The candle auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} is split into two parts: 
 
-1. The *opening period* which is in effect immediately after the auction starts. This period lasts for one day and eighteen hours and serves as a buffer time for parachain candidates to setup their initial bids, and likely start executing their
-strategy on how to win the slot auction. During the opening phase, bids will continue to be accepted, but they do not have any effect on the outcome of the auction.
+1. The *opening period* which is in effect immediately after the auction starts. This period lasts for one day
+ and eighteen hours and serves as a buffer time for parachain candidates to setup their initial bids, and likely 
+ start executing their strategy on how to win the slot auction. During the opening phase, bids will continue to 
+ be accepted, but they do not have any effect on the outcome of the auction.
 
-2. The _ending period_ follows the opening period for five additional days, where the auction is subject to end based on the candle auction mechanism.
+2. The _ending period_ follows the opening period for five additional days, where the auction is subject to end 
+ based on the candle auction mechanism.
 
 The auction’s ending time can occur any time within the ending period.
-This time is automatically and randomly chosen by the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The probability
-of winning the auction is equal to the number of blocks that contain a winning bid, divided by the total
-number of blocks in the ending period. The random ending is managed by propagating through the
+This time is automatically and randomly chosen by the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). 
+The probability of winning the auction is equal to the number of blocks that contain a winning bid, divided by the
+total number of blocks in the ending period. The random ending is managed by propagating through the
 entire ending period, where a snapshot is taken at each block within the ending period to capture
 the winners for that given block. At the end of the period, one of the snapshots is randomly selected
 to determine the winner of the auction.
@@ -140,20 +147,23 @@ an opportunity to snipe any auction at the last concluding block by adding it th
 ignoring other bids. There is also the possibility of a malicious bidder or a block producer trying
 to _grief_ honest bidders by sniping auctions.
 
-For this reason, [Vickrey auctions](https://en.wikipedia.org/wiki/Vickrey_auction), a type of sealed-bid auction where bids are hidden and only revealed at a later phase, have emerged as a
+For this reason, [Vickrey auctions](https://en.wikipedia.org/wiki/Vickrey_auction), 
+a type of sealed-bid auction where bids are hidden and only revealed at a later phase, have emerged as a
 well-regarded mechanic. For example, this mechanism is leveraged to auction human readable
 names on the [ENS](../general/ens.md). The Candle auction is another solution that does not require a
 two-step commit and reveal schemes (a main component of Vickrey auctions), which
 allows smart contracts to participate.
 
-Candle auctions allow everyone to always know the states of the bid, but they do not reveal when the auction has officially ended. This helps to ensure that bidders are willing to make their true bids
+Candle auctions allow everyone to always know the states of the bid, but they do not reveal when the 
+auction has officially ended. This helps to ensure that bidders are willing to make their true bids
 early. Otherwise, they may find themselves in a situation where the auction was determined to
 have ended before having an opportunity to bid.
 
 ## Network Implementation
 
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} will use a *random beacon* based on the [Verifiable Random Function (VRF)](learn-randomness.md##vrf).
-The VRF will provide the base of the randomness, which will retroactively determine the end-time of the auction.
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} will use a *random beacon* based on 
+the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The VRF will provide the base of 
+the randomness, which will retroactively determine the end-time of the auction.
 
 The slot durations are capped to {{ polkadot: 2 years and divided into 3-month periods :polkadot }}
 {{ kusama: 1 year and divided into 6-week periods :kusama }}; Parachains may lease a slot for any
@@ -163,7 +173,8 @@ contiguous slot.
 
 :::note Individual parachain slots are fungible. 
 
-This means that parachains do not need to always inhabit the same slot, however they always must maintain a slot to remain a parachain.
+This means that parachains do not need to always inhabit the same slot, however they always must maintain
+a slot to remain a parachain.
 
 :::
 
@@ -315,7 +326,8 @@ it wins a new slot.
 
 ### Why doesn't everyone bid for the max length?
 
-For the duration of the slot, the tokens used for bidding in the auction are locked up. This suggests there is an opportunity cost associated with bidding, as the tokens could have been leveraged for something else.
+For the duration of the slot, the tokens used for bidding in the auction are locked up. This suggests there 
+is an opportunity cost associated with bidding, as the tokens could have been leveraged for something else.
 
 ### How does this mechanism help ensure parachain diversity?
 

--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -89,8 +89,6 @@ More details on this are available in the [Network Implementation](#network-impl
 
 ### [Randomness](learn-randomness.md) in action
 
-:::info Randomness Example
-
 The following example will showcase the randomness mechanics of the candle auction for the ninth
 auction on Kusama. Keep in mind that the candle phase has a uniform termination profile and has an
 equal probability of ending at any given block, and the termination block cannot be predicted before
@@ -124,9 +122,9 @@ or during the auction.
   [archive node](../maintain/maintain-sync.md####types-of-nodes). The digest in the `Logs` of
   `9434277` is decodable and contains the random value as well as the BABE authorities.
 
-- As a result, the winner of this auction was not the highest bid during the full duration.
+  :::
 
-:::
+- As a result, the winner of this auction was not the highest bid during the full duration.
 
 ## Rationale
 
@@ -168,13 +166,12 @@ ended before having an opportunity to bid.
 the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The VRF will provide the base of
 the randomness, which will retroactively determine the end-time of the auction.
 
-The slot durations are capped to {{ polkadot: 2 years and divided into 3-month periods :polkadot }}
-{{ kusama: 1 year and divided into 6-week periods :kusama }}; Parachains may lease a slot for any
+The slot durations are capped to {{ polkadot: 2 years and divided into 3-month periods :polkadot }}{{ kusama: 1 year and divided into 6-week periods :kusama }}. Parachains may lease a slot for any
 combination of periods of the slot duration. Parachains may lease more than one slot over time,
 meaning that they could extend their lease to the network past the maximum duration by leasing a
 contiguous slot.
 
-:::note Individual parachain slots are fungible.
+:::note Individual parachain slots are fungible
 
 This means that parachains do not need to always inhabit the same slot, however they always must
 maintain a slot to remain a parachain.
@@ -211,10 +208,7 @@ for which periods. The slot ranges may be any of the periods 1 - `n`, where `n` 
 periods available for a slot.
 (`n`={{ polkadot: <RPC network="polkadot" path="consts.auctions.leasePeriodsPerSlot" defaultValue={8}/> for Polkadot :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.leasePeriodsPerSlot" defaultValue={8}/> for Kusama :kusama }})
 
-:::note
-
-If you bond tokens with a parachain slot, you cannot stake with those tokens. In this way, you pay
-for the parachain slot by forfeiting the opportunity to earn staking rewards.
+:::note If you bond tokens with a parachain slot, you cannot stake with those tokens. In this way, you pay for the parachain slot by forfeiting the opportunity to earn staking rewards.
 
 :::
 
@@ -273,11 +267,9 @@ Dave - 100 \* 4 = 400 for range 5 - 8
 
 Emily - 40 \* 4 = 160 for range 1 - 4
 
-Although Dave had the highest bid in accordance to token amount, when we do the calculations we see
+Although Dave had the highest bid in accordance to token amount per period, when we do the calculations we see
 that since he only bid for a range of 4, he would need to share the slot with Emily who bid much
-less. Together Dave and Emily's bids only equals a valuation of `560`.
-
-Charlie's valuation for the entire range is `600`. Therefore Charlie is awarded the complete range
+less. Together Dave and Emily's bids only equals a valuation of `560`. Charlie's valuation for the entire range is `600`. Therefore Charlie is awarded the complete range
 of the parachain slot.
 
 ## Parachain Lease Extension

--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -6,20 +6,23 @@ description: Learn about slot auctions.
 keywords: [auction, slot auctions, parachain, bidding]
 slug: ../learn-auction
 ---
+
 import RPC from "./../../components/RPC-Connection"
 
-For a [parachain](learn-parachains.md) to be added to {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} 
-it must inhabit one of the available parachain slots. A parachain slot is a scarce resource 
-on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} as only a limited number are
-available. As parachains ramp up, there may only be a few slots unlocked every few months.
-The goal is to eventually have 100 parachain slots available on {{ polkadot: Polkadot :polkadot }}
+For a [parachain](learn-parachains.md) to be added to
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} it must inhabit one of the available
+parachain slots. A parachain slot is a scarce resource on
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} as only a limited number are
+available. As parachains ramp up, there may only be a few slots unlocked every few months. The goal
+is to eventually have 100 parachain slots available on {{ polkadot: Polkadot :polkadot }}
 {{ kusama: Kusama :kusama }} (these will be split between parachains and the
 [parathread pool](learn-parathreads.md)). If a parachain wants to have guaranteed block inclusion at
 every Relay Chain block, it must acquire a parachain slot.
 
 The parachain slots will be leased according to an unpermissioned
-[candle auction](https://en.wikipedia.org/wiki/Candle_auction), with several alterations related to 
-improving security while operating on a blockchain. See [Rationale](#rationale) for additional details.
+[candle auction](https://en.wikipedia.org/wiki/Candle_auction), with several alterations related to
+improving security while operating on a blockchain. See [Rationale](#rationale) for additional
+details.
 
 :::info Auction Schedule
 
@@ -35,37 +38,39 @@ on the auctions page of the {{ polkadot: [Polkadot website](https://polkadot.net
 Candle auctions are a variant of open auctions where bidders submit bids that are increasingly
 higher. The highest bidder at the conclusion of the auction is considered the winner.
 
-Candle auctions were originally employed in the 16th century for the sale of ships. 
-The name is derived from the system by which the auction length was determined. 
-The phrase "inch of a candle" refers to the length of time required for a candle to burn down 1 inch. 
-When the flame extinguishes and the candle goes out, the auction terminates and the standing bid at
-that point in time prevails the winner.
+Candle auctions were originally employed in the 16th century for the sale of ships. The name is
+derived from the system by which the auction length was determined. The phrase "inch of a candle"
+refers to the length of time required for a candle to burn down 1 inch. When the flame extinguishes
+and the candle goes out, the auction terminates and the standing bid at that point in time prevails
+the winner.
 
 When candle auctions are used online, they require a random number to decide the moment of
 termination. Parachain slot auctions differ slightly from a normal candle auction in that they do
 not randomly terminate the auction. Instead, they run for an entire fixed duration and the winner is
 randomly chosen retroactively.
 
-The candle auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} is split into two parts: 
+The candle auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} is split into
+two parts:
 
-1. The *opening period* which is in effect immediately after the auction starts. This period lasts for one day
- and eighteen hours and serves as a buffer time for parachain candidates to setup their initial bids, and likely 
- start executing their strategy on how to win the slot auction. During the opening phase, bids will continue to 
- be accepted, but they do not have any effect on the outcome of the auction.
+1. The _opening period_ which is in effect immediately after the auction starts. This period lasts
+   for one day and eighteen hours and serves as a buffer time for parachain candidates to setup
+   their initial bids, and likely start executing their strategy on how to win the slot auction.
+   During the opening phase, bids will continue to be accepted, but they do not have any effect on
+   the outcome of the auction.
 
-2. The _ending period_ follows the opening period for five additional days, where the auction is subject to end 
- based on the candle auction mechanism.
+2. The _ending period_ follows the opening period for five additional days, where the auction is
+   subject to end based on the candle auction mechanism.
 
-The auction’s ending time can occur any time within the ending period.
-This time is automatically and randomly chosen by the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). 
-The probability of winning the auction is equal to the number of blocks that contain a winning bid, divided by the
-total number of blocks in the ending period. The random ending is managed by propagating through the
-entire ending period, where a snapshot is taken at each block within the ending period to capture
-the winners for that given block. At the end of the period, one of the snapshots is randomly selected
-to determine the winner of the auction.
+The auction’s ending time can occur any time within the ending period. This time is automatically
+and randomly chosen by the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The
+probability of winning the auction is equal to the number of blocks that contain a winning bid,
+divided by the total number of blocks in the ending period. The random ending is managed by
+propagating through the entire ending period, where a snapshot is taken at each block within the
+ending period to capture the winners for that given block. At the end of the period, one of the
+snapshots is randomly selected to determine the winner of the auction.
 
-This process executes in the next epoch after the ending period. **The parachain candidate with the highest
-bid at the ending time chosen by the VRF wins the slot auction**.
+This process executes in the next epoch after the ending period. **The parachain candidate with the
+highest bid at the ending time chosen by the VRF wins the slot auction**.
 
 :::info
 
@@ -76,9 +81,9 @@ during these six hours when the winning block for the auction is being determine
 
 With 1 day and 18 hours for the starting period,
 {{ polkadot: <RPC network="polkadot" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :kusama }}
-days for the ending period (candle auction phase) and 6 hours for determining the auction winner,
-a parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts 
-exactly one week from the start.
+days for the ending period (candle auction phase) and 6 hours for determining the auction winner, a
+parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts exactly
+one week from the start.
 
 More details on this are available in the [Network Implementation](#network-implementation) section.
 
@@ -96,14 +101,13 @@ or during the auction.
 
   :::note The auction has a full duration equal to `block 9362014` + `72000`
 
-  Here, `block 72000` is the "ending period", which is divided into 
-  **3600 samples of 20 blocks**. Figuratively, the candle
-  is lit, and the candle phase lasts for 72,000 blocks.
+  Here, `block 72000` is the "ending period", which is divided into **3600 samples of 20 blocks**.
+  Figuratively, the candle is lit, and the candle phase lasts for 72,000 blocks.
 
   :::
 
 - The winning sample during the ending period had the `index 1078`.
-  
+
   :::note Sample 1078 is the winner
 
   Sample 1078 refers to the winner as of `block 9362014 + 21560`, which equals
@@ -116,12 +120,11 @@ or during the auction.
 
   :::note Inspecting the block state
 
-  You can inspect the state at the end of `block 9434277` to see the sample indices with
-  an [archive node](../maintain/maintain-sync.md####types-of-nodes). The digest in the `Logs` of
+  You can inspect the state at the end of `block 9434277` to see the sample indices with an
+  [archive node](../maintain/maintain-sync.md####types-of-nodes). The digest in the `Logs` of
   `9434277` is decodable and contains the random value as well as the BABE authorities.
 
-- As a result, the winner of this auction was not the highest bid during the full
-  duration.
+- As a result, the winner of this auction was not the highest bid during the full duration.
 
 :::
 
@@ -147,22 +150,22 @@ an opportunity to snipe any auction at the last concluding block by adding it th
 ignoring other bids. There is also the possibility of a malicious bidder or a block producer trying
 to _grief_ honest bidders by sniping auctions.
 
-For this reason, [Vickrey auctions](https://en.wikipedia.org/wiki/Vickrey_auction), 
-a type of sealed-bid auction where bids are hidden and only revealed at a later phase, have emerged as a
-well-regarded mechanic. For example, this mechanism is leveraged to auction human readable
-names on the [ENS](../general/ens.md). The Candle auction is another solution that does not require a
-two-step commit and reveal schemes (a main component of Vickrey auctions), which
-allows smart contracts to participate.
+For this reason, [Vickrey auctions](https://en.wikipedia.org/wiki/Vickrey_auction), a type of
+sealed-bid auction where bids are hidden and only revealed at a later phase, have emerged as a
+well-regarded mechanic. For example, this mechanism is leveraged to auction human readable names on
+the [ENS](../general/ens.md). The Candle auction is another solution that does not require a
+two-step commit and reveal schemes (a main component of Vickrey auctions), which allows smart
+contracts to participate.
 
-Candle auctions allow everyone to always know the states of the bid, but they do not reveal when the 
+Candle auctions allow everyone to always know the states of the bid, but they do not reveal when the
 auction has officially ended. This helps to ensure that bidders are willing to make their true bids
-early. Otherwise, they may find themselves in a situation where the auction was determined to
-have ended before having an opportunity to bid.
+early. Otherwise, they may find themselves in a situation where the auction was determined to have
+ended before having an opportunity to bid.
 
 ## Network Implementation
 
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} will use a *random beacon* based on 
-the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The VRF will provide the base of 
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} will use a _random beacon_ based on
+the [Verifiable Random Function (VRF)](learn-randomness.md##vrf). The VRF will provide the base of
 the randomness, which will retroactively determine the end-time of the auction.
 
 The slot durations are capped to {{ polkadot: 2 years and divided into 3-month periods :polkadot }}
@@ -171,19 +174,18 @@ combination of periods of the slot duration. Parachains may lease more than one 
 meaning that they could extend their lease to the network past the maximum duration by leasing a
 contiguous slot.
 
-:::note Individual parachain slots are fungible. 
+:::note Individual parachain slots are fungible.
 
-This means that parachains do not need to always inhabit the same slot, however they always must maintain
-a slot to remain a parachain.
+This means that parachains do not need to always inhabit the same slot, however they always must
+maintain a slot to remain a parachain.
 
 :::
 
 ## Bidding
 
-Parachains or parachain teams, bid in the auction by specifying the slot range that they want
-to lease and the number of tokens they are willing to reserve. Bidders can be either ordinary
-accounts, or use the [crowdloan functionality](learn-crowdloans.md) to source tokens from the
-community.
+Parachains or parachain teams, bid in the auction by specifying the slot range that they want to
+lease and the number of tokens they are willing to reserve. Bidders can be either ordinary accounts,
+or use the [crowdloan functionality](learn-crowdloans.md) to source tokens from the community.
 
 ```
 Parachain slots at genesis
@@ -211,8 +213,8 @@ periods available for a slot.
 
 :::note
 
-If you bond tokens with a parachain slot, you cannot stake with those tokens. In this
-way, you pay for the parachain slot by forfeiting the opportunity to earn staking rewards.
+If you bond tokens with a parachain slot, you cannot stake with those tokens. In this way, you pay
+for the parachain slot by forfeiting the opportunity to earn staking rewards.
 
 :::
 
@@ -244,12 +246,12 @@ amount of tokens held over the entire lease duration of the parachain slot. This
 highest bidder for any given slot lease period might not always win (see the
 [example below](#examples)).
 
-A random number, which is based on the [VRF](learn-randomness.md##vrf) used 
-by {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, is determined at each block.
+A random number, which is based on the [VRF](learn-randomness.md##vrf) used by
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, is determined at each block.
 Additionally, each auction will have a threshold that starts at 0 and increases to 1. The random
 number produced by the VRF is examined next to the threshold to determine if that block is the end
-of the auction within the so-called *ending period*. Additionally, the VRF will pick a block from
-the last epoch to access the state of bids which can help aid in mitigating some types of attacks 
+of the auction within the so-called _ending period_. Additionally, the VRF will pick a block from
+the last epoch to access the state of bids which can help aid in mitigating some types of attacks
 from malicious validators.
 
 ### Examples
@@ -281,10 +283,10 @@ of the parachain slot.
 ## Parachain Lease Extension
 
 Before the slot lease expires, parachains have to bid and win another auction for continuity of the
-lease. To avoid any downtime in connectivity and minimize the risk of losing a subsequent auction, 
-parachain teams need to plan ahead to bid for the lease extension before their current 
-lease period ends. Explained in the section above, each auction lets you bid for 8 LPs
-(Lease Periods) which enables two scenarios for the parachain's lease extension.
+lease. To avoid any downtime in connectivity and minimize the risk of losing a subsequent auction,
+parachain teams need to plan ahead to bid for the lease extension before their current lease period
+ends. Explained in the section above, each auction lets you bid for 8 LPs (Lease Periods) which
+enables two scenarios for the parachain's lease extension.
 
 ### Lease Extension with Overlapping Slots
 
@@ -293,74 +295,74 @@ Acquire a slot where the first lease period is before the last lease period of t
 - Register a new `paraId`
 - Win a slot auction with the new `paraId`
 
-The parachain team has access to two slots: 
+The parachain team has access to two slots:
 
 - one that will end soon
 - one that just started
 
-Both slots have at least one LP in common. When the old slot transitions to their last LP, 
-the parachain can [swap](https://github.com/paritytech/polkadot/pull/4772) the slots. This can be 
-done via [on-chain governance](https://kusama.polkassembly.io/post/1491). The `swap`
-call is available in the `registrar` pallet. 
+Both slots have at least one LP in common. When the old slot transitions to their last LP, the
+parachain can [swap](https://github.com/paritytech/polkadot/pull/4772) the slots. This can be done
+via [on-chain governance](https://kusama.polkassembly.io/post/1491). The `swap` call is available in
+the `registrar` pallet.
 
 ![Parachain Slot Swap](../assets/para-swap.png)
 
-
 :::note Any two parachains can swap their slots via XCM
 
-The [slot swap via XCM](https://github.com/paritytech/polkadot/pull/4772) requires two live parachains
-to send an XCM message to the relay chain to approve the swap. A parachain team with access to two 
-overlapping slots can start a shell parachain on the new slot and swap it with their actual parachain
-on the old slot, thus ensuring continuity of the lease.
+The [slot swap via XCM](https://github.com/paritytech/polkadot/pull/4772) requires two live
+parachains to send an XCM message to the relay chain to approve the swap. A parachain team with
+access to two overlapping slots can start a shell parachain on the new slot and swap it with their
+actual parachain on the old slot, thus ensuring continuity of the lease.
 
 :::
 
 ### Lease Extension with Non-Overlapping Slots
 
-Acquire a slot where the first LP starts right after the end of the last LP of the current slot.
-In this case, the parachain can bid directly with their current `paraId`, and it will be automatically 
-extended without the need of swapping. This method has the advantage of not having superfluous LP's on 
-different slots owned by the same team, however it has the disadvantage of losing flexibility on when 
-to win a new slot: if the team does not win the exact slot, then it will suffer some downtime until 
-it wins a new slot.
+Acquire a slot where the first LP starts right after the end of the last LP of the current slot. In
+this case, the parachain can bid directly with their current `paraId`, and it will be automatically
+extended without the need of swapping. This method has the advantage of not having superfluous LP's
+on different slots owned by the same team, however it has the disadvantage of losing flexibility on
+when to win a new slot: if the team does not win the exact slot, then it will suffer some downtime
+until it wins a new slot.
 
 ## FAQ
 
 ### Why doesn't everyone bid for the max length?
 
-For the duration of the slot, the tokens used for bidding in the auction are locked up. This suggests there 
-is an opportunity cost associated with bidding, as the tokens could have been leveraged for something else.
+For the duration of the slot, the tokens used for bidding in the auction are locked up. This
+suggests there is an opportunity cost associated with bidding, as the tokens could have been
+leveraged for something else.
 
 ### How does this mechanism help ensure parachain diversity?
 
 The method for dividing the parachain slots into intervals was partly inspired by the desire to
-allow for a greater amount of parachain diversity, while preventing particularly large and well-funded
-parachains from hoarding slots. By making each period a {{ polkadot: three-month duration but the
+allow for a greater amount of parachain diversity, while preventing particularly large and
+well-funded parachains from hoarding slots. By making each period a
+{{ polkadot: three-month duration but the
 overall slot a 2-year duration :polkadot }}{{ kusama: 6-week duration but the overall slot a 1-year
-duration :kusama }}, the mechanism can cope with well-funded parachains, ensuring they secure
-a slot at the end of their lease, while gradually allowing other parachains to enter the ecosystem
-to occupy the durations that are not filled. For example, if a large, well-funded parachain has
-already acquired a slot for range 1 - 8, they would be very interested in getting the next slot that
-would open for 2 - 9. Under this mechanism, that parachain could acquire just period 9 (since
-that is the only one required) and allow the 2 - 8  range of the second parachain slot to be occupied by
-another party.
+duration :kusama }}, the mechanism can cope with well-funded parachains, ensuring they secure a slot
+at the end of their lease, while gradually allowing other parachains to enter the ecosystem to
+occupy the durations that are not filled. For example, if a large, well-funded parachain has already
+acquired a slot for range 1 - 8, they would be very interested in getting the next slot that would
+open for 2 - 9. Under this mechanism, that parachain could acquire just period 9 (since that is the
+only one required) and allow the 2 - 8 range of the second parachain slot to be occupied by another
+party.
 
 ### Why is randomness difficult on blockchains?
 
-Generating a random number trustlessly on a
-transparent and open network opens up the possibility for bad
-actors to attempt to alter or manipulate the randomness. There have been a few solutions that have
-been proposed, including hash-onions like [RANDAO](https://github.com/randao/randao) and
+Generating a random number trustlessly on a transparent and open network opens up the possibility
+for bad actors to attempt to alter or manipulate the randomness. There have been a few solutions
+that have been proposed, including hash-onions like [RANDAO](https://github.com/randao/randao) and
 [verifiable random functions](https://en.wikipedia.org/wiki/Verifiable_random_function) (VRFs). The
-latter is what {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses as a base for its randomness.
+latter is what {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses as a base for its
+randomness.
 
 ### Are there other ways of acquiring a slot besides the candle auction?
 
-Aa parachain slot can also be acquired through a secondary market
-where a 3rd party has already won a parachain slot and has the ability to resell the slot along with the associated
-deposit of tokens that are locked up to another buyer. This would allow the seller to get liquid
-tokens in exchange for the parachain slot and the buyer to acquire the slot as well as the deposited
-tokens.
+Aa parachain slot can also be acquired through a secondary market where a 3rd party has already won
+a parachain slot and has the ability to resell the slot along with the associated deposit of tokens
+that are locked up to another buyer. This would allow the seller to get liquid tokens in exchange
+for the parachain slot and the buyer to acquire the slot as well as the deposited tokens.
 
 A number of system or common-good parachains may be granted slots by the
 [governing bodies](learn-governance.md) of the Relay Chain. System parachains can be recognized by a
@@ -370,9 +372,9 @@ their slots as they would be considered essential to the ecosystem's future.
 
 ### How are auctions scheduled?
 
-The parachain slot auctions are scheduled through the governance. At least 2/3 of the Council can 
+The parachain slot auctions are scheduled through the governance. At least 2/3 of the Council can
 initiate an auction, however, Root origin (via referendum) is needed to cancel an auction. Here is a
-proposal that gives a glimpse of what goes into planning auctions schedule - 
+proposal that gives a glimpse of what goes into planning auctions schedule -
 [Proposed Polkadot Auction Schedule 2022](https://polkadot.polkassembly.io/post/863).
 
 ## Resources

--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -64,9 +64,8 @@ entire ending period, where a snapshot is taken at each block within the ending 
 the winners for that given block. At the end of the period, one of the snapshots is randomly selected
 to determine the winner of the auction.
 
-This process executes in the next epoch after the ending
-period. **The parachain candidate with the highest bid at the ending time chosen by the VRF wins the
-slot auction**.
+This process executes in the next epoch after the ending period. **The parachain candidate with the highest
+bid at the ending time chosen by the VRF wins the slot auction**.
 
 :::info
 
@@ -78,7 +77,8 @@ during these six hours when the winning block for the auction is being determine
 With 1 day and 18 hours for the starting period,
 {{ polkadot: <RPC network="polkadot" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.auctions.endingPeriod" defaultValue={72000} filter="blocksToDays"/> :kusama }}
 days for the ending period (candle auction phase) and 6 hours for determining the auction winner,
-a parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts exactly one week from the start.
+a parachain auction on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} lasts 
+exactly one week from the start.
 
 More details on this are available in the [Network Implementation](#network-implementation) section.
 
@@ -244,11 +244,13 @@ amount of tokens held over the entire lease duration of the parachain slot. This
 highest bidder for any given slot lease period might not always win (see the
 [example below](#examples)).
 
-A random number, which is based on the [VRF](learn-randomness.md##vrf) used by {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, is determined at each block.
+A random number, which is based on the [VRF](learn-randomness.md##vrf) used 
+by {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, is determined at each block.
 Additionally, each auction will have a threshold that starts at 0 and increases to 1. The random
 number produced by the VRF is examined next to the threshold to determine if that block is the end
 of the auction within the so-called *ending period*. Additionally, the VRF will pick a block from
-the last epoch to access the state of bids which can help aid in mitigating some types of attacks from malicious validators.
+the last epoch to access the state of bids which can help aid in mitigating some types of attacks 
+from malicious validators.
 
 ### Examples
 


### PR DESCRIPTION
### Description
This PR addresses the `Parachain Slots Auction` removal task outlined in https://github.com/w3f/polkadot-wiki/issues/3597.

### Actions
- [x] Reviewed and revised the #learn-auctions doc
- [x] Links to new support content in wiki/guide
- [ ] ~~Remove overlapping content with new support article~~
- [ ] ~~Remove any images associated with removal, ensuring no other references in the project~~
^ The support articles states "For a more in-depth explanation of the mechanism, please read [this wiki article](https://wiki.polkadot.network/docs/learn-auction)."  For this reason I have not removed much content from the wiki as it provides an more in-depth overview of the protocol.

### Support Articles Referenced
[- https://support.polkadot.network/support/solutions/articles/65000138217-how-to-claim-your-dot-tutorial](https://support.polkadot.network/support/solutions/articles/65000182287-how-does-a-parachain-slots-auction-work-)