### PR TITLE
Update several missing or hard-coded variable references to on-chain values

### DIFF
--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -6,12 +6,9 @@ description: Learn about Nomination Pools and their features
 keyword: [nominate, nominator, stake, staking, pools]
 slug: ../learn-nomination-pools
 ---
-
 import RPC from "./../../components/RPC-Connection"
 
-:::info Nomination Pools are live on
-[Westend](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-rpc.polkadot.io#/staking/pools) and
-[Kusama](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-rpc.polkadot.io#/staking/pools).
+:::info Nomination Pools are live on [Westend](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-rpc.polkadot.io#/staking/pools) and [Kusama](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-rpc.polkadot.io#/staking/pools).
 
 Get some [Westies (WND)](learn-DOT.md#getting-westies) and start experimenting with Nomination
 pools! Soon they will be deployed on Polkadot.
@@ -27,36 +24,32 @@ If you have questions about nomination pools, please join our
 
 ![Nomination Pools](../assets/staking/NPoS-Pools.png)
 
-Nomination pools are one of the key features from the roadmap of staking improvements on
-{{ kusama: Kusama :kusama }}{{ polkadot: Polkadot :polkadot }}. They are designed to
-permissionlessly allow members to pool their funds together and act as a single nominator account.
+Nomination pools are one of the key features from the roadmap of staking improvements on {{ kusama: Kusama :kusama }}{{ polkadot: Polkadot :polkadot }}. They are designed to permissionlessly allow members to pool their funds together and act
+as a single nominator account. 
 
-Due to the current runtime constraints,
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} can only handle
+Due to the current runtime constraints, {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} can only handle
 {{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.maxElectingVoters" defaultValue={22500}/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.maxElectingVoters" defaultValue={12500}/> :kusama }}
-nominators comfortably in the [electing set](learn-nominator.md#staking-election-stages). As one of
-the objectives of the [NPoS algorithm](learn-phragmen.md) is to maximize the overall stake on the
-network, it can be inferred that the staking system on
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} favors nominators with a larger
-stake. Only the nominator accounts which back the validators in the active set are eligible for
-receiving staking rewards. This leaves out nomination intents from the accounts with lower token
-balance than the min-active nomination and places them in a waiting queue to enter electing set.
-Nomination pools will be handy to the members who would like to participate in the staking system
-with a stake much lower than the dynamic min-active nomination threshold on the network. All
-operations are constant space and time complexity relative to the number of members, eliminating any
-theoretical upper bound on the quantity of members the system can handle and thus scaling the number
-of accounts that can participate and earn rewards in the staking system on
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}. In summary, each nomination pool is
+nominators comfortably in the
+[electing set](learn-nominator.md#staking-election-stages). As one of the objectives of the
+[NPoS algorithm](learn-phragmen.md) is to maximize the overall stake on the network, it can be
+inferred that the staking system on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} favors nominators with a larger stake. Only the
+nominator accounts which back the validators in the active set are eligible for receiving staking
+rewards. This leaves out nomination intents from the accounts with lower token balance than the
+min-active nomination and places them in a waiting queue to enter electing set. Nomination pools
+will be handy to the members who would like to participate in the staking system with a stake much
+lower than the dynamic min-active nomination threshold on the network. All operations are constant
+space and time complexity relative to the number of members, eliminating any theoretical upper bound
+on the quantity of members the system can handle and thus scaling the number of accounts that can
+participate and earn rewards in the staking system on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}. In summary, each nomination pool is
 viewed as a single nominator from the NPoS system point of view.
 
 :::info Why aren't the members in the nomination pools called delegators?
 
 The term `delegator` is associated too much with Delegated Proof of Staking (DPoS) and since
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} implements Nominated Proof of Staking
-(NPoS), naming them as delegators would be misleading. The term `member` is our generic replacement
-for `delegator`. In action, members are actually quite similar to delegators and do delegate their
-nomination power to the pool.
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} implements Nominated Proof of Staking (NPoS), naming them as delegators would be
+misleading. The term `member` is our generic replacement for `delegator`. In action, members are actually
+quite similar to delegators and do delegate their nomination power to the pool.
 
 :::
 
@@ -95,58 +88,43 @@ pool's internal logic can access the account.
 
 :::
 
-Check the "How to join a pool" section in
-[this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
-for guidelines.
+Check the "How to join a pool" section in [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools) for guidelines.
 
 ### Claim rewards
 
 The member can claim their portion of any rewards that have accumulated since the previous time they
 claimed (or in the case that they have never claimed, any rewards that have accumulated since the
-era after they joined). Rewards are split pro rata among the actively bonded members. Check the "How
-to claim rewards" section in
-[this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
-for guidelines.
+era after they joined). Rewards are split pro rata among the actively bonded members. Check the "How to claim rewards" section in [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools) for guidelines.
 
 ### Unbond and withdraw funds
 
 At any point in time after joining the pool, a member can start the process of exiting by unbonding.
-`unbond` will unbond part or all of the member's funds. After unbond has been called and the
-unbonding duration has passed
+`unbond` will unbond part or all of the member's funds. After unbond has been called and the unbonding
+duration has passed
 {{ polkadot: (<RPC network="polkadot" path="consts.staking.bondingDuration" defaultValue={28}/> :polkadot }}
 {{ kusama: (<RPC network="kusama" path="consts.staking.bondingDuration" defaultValue={28}/> :kusama }}
 eras which correspond to
 {{ polkadot: <RPC network="polkadot" path="consts.staking.bondingDuration" defaultValue={28}/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.staking.bondingDuration" defaultValue={28}/> :kusama }}
-days on {{ polkadot: Polkadot). :polkadot }} {{ kusama: Kusama). :kusama }} A member may withdraw
-their funds with `withdrawUnbonded`. Withdrawing effectively ends a member's relationship with their
-pool, allowing them to join a different pool if desired. Check the "Withdraw unbonded funds" section
-in
-[this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
-for guidelines.
+days on
+{{ polkadot: Polkadot). :polkadot }}
+{{ kusama: Kusama). :kusama }}
+A member may withdraw their funds with `withdrawUnbonded`. Withdrawing effectively ends a member's
+relationship with their pool, allowing them to join a different pool if desired. Check the "Withdraw unbonded funds" section in [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools) for guidelines.
 
 ### Limitations
 
 - A member cannot vote (e.g. in Referenda or for Council members) with their nominated funds. This
   may be changed in the future once accounts are afforded the ability to split votes.
-- In order for a member to switch pools all funds from the account must be unbonded. This process
-  takes 28 eras.
+- In order for a member to switch pools all funds from the account must be unbonded.  This process takes 28 eras.
 - A member can partially unbond the staked funds in the pool (at most 16 partial unbonds).
 
-:::info Kusama Pool Stats
 
-- There can be a maximum of
-  <RPC network="kusama" path="query.nominationPools.maxPoolMembers" defaultValue={65536} /> members
-  (there are currently
-  <RPC network="kusama" path="query.nominationPools.counterForPoolMembers" defaultValue={149} />
-  members).
-- There can be a maximum of
-  <RPC network="kusama" path="query.nominationPools.maxPools" defaultValue={64} /> pools (there are
-  currently <RPC network="kusama" path="query.nominationPools.lastPoolId" defaultValue={59} />
-  pools).
-- There can be a maximum of
-  <RPC network="kusama" path="query.nominationPools.maxPoolMembersPerPool" defaultValue={16} />
-  members per pool. :::info
+:::info Kusama Pool Stats
+- There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPoolMembers" defaultValue={65536} /> members (there are currently <RPC network="kusama" path="query.nominationPools.counterForPoolMembers" defaultValue={149} /> members).
+- There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPools" defaultValue={64} /> pools (there are currently <RPC network="kusama" path="query.nominationPools.lastPoolId" defaultValue={59} /> pools).
+- There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPoolMembersPerPool" defaultValue={16} /> members per pool.
+:::info
 
 ## Pool Administration
 
@@ -178,12 +156,13 @@ The depositor calls the `create` extrinsic, setting the administrative roles and
 funds to the pool in order to add themselves as the first member. As stated above, the depositor
 must always be a member as long as the pool exists; they will be the last member to leave, ensuring
 they always have some skin in the game. Significant stake from the depositor is always a good
-indicator for the pool's credibility.
+indicator for the pool's credibility. 
 
 {{ kusama: **The current minimum bond to create a pool is <RPC network="kusama" path="query.nominationPools.minCreateBond" defaultValue={1000000000000} filter="humanReadable" />.** :kusama }}
 
-The pool’s ‘nominator role’ selects validators with the nominate extrinsic. On Polkadot JS Apps UI,
-navigate to Network > Staking > Pools and click on Add Pool button.
+The pool’s ‘nominator role’ selects validators with the
+nominate extrinsic. On Polkadot JS Apps UI, navigate to Network > Staking > Pools and click on Add
+Pool button.
 
 ![Create Nomination Pools](../assets/staking/Nomination-Pools-1.png)
 

--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -6,9 +6,12 @@ description: Learn about Nomination Pools and their features
 keyword: [nominate, nominator, stake, staking, pools]
 slug: ../learn-nomination-pools
 ---
+
 import RPC from "./../../components/RPC-Connection"
 
-:::info Nomination Pools are live on [Westend](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-rpc.polkadot.io#/staking/pools) and [Kusama](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-rpc.polkadot.io#/staking/pools).
+:::info Nomination Pools are live on
+[Westend](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-rpc.polkadot.io#/staking/pools) and
+[Kusama](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-rpc.polkadot.io#/staking/pools).
 
 Get some [Westies (WND)](learn-DOT.md#getting-westies) and start experimenting with Nomination
 pools! Soon they will be deployed on Polkadot.
@@ -24,32 +27,36 @@ If you have questions about nomination pools, please join our
 
 ![Nomination Pools](../assets/staking/NPoS-Pools.png)
 
-Nomination pools are one of the key features from the roadmap of staking improvements on {{ kusama: Kusama :kusama }}{{ polkadot: Polkadot :polkadot }}. They are designed to permissionlessly allow members to pool their funds together and act
-as a single nominator account. 
+Nomination pools are one of the key features from the roadmap of staking improvements on
+{{ kusama: Kusama :kusama }}{{ polkadot: Polkadot :polkadot }}. They are designed to
+permissionlessly allow members to pool their funds together and act as a single nominator account.
 
-Due to the current runtime constraints, {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} can only handle
+Due to the current runtime constraints,
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} can only handle
 {{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.maxElectingVoters" defaultValue={22500}/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.maxElectingVoters" defaultValue={12500}/> :kusama }}
-nominators comfortably in the
-[electing set](learn-nominator.md#staking-election-stages). As one of the objectives of the
-[NPoS algorithm](learn-phragmen.md) is to maximize the overall stake on the network, it can be
-inferred that the staking system on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} favors nominators with a larger stake. Only the
-nominator accounts which back the validators in the active set are eligible for receiving staking
-rewards. This leaves out nomination intents from the accounts with lower token balance than the
-min-active nomination and places them in a waiting queue to enter electing set. Nomination pools
-will be handy to the members who would like to participate in the staking system with a stake much
-lower than the dynamic min-active nomination threshold on the network. All operations are constant
-space and time complexity relative to the number of members, eliminating any theoretical upper bound
-on the quantity of members the system can handle and thus scaling the number of accounts that can
-participate and earn rewards in the staking system on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}. In summary, each nomination pool is
+nominators comfortably in the [electing set](learn-nominator.md#staking-election-stages). As one of
+the objectives of the [NPoS algorithm](learn-phragmen.md) is to maximize the overall stake on the
+network, it can be inferred that the staking system on
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} favors nominators with a larger
+stake. Only the nominator accounts which back the validators in the active set are eligible for
+receiving staking rewards. This leaves out nomination intents from the accounts with lower token
+balance than the min-active nomination and places them in a waiting queue to enter electing set.
+Nomination pools will be handy to the members who would like to participate in the staking system
+with a stake much lower than the dynamic min-active nomination threshold on the network. All
+operations are constant space and time complexity relative to the number of members, eliminating any
+theoretical upper bound on the quantity of members the system can handle and thus scaling the number
+of accounts that can participate and earn rewards in the staking system on
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}. In summary, each nomination pool is
 viewed as a single nominator from the NPoS system point of view.
 
 :::info Why aren't the members in the nomination pools called delegators?
 
 The term `delegator` is associated too much with Delegated Proof of Staking (DPoS) and since
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} implements Nominated Proof of Staking (NPoS), naming them as delegators would be
-misleading. The term `member` is our generic replacement for `delegator`. In action, members are actually
-quite similar to delegators and do delegate their nomination power to the pool.
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} implements Nominated Proof of Staking
+(NPoS), naming them as delegators would be misleading. The term `member` is our generic replacement
+for `delegator`. In action, members are actually quite similar to delegators and do delegate their
+nomination power to the pool.
 
 :::
 
@@ -88,34 +95,58 @@ pool's internal logic can access the account.
 
 :::
 
-Check the "How to join a pool" section in [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools) for guidelines.
+Check the "How to join a pool" section in
+[this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
+for guidelines.
 
 ### Claim rewards
 
 The member can claim their portion of any rewards that have accumulated since the previous time they
 claimed (or in the case that they have never claimed, any rewards that have accumulated since the
-era after they joined). Rewards are split pro rata among the actively bonded members. Check the "How to claim rewards" section in [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools) for guidelines.
+era after they joined). Rewards are split pro rata among the actively bonded members. Check the "How
+to claim rewards" section in
+[this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
+for guidelines.
 
 ### Unbond and withdraw funds
 
 At any point in time after joining the pool, a member can start the process of exiting by unbonding.
-`unbond` will unbond part or all of the member's funds. After unbond has been called and the unbonding duration has passed (28 eras {{ polkadot: which correspond to 28 days on Polkadot :polkadot }}{{ kusama: which correspond to 7 days on Kusama :kusama }}), a
-member may withdraw their funds with `withdrawUnbonded`. Withdrawing effectively ends a member's
-relationship with their pool, allowing them to join a different pool if desired. Check the "Withdraw unbonded funds" section in [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools) for guidelines.
+`unbond` will unbond part or all of the member's funds. After unbond has been called and the
+unbonding duration has passed
+{{ polkadot: (<RPC network="polkadot" path="consts.staking.bondingDuration" defaultValue={28}/> :polkadot }}
+{{ kusama: (<RPC network="kusama" path="consts.staking.bondingDuration" defaultValue={28}/> :kusama }}
+eras which correspond to
+{{ polkadot: <RPC network="polkadot" path="consts.staking.bondingDuration" defaultValue={28}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.staking.bondingDuration" defaultValue={28}/> :kusama }}
+days on {{ polkadot: Polkadot). :polkadot }} {{ kusama: Kusama). :kusama }} A member may withdraw
+their funds with `withdrawUnbonded`. Withdrawing effectively ends a member's relationship with their
+pool, allowing them to join a different pool if desired. Check the "Withdraw unbonded funds" section
+in
+[this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
+for guidelines.
 
 ### Limitations
 
 - A member cannot vote (e.g. in Referenda or for Council members) with their nominated funds. This
   may be changed in the future once accounts are afforded the ability to split votes.
-- In order for a member to switch pools all funds from the account must be unbonded.  This process takes 28 eras.
+- In order for a member to switch pools all funds from the account must be unbonded. This process
+  takes 28 eras.
 - A member can partially unbond the staked funds in the pool (at most 16 partial unbonds).
 
-
 :::info Kusama Pool Stats
-- There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPoolMembers" defaultValue={65536} /> members (there are currently <RPC network="kusama" path="query.nominationPools.counterForPoolMembers" defaultValue={149} /> members).
-- There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPools" defaultValue={64} /> pools (there are currently <RPC network="kusama" path="query.nominationPools.lastPoolId" defaultValue={59} /> pools).
-- There can be a maximum of <RPC network="kusama" path="query.nominationPools.maxPoolMembersPerPool" defaultValue={16} /> members per pool.
-:::info
+
+- There can be a maximum of
+  <RPC network="kusama" path="query.nominationPools.maxPoolMembers" defaultValue={65536} /> members
+  (there are currently
+  <RPC network="kusama" path="query.nominationPools.counterForPoolMembers" defaultValue={149} />
+  members).
+- There can be a maximum of
+  <RPC network="kusama" path="query.nominationPools.maxPools" defaultValue={64} /> pools (there are
+  currently <RPC network="kusama" path="query.nominationPools.lastPoolId" defaultValue={59} />
+  pools).
+- There can be a maximum of
+  <RPC network="kusama" path="query.nominationPools.maxPoolMembersPerPool" defaultValue={16} />
+  members per pool. :::info
 
 ## Pool Administration
 
@@ -147,13 +178,12 @@ The depositor calls the `create` extrinsic, setting the administrative roles and
 funds to the pool in order to add themselves as the first member. As stated above, the depositor
 must always be a member as long as the pool exists; they will be the last member to leave, ensuring
 they always have some skin in the game. Significant stake from the depositor is always a good
-indicator for the pool's credibility. 
+indicator for the pool's credibility.
 
 {{ kusama: **The current minimum bond to create a pool is <RPC network="kusama" path="query.nominationPools.minCreateBond" defaultValue={1000000000000} filter="humanReadable" />.** :kusama }}
 
-The pool’s ‘nominator role’ selects validators with the
-nominate extrinsic. On Polkadot JS Apps UI, navigate to Network > Staking > Pools and click on Add
-Pool button.
+The pool’s ‘nominator role’ selects validators with the nominate extrinsic. On Polkadot JS Apps UI,
+navigate to Network > Staking > Pools and click on Add Pool button.
 
 ![Create Nomination Pools](../assets/staking/Nomination-Pools-1.png)
 

--- a/docs/learn/learn-phragmen.md
+++ b/docs/learn/learn-phragmen.md
@@ -7,30 +7,32 @@ keywords: [phragmen, sequential phragmén method, elections, algorithm, phragmms
 slug: ../learn-phragmen
 ---
 
+import RPC from "./../../components/RPC-Connection"
+
 ## NPoS Election Algorithms
 
-Since validators are paid almost equally in Polkadot in each era, it is important that the stake behind each validator 
-is uniformly spread out. An election algorithm for Nominated Proof of Staking (NPoS) on Polkadot will try to optimize three 
-metrics when computing a solution graph of nominators and validators:
+Since validators are paid almost equally in Polkadot in each era, it is important that the stake
+behind each validator is uniformly spread out. An election algorithm for Nominated Proof of Staking
+(NPoS) on Polkadot will try to optimize three metrics when computing a solution graph of nominators
+and validators:
 
 1. Maximize the total amount at stake.
 1. Maximize the stake behind the minimally staked validator.
 1. Minimize the variance of the stake in the set.
 
-:::note 
+:::note
 
- [Sequential Phragmén](#understanding-phragmén), [Phragmms](#phragmms-fka-balphragmms) and 
- [Star balancing](https://crates.parity.io/sp_npos_elections/balancing/fn.balance.html) are a few
- notable algorithms used for computing the NPoS solutions in Polkadot and Kusama.
+[Sequential Phragmén](#understanding-phragmén), [Phragmms](#phragmms-fka-balphragmms) and
+[Star balancing](https://crates.parity.io/sp_npos_elections/balancing/fn.balance.html) are a few
+notable algorithms used for computing the NPoS solutions in Polkadot and Kusama.
 
 :::
-
 
 ## What is the sequential Phragmén method?
 
 The sequential Phragmén method is a multi-winner election method introduced by Edvard Phragmén in
-the 1890s. The quote below taken from the reference [Phragmén paper](#external-resources) sums up the purpose
-of the sequential Phragmén method:
+the 1890s. The quote below taken from the reference [Phragmén paper](#external-resources) sums up
+the purpose of the sequential Phragmén method:
 
 :::note
 
@@ -42,12 +44,11 @@ organization.
 
 :::
 
-
 ### Validator Elections
 
-The sequential Phragmén is one of the methods used in the Nominated Proof-of-Stake scheme to elect validators
-based on their own self-stake and the stake that is voted to them from nominators. It also tries to
-equalize the weights between the validators after each election round.
+The sequential Phragmén is one of the methods used in the Nominated Proof-of-Stake scheme to elect
+validators based on their own self-stake and the stake that is voted to them from nominators. It
+also tries to equalize the weights between the validators after each election round.
 
 #### Off-Chain Phragmén
 
@@ -112,7 +113,7 @@ weighting can be "simulated" by having multiple voters vote for the same slate o
 instance, five people voting for a particular candidate is mathematically the same as a single
 person with weight `5` voting for that candidate.
 
-The particular algorithm we call here the "Basic Phragmén" was first described by Brill *et al.* in
+The particular algorithm we call here the "Basic Phragmén" was first described by Brill _et al._ in
 their paper
 ["Phragmén’s Voting Methods and Justified Representation"](https://aaai.org/ocs/index.php/AAAI/AAAI17/paper/download/14757/13791).
 
@@ -124,8 +125,8 @@ The Phragmén method will iterate, selecting one seat at a time, according to th
    modified after submission.
 2. An initial load of 0 is set for each ballot.
 3. The candidate who wins the next available seat is the one where the ballots of their supporters
-   would have the *least average (mean) cost* if that candidate wins.
-4. The *n* ballots that approved that winning candidate get *1/n* added to their load.
+   would have the _least average (mean) cost_ if that candidate wins.
+4. The _n_ ballots that approved that winning candidate get _1/n_ added to their load.
 5. The load of all ballots that supported the winner of this round are averaged out so that they are
    equal.
 6. If there are any more seats, go back to step 3. Otherwise, the selection ends.
@@ -247,8 +248,8 @@ Weighted Phragmén is similar to Basic Phragmén in that it selects candidates s
 round, until the maximum number of candidates are elected. However, it has additional features to
 also allocate weight (stake) behind the candidates.
 
-*NOTE: in terms of validator selection, for the following algorithm, you can think of "voters" as
-"nominators" and "candidates" as "validators".*
+_NOTE: in terms of validator selection, for the following algorithm, you can think of "voters" as
+"nominators" and "candidates" as "validators"._
 
 1. Candidates are elected, one per round, and added to the set of successful candidates (they have
    won a "seat"). This aspect of the algorithm is very similar to the "basic Phragmén" algorithm
@@ -260,8 +261,8 @@ In more depth, the algorithm operates like so:
 
 1. Create a list of all voters, their total amount of stake, and which validators they support.
 2. Generate an initial edge-weighted graph mapping from voters to candidates, where each edge weight
-   is the total *potential* weight (stake) given by that voter. The sum of all potential weight for
-   a given candidate is called their *approval stake*.
+   is the total _potential_ weight (stake) given by that voter. The sum of all potential weight for
+   a given candidate is called their _approval stake_.
 3. Now we start electing candidates. For the list of all candidates who have not been elected, get
    their score, which is equal to `1 / approval_stake`.
 4. For each voter, update the score of each candidate they support by adding their total budget
@@ -280,11 +281,11 @@ In more depth, the algorithm operates like so:
 
 ### Example
 
-*Note: All numbers in this example are rounded off to three decimal places.*
+_Note: All numbers in this example are rounded off to three decimal places._
 
 In the following example, there are five voters and five candidates vying for three potential seats.
 Each voter `V1 - V5` has an amount of stake equal to their number (e.g., `V1` has stake of 1, `V2`
-has stake of 2, etc.). Every voter is also going to have a *load,* which initially starts at `0`.
+has stake of 2, etc.). Every voter is also going to have a _load,_ which initially starts at `0`.
 
 ```
 Filled seats: 0
@@ -364,7 +365,7 @@ the voters, and then calculate the new scores of the candidates.
 Any voter who had one of their choices for candidate fill the seat in this round (i.e., voters `V1`,
 `V2`, `V3`, and `V5`, who all voted for `A`) will have their load increased. This load increase will
 blunt the impact of their vote in future rounds, and the edge (which will be used in determining
-stake allocation later) is set to the score of the elected candidate minus the *current* voter load.
+stake allocation later) is set to the score of the elected candidate minus the _current_ voter load.
 
 ```
 edge_load = elected_candidate_score - voter_load
@@ -559,9 +560,9 @@ possible. It then runs an edge-reducing algorithm to minimize the number of vali
 nominator, ideally giving every nominator a single validator to nominate per era.
 
 To minimize block computation time, the staking process is run as an
-[off-chain worker](https://docs.substrate.io/reference/how-to-guides/offchain-workers/).
-In order to give time for this off-chain worker to run, staking commands (bond, nominate, etc.) are
-not allowed in the last quarter of each era.
+[off-chain worker](https://docs.substrate.io/reference/how-to-guides/offchain-workers/). In order to
+give time for this off-chain worker to run, staking commands (bond, nominate, etc.) are not allowed
+in the last quarter of each era.
 
 These optimizations will not be covered in-depth on this page. For more details, you can view the
 [Rust implementation of elections in Substrate](https://github.com/paritytech/substrate/blob/master/frame/elections-phragmen/src/lib.rs),
@@ -626,12 +627,16 @@ significant amount of time to calculate the new active validator set and allocat
 an optimal manner.
 
 There are several further restrictions put in place to limit the complexity of the election and
-payout. As already mentioned, any given nominator can only select up to 16 validators to nominate.
-Conversely, a single validator can have only {{ polkadot_max_nominators }} nominators. A drawback to
-this is that it is possible, if the number of nominators is very high or the number of validators is
-very low, that all available validators may be "oversubscribed" and unable to accept more
-nominations. In this case, one may need a larger amount of stake to participate in staking, since
-nominations are priority-ranked in terms of amount of stake.
+payout. As already mentioned, any given nominator can only select up to
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominations" defaultValue={16}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }}
+validators to nominate. Conversely, a single validator can have only
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+nominators. A drawback to this is that it is possible, if the number of nominators is very high or
+the number of validators is very low, that all available validators may be "oversubscribed" and
+unable to accept more nominations. In this case, one may need a larger amount of stake to
+participate in staking, since nominations are priority-ranked in terms of amount of stake.
 
 ### Phragmms (fka Balphragmms)
 
@@ -649,14 +654,14 @@ Kusama are the only blockchain networks that implement an election rule that gua
 representation.
 
 The security of a distributed and decentralized system such as Polkadot is directly related to the
-goal of avoiding *overrepresentation* of any minority. This is a stark contrast to traditional
+goal of avoiding _overrepresentation_ of any minority. This is a stark contrast to traditional
 approaches to proportional representation axioms, which typically only seek to avoid
 underrepresentation.
 
 #### Maximin Support Objective and PJR
 
-This new election rule aims to achieve a constant-factor approximation guarantee for the *maximin
-support objective* and the closely related *proportional justified representation* (PJR) property.
+This new election rule aims to achieve a constant-factor approximation guarantee for the _maximin
+support objective_ and the closely related _proportional justified representation_ (PJR) property.
 
 The maximin support objective is based on maximizing the support of the least-supported elected
 candidate, or in the case of Polkadot and Kusama, maximizing the least amount of stake backing
@@ -671,12 +676,12 @@ strength deserve to have a number of representatives proportional to the group�
 
 #### Comparing Sequential Phragmén, MMS, and Phragmms
 
-*Sequential Phragmén* (`seqPhragmen`) and `MMS` are two efficient election rules that both achieve
+_Sequential Phragmén_ (`seqPhragmen`) and `MMS` are two efficient election rules that both achieve
 PJR.
 
 Currently, Polkadot employs the `seqPhragmen` method for validator and council elections. Although
 `seqPhramen` has a very fast runtime, it does not provide constant-factor approximation for the
-maximin support problem. This is due to `seqPhramen` only performing an *approximate* rebalancing of
+maximin support problem. This is due to `seqPhramen` only performing an _approximate_ rebalancing of
 the distribution of stake.
 
 In contrast, `MMS` is another standard greedy algorithm that simultaneously achieves the PJR
@@ -693,21 +698,21 @@ guarantee for maximin support.
 #### The New Election Rule: Phragmms
 
 `Phragmms` is an iterative greedy algorithm that starts with an empty committee and alternates
-between the `Phragmms` heuristic for inserting a new candidate and *rebalancing* by replacing the
+between the `Phragmms` heuristic for inserting a new candidate and _rebalancing_ by replacing the
 weight vector with a balanced one. The main differentiator between `Phragmms` and `seqPhragmen` is
 that the latter only perform an approximate rebalancing. Details can be found in
 [Balanced Stake Distribution](#rationale-for-maintaining-an-even-distribution-of-stake).
 
 The computation is executed by off-chain workers privately and separately from block production, and
-the validators only need to submit and verify the solutions on-chain. Relative to a committee *A*,
-the score of an unelected candidate *c* is an easy-to-compute rough estimate of what would be the
-size of the least stake backing if we added *c* to committee *A*. Observing on-chain, only one
+the validators only need to submit and verify the solutions on-chain. Relative to a committee _A_,
+the score of an unelected candidate _c_ is an easy-to-compute rough estimate of what would be the
+size of the least stake backing if we added _c_ to committee _A_. Observing on-chain, only one
 solution needs to be tracked at any given time, and a block producer can submit a new solution in
 the block only if the block passes the verification test, consisting of checking:
 
 1. Feasibility,
 2. Balancedness, and
-3. Local Optimality - The least stake backing of *A* is higher than the highest score among
+3. Local Optimality - The least stake backing of _A_ is higher than the highest score among
    unelected candidates
 
 If the tentative solution passes the tests, then it replaces the current solution as the tentative
@@ -726,7 +731,7 @@ inserts them with higher support values.
 - Inspired by `seqPhragmen`, the scoring system of `Phragmms` can be considered to be more intuitive
   and does a better job at estimating the value of adding a candidate to the current solution, and
   hence leads to a better candidate-selection heuristic.
-- Unlike `seqPhragmen`, in `Phragmms`, the edge weight vector *w* is completely rebalanced after
+- Unlike `seqPhragmen`, in `Phragmms`, the edge weight vector _w_ is completely rebalanced after
   each iteration of the algorithm.
 
 The `Phragmms` election rule is currently being implemented on Polkadot. Once completed, it will
@@ -737,16 +742,16 @@ approximation for the maximin support objection) to a blockchain network.
 #### Algorithm
 
 The `Phragmms` algorithm iterates through the available seats, starting with an empty committee of
-size *k*:
+size _k_:
 
-1. Initialize an empty committee *A* and zero edge weight vector *w = 0*.
+1. Initialize an empty committee _A_ and zero edge weight vector _w = 0_.
 
-2. Repeat *k* times:
+2. Repeat _k_ times:
 
-   - Find the unelected candidate with highest score and add it to committee *A*.
-   - Re-balance the weight vector *w* for the new committee *A*.
+   - Find the unelected candidate with highest score and add it to committee _A_.
+   - Re-balance the weight vector _w_ for the new committee _A_.
 
-3. Return *A* and *w*.
+3. Return _A_ and _w_.
 
 ## External Resources
 
@@ -761,7 +766,7 @@ size *k*:
 - [Phragmén's and Thiele's Election Methods](https://arxiv.org/pdf/1611.08826.pdf) - 95-page paper
   explaining Phragmén's election methods in detail.
 - [Phragmén’s Voting Methods and Justified Representation](https://aaai.org/ocs/index.php/AAAI/AAAI17/paper/download/14757/13791) -
-  This paper by Brill *et al.* is the source for the simple Phragmén method, along with proofs about
+  This paper by Brill _et al._ is the source for the simple Phragmén method, along with proofs about
   its properties.
 - [Offline Phragmén](https://github.com/kianenigma/offline-phragmen) - Script to generate the
   Phragmén validator election outcome before the start of an era.

--- a/docs/learn/learn-simple-payouts.md
+++ b/docs/learn/learn-simple-payouts.md
@@ -7,6 +7,8 @@ keywords: [payouts, simple payouts, rewards, staking]
 slug: ../learn-simple-payouts
 ---
 
+import RPC from "./../../components/RPC-Connection"
+
 Polkadot and Kusama make stakers claim their rewards for past eras by submitting a transaction. This
 naturally leads to spreading out reward distribution, as people make transactions at disparate
 times, rather than updating the accounts of all stakers in a single block.
@@ -16,10 +18,11 @@ transactions would allow the block construction algorithm to process only a limi
 and ensure that the network maintains a constant block time. If all rewards were sent out in one
 block, this could cause serious issues with the stability of the network.
 
-Simple payouts require one transaction per validator, per [era](../general/glossary.md##era), to claim rewards.
-The reason Polkadot requires this is to avoid an attack where someone has several thousand accounts
-nominating a single validator. The major cost in reward distribution is mutating the accounts in
-storage, and Polkadot cannot pay out several thousand accounts in a single transaction.
+Simple payouts require one transaction per validator, per [era](../general/glossary.md##era), to
+claim rewards. The reason Polkadot requires this is to avoid an attack where someone has several
+thousand accounts nominating a single validator. The major cost in reward distribution is mutating
+the accounts in storage, and Polkadot cannot pay out several thousand accounts in a single
+transaction.
 
 ## Claiming Rewards
 
@@ -34,16 +37,22 @@ which takes 28 eras. If a validator were to immediately chill and start unbondin
 calculated, and nobody issued a payout for that era from that validator in the next 28 eras, the
 reward would no longer be claimable.
 
-:::info In order to be absolutely sure that staking rewards can be claimed, users should trigger a payout before 28 eras have passed.
+:::info In order to be absolutely sure that staking rewards can be claimed, users should trigger a
+payout before 28 eras have passed.
 
 :::
 
 Anyone can trigger a payout for any validator, as long as they are willing to pay the transaction
 fee. Someone must submit a transaction with a validator ID and an era index. Polkadot will
-automatically calculate that validator's reward, find the top {{ polkadot_max_nominators }}
+automatically calculate that validator's reward, find the top
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
 nominators for that era, and distribute the rewards pro rata.
 
-:::note The Staking system only applies the highest {{ polkadot_max_nominators }} nominations to each validator to reduce the complexity of the staking set.
+:::note The Staking system only applies the highest
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+nominations to each validator to reduce the complexity of the staking set.
 
 :::
 

--- a/docs/learn/learn-simple-payouts.md
+++ b/docs/learn/learn-simple-payouts.md
@@ -45,13 +45,13 @@ payout before 28 eras have passed.
 Anyone can trigger a payout for any validator, as long as they are willing to pay the transaction
 fee. Someone must submit a transaction with a validator ID and an era index. Polkadot will
 automatically calculate that validator's reward, find the top
-{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
 nominators for that era, and distribute the rewards pro rata.
 
 :::note The Staking system only applies the highest
-{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
 nominations to each validator to reduce the complexity of the staking set.
 
 :::

--- a/docs/learn/learn-staking-miner.md
+++ b/docs/learn/learn-staking-miner.md
@@ -7,6 +7,8 @@ keywords: [staking, npos, miner, phragmén]
 slug: ../learn-staking-miner
 ---
 
+import RPC from "./../../components/RPC-Connection"
+
 :::caution
 
 The staking-miner code is experimental and it is still in development phase. Use is at your own
@@ -78,8 +80,10 @@ A maximum of `pallet::Config::MaxSignedSubmissions` will be stored on-chain and 
 based on score. Higher the score the more optimal the election solution is. On both Polkadot and
 Kusama the
 ['MaxSignedSubmissions'](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/lib.rs#L446)
-is set to {{ signed_max_submission }} submissions. This variable can be modified if needed through
-governance.
+is set to
+{{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedMaxSubmissions" defaultValue={16}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedMaxSubmissions" defaultValue={16}/> :kusama }}
+submissions. This variable can be modified if needed through governance.
 
 Upon arrival of a new solution:
 

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -6,16 +6,18 @@ description: An introduction on staking in Polkadot's NPoS consensus model.
 keywords: [staking, stake, nominate, nominating, NPoS]
 slug: ../learn-staking
 ---
+
 import RPC from "./../../components/RPC-Connection"
 
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} implements NPoS (Nominated Proof-of-Stake),
-a relatively novel and sophisticated mechanism to select the validators who are allowed to participate in 
-its [consensus](learn-consensus.md) protocol. The NPoS encourages {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} 
-holders to participate as nominators. Nominators may back up to 
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} implements NPoS (Nominated
+Proof-of-Stake), a relatively novel and sophisticated mechanism to select the validators who are
+allowed to participate in its [consensus](learn-consensus.md) protocol. The NPoS encourages
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} holders to participate as nominators.
+Nominators may back up to
 {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominations" defaultValue={16}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }} 
-validators as trusted validator candidates. Both validators and nominators lock their tokens as collateral 
-and receive staking rewards.
+{{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }}
+validators as trusted validator candidates. Both validators and nominators lock their tokens as
+collateral and receive staking rewards.
 
 The staking system pays out rewards essentially equally to all validators regardless of stake.
 Having more stake on a validator does not influence the amount of block rewards it receives.
@@ -51,24 +53,22 @@ video below.
 Any potential validators can indicate their intention to be a validator candidate. Their candidacies
 are made public to all nominators, and a nominator in turn submits a list of up to
 {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominations" defaultValue={16}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }} 
-candidates that it supports. In the next era, a certain number of validators having the
-most {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} backing get elected and become active.
-As a nominator, a minimum of 
+{{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }}
+candidates that it supports. In the next era, a certain number of validators having the most
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} backing get elected and become active. As a
+nominator, a minimum of
 {{ polkadot: <RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :kusama }}
-is required to submit an intention to
-nominate. The nomination intents are placed in a semi-sorted list called
-[bags-list](https://github.com/paritytech/substrate/pull/9507).
+is required to submit an intention to nominate. The nomination intents are placed in a semi-sorted
+list called [bags-list](https://github.com/paritytech/substrate/pull/9507).
 
 :::caution Minimum Nomination to Receive Staking Rewards
 
-Although the minimum nomination intent is 
-{{ polkadot: <RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :kusama }}, 
-it does not guarantee
-staking rewards. The nominated amount has to be greater than
+Although the minimum nomination intent is
+{{ polkadot: <RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :kusama }},
+it does not guarantee staking rewards. The nominated amount has to be greater than
 [minimum active nomination](learn-nominator.md#minimum-active-nomination-to-receive-staking-rewards),
-which is a dynamic value that can be much higher than 
+which is a dynamic value that can be much higher than
 {{ polkadot: <RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :kusama }}.
 
 :::
@@ -107,9 +107,9 @@ staking/election system. The bags-list is capable of including an unlimited numb
 to the chain's runtime storage. In the current staking system configuration, the bags list keeps
 {{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
-nomination intents, of which, at most
-{{ polkadot: 22,500 :polkadot }}{{ kusama: 20,000  :kusama }} come out as the electing nominators.
-Check [Staking Election Stages](learn-nominator.md#staking-election-stages) section for more info.
+nomination intents, of which, at most {{ polkadot: 22,500 :polkadot }}{{ kusama: 20,000  :kusama }}
+come out as the electing nominators. Check
+[Staking Election Stages](learn-nominator.md#staking-election-stages) section for more info.
 
 :::caution Minimum active nomination threshold to earn rewards is dynamic
 
@@ -229,12 +229,18 @@ There is an additional factor to consider in terms of rewards. While there is no
 of nominators a validator may have, a validator does have a limit to how many nominators to which it
 can pay rewards.
 
-In Polkadot and Kusama, this limit is currently {{ polkadot_max_nominators }}, although this can be
-modified via runtime upgrade. A validator with more than {{ polkadot_max_nominators }} nominators is
-*oversubscribed*. When payouts occur, only the top {{ polkadot_max_nominators }} nominators as
-measured by amount of stake allocated to that validator will receive rewards. All other nominators
-are essentially "wasting" their stake - they used their nomination to elect that validator to the
-active stake, but receive no rewards in exchange for doing so.
+In {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, this limit is currently
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/>, :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/>, :kusama }}
+although it can be modified via runtime upgrade. A validator with more than
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+nominators is _oversubscribed_. When payouts occur, only the top
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+nominators as measured by amount of stake allocated to that validator will receive rewards. All
+other nominators are essentially "wasting" their stake - they used their nomination to elect that
+validator to the active stake, but receive no rewards in exchange for doing so.
 
 We also remark that when the network slashes a validator slot for a misbehavior (e.g. validator
 offline, equivocation, etc.) the slashed amount is a fixed percentage (and NOT a fixed amount),
@@ -368,12 +374,12 @@ Let's look at these offences in a bit more detail.
 
 For every session, validators will send an "I'm online" heartbeat to indicate they are live. If a
 validator produces no blocks during an epoch and fails to send the heartbeat, it will be reported as
-unresponsive. Slashing may occur depending on the repeated offences and how many other validators were
-unresponsive or offline during the epoch.
+unresponsive. Slashing may occur depending on the repeated offences and how many other validators
+were unresponsive or offline during the epoch.
 
-Validators should have a well-architected network infrastructure to ensure the node runs to
-reduce the risk of slashing or chilling. A high availability setup is desirable, preferably with
-backup nodes that kick in **only once the original node is verifiably offline** (to avoid double-signing
+Validators should have a well-architected network infrastructure to ensure the node runs to reduce
+the risk of slashing or chilling. A high availability setup is desirable, preferably with backup
+nodes that kick in **only once the original node is verifiably offline** (to avoid double-signing
 and being slashed for equivocation - see below). A comprehensive guide on validator setup is
 available [here](../maintain/maintain-guides-secure-validator.md).
 
@@ -393,8 +399,8 @@ In all of the examples, assume that there are 100 validators in the active set.
 
 No slashing would enact if < 10% of all validators are unresponsive.
 
-For example, if exactly 10 validators were unresponsive, the expression 3 * (x - (n / 10 + 1))) / n
-would be 3 * (10 - (100 / 10 + 1)) / 100 = 3 * (10 - (10 + 1)) / 100 = -0.03 which is rounded to 0.
+For example, if exactly 10 validators were unresponsive, the expression 3 _ (x - (n / 10 + 1))) / n
+would be 3 _ (10 - (100 / 10 + 1)) / 100 = 3 \* (10 - (10 + 1)) / 100 = -0.03 which is rounded to 0.
 
 :::note
 
@@ -402,23 +408,25 @@ The minimum value between 0 and 1 is 0. 0 multipled by 0.07 is 0.
 
 :::
 
-If 14 validators are unresponsive, then slashing would occur, as > 10% of validators are unresponsive.
+If 14 validators are unresponsive, then slashing would occur, as > 10% of validators are
+unresponsive.
 
-The slashing penalty would be
-min((3 * (14 - (100 / 10 + 1))) / 100, 1) * 0.07 = min((3 * (14 - 11))/100, 1) * 0.07 = min(0.09, 1) * 0.07 = 0.6%
+The slashing penalty would be min((3 _ (14 - (100 / 10 + 1))) / 100, 1) _ 0.07 = min((3 _ (14 -
+11))/100, 1) _ 0.07 = min(0.09, 1) \* 0.07 = 0.6%
 
-Similarly, if one-third of the validator set (around 33/100) are unresponsive, the slashing penalty would be
-about 5%.
+Similarly, if one-third of the validator set (around 33/100) are unresponsive, the slashing penalty
+would be about 5%.
 
-The maximum slashing that can occur due to unresponsiveness is 7%. After around 45% of the validators go offline,
-the expression 3 * (x - (n / 10 + 1))) / n will go beyond 1. Hence, min((3 * (x - (n / 10 + 1))) / n, 1) * 0.07
-will be ceiled to 7%.
+The maximum slashing that can occur due to unresponsiveness is 7%. After around 45% of the
+validators go offline, the expression 3 _ (x - (n / 10 + 1))) / n will go beyond 1. Hence, min((3 _
+(x - (n / 10 + 1))) / n, 1) \* 0.07 will be ceiled to 7%.
 
 ### Equivocation
 
 **GRANDPA Equivocation**: A validator signs two or more votes in the same round on different chains.
 
-**BABE Equivocation**: A validator produces two or more blocks on the Relay Chain in the same time slot.
+**BABE Equivocation**: A validator produces two or more blocks on the Relay Chain in the same time
+slot.
 
 Both GRANDPA and BABE equivocation use the same formula for calculating the slashing penalty:
 
@@ -433,10 +441,11 @@ validator. The penalty would be min(3 \* 1 / 100)^2, 1) = 0.0009, or a 0.09% sla
 validator pool (i.e., all stake held by the validator and its nominators).
 
 Now assume that there is a group running several validators, and all of them have an issue in the
-same slot. The penalty would be min((3 \* 5 / 100)^2, 1) = 0.0225, or a 2.25% slash. If 20 validators
-equivocate, this is a much more serious offence and possibly indicates a coordinated attack on the
-network, and so the slash will be much greater - min((3 \* 20 / 100)^2, 1) = 0.36, or a 36% slash on
-all of these validators and their nominators. All slashed validators will also be chilled.
+same slot. The penalty would be min((3 \* 5 / 100)^2, 1) = 0.0225, or a 2.25% slash. If 20
+validators equivocate, this is a much more serious offence and possibly indicates a coordinated
+attack on the network, and so the slash will be much greater - min((3 \* 20 / 100)^2, 1) = 0.36, or
+a 36% slash on all of these validators and their nominators. All slashed validators will also be
+chilled.
 
 From the example above, the risk in nominating or running many validators in the active set are
 apparent. While rewards grow linearly (two validators will get you approximately twice as many
@@ -461,9 +470,9 @@ If you want to know more details about slashing, please look at our
 ### Chilling
 
 Chilling is the act of stepping back from any nominating or validating. It can be done by a
-validator or nominator at any time themselves, taking effect in the next era. It can also specifically
-mean removing a validator from the active validator set by another validator, disqualifying them
-from the set of electable candidates in the next NPoS cycle.
+validator or nominator at any time themselves, taking effect in the next era. It can also
+specifically mean removing a validator from the active validator set by another validator,
+disqualifying them from the set of electable candidates in the next NPoS cycle.
 
 Chilling may be voluntary and validator-initiated, e.g. if there is a planned outage in the
 validator's surroundings or hosting provider, and the validator wants to exit to protect themselves
@@ -508,21 +517,20 @@ rewards will be calculated four times per day on Kusama and once per day on Polk
 Rewards are calculated based on era points, which have a probabilistic component. In other words,
 there may be slight differences in your rewards from era to era, and even amongst validators in the
 active set at the same time. These variations should cancel out over a long enough timeline. See the
-page on [Validator Payout Guide](../maintain/maintain-guides-validator-payout.md) for more information on how
-these are calculated.
+page on [Validator Payout Guide](../maintain/maintain-guides-validator-payout.md) for more
+information on how these are calculated.
 
 In order to be paid your staking rewards, someone must claim them for each validator that you
 nominate. Staking rewards are kept available for 84 eras, which is approximately 84 days on Polkadot
 and 21 days on Kusama. For more information on why this is so, see the page on
 [simple payouts](learn-simple-payouts.md).
 
-
 :::warning Claiming staking rewards
 
-If nobody claims your staking rewards by this time, then you will not be able to claim
-them and some of your staking rewards will be lost. Additionally, if the validator unbonds all
-their own stake, any pending payouts will be lost. Since unbonding takes 28 days on Polkadot,
-nominators should check if they have pending payouts at least this often.
+If nobody claims your staking rewards by this time, then you will not be able to claim them and some
+of your staking rewards will be lost. Additionally, if the validator unbonds all their own stake,
+any pending payouts will be lost. Since unbonding takes 28 days on Polkadot, nominators should check
+if they have pending payouts at least this often.
 
 :::
 
@@ -574,50 +582,51 @@ For specific details about validator payouts, please see
 
 {{ polkadot: DOT is inflationary; there is no maximum number of DOT. Inflation is designed
 to be approximately 10% annually, with validator rewards being a function of the amount staked
-and the remainder going to treasury. DOT went through [redenomination](../general/redenomination.md) 
+and the remainder going to treasury. DOT went through [redenomination](../general/redenomination.md)
 in 2020. The current token supply on Polkadot is <RPC network="polkadot" path="query.balances.totalIssuance" defaultValue={12230666300429914781} filter="humanReadable"/> (Over 1.2 Billion DOT). :polkadot }}
 
 {{ kusama: KSM is inflationary; there is no maximum number of KSM. Inflation is designed
 to be approximately 10% annually, with validator rewards being a function of the amount staked
-and the remainder going to treasury. The current token supply on Kusama is 
-{{ kusama: <RPC network="kusama" path="query.balances.totalIssuance" defaultValue={12619256191792480093}/> :kusama }} (Over 12 Million KSM). :kusama }}
+and the remainder going to treasury. The current token supply on Kusama is
+{{ kusama: <RPC network="kusama" path="query.balances.totalIssuance" defaultValue={12619256191792480093}/> :kusama }}
+(Over 12 Million KSM). :kusama }}
 
-There is an *ideal staking rate* that the network tries to maintain.
-The goal is to have the *system staking rate* meet the *ideal staking rate*. The system staking rate would be the total amount staked over the total token supply, where
-the total amount staked is the stake of all validators and nominators on the network. The ideal
-staking rate accounts for having sufficient backing of {{ polkadot: DOT :polkadot }}
-{{ kusama: KSM :kusama }} to prevent the possible compromise of security while keeping the native
-token liquid. {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} is inflated according to the 
-system staking rate of the entire network.
+There is an _ideal staking rate_ that the network tries to maintain. The goal is to have the _system
+staking rate_ meet the _ideal staking rate_. The system staking rate would be the total amount
+staked over the total token supply, where the total amount staked is the stake of all validators and
+nominators on the network. The ideal staking rate accounts for having sufficient backing of
+{{ polkadot: DOT :polkadot }} {{ kusama: KSM :kusama }} to prevent the possible compromise of
+security while keeping the native token liquid.
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} is inflated according to the system staking
+rate of the entire network.
 
-:::info 
+:::info
 
 According to the inflation model, this would suggest that if you do not use your
-{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} for staking, your tokens
-dilute over time.
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} for staking, your tokens dilute over time.
 
 :::
 
-The ideal staking rate on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}
-is designed to be dynamic and is adjusted based on the number of parachain slots. As the
-number of parachain slots increase, the ideal staking rate decreases. 
+The ideal staking rate on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} is designed
+to be dynamic and is adjusted based on the number of parachain slots. As the number of parachain
+slots increase, the ideal staking rate decreases.
 
-:::note 
+:::note
 
-The current staking rate on Polkadot still assumes the absence of parachains, with the suggested 
-ideal staking rate of 75%. You can track the progress on the issue to adjust it 
+The current staking rate on Polkadot still assumes the absence of parachains, with the suggested
+ideal staking rate of 75%. You can track the progress on the issue to adjust it
 [here](https://github.com/paritytech/polkadot/pull/5872). This has already been adjusted on Kusama.
-At the time of updating this section, the ideal staking rate on Kusama was 50.5% when there were 
-49 parachain slots. When the number of slots goes to 60, the ideal staking rate will be 45%. 
-[Here](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/lib.rs#L535)
-is the code for reference.
+At the time of updating this section, the ideal staking rate on Kusama was 50.5% when there were 49
+parachain slots. When the number of slots goes to 60, the ideal staking rate will be 45%.
+[Here](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/lib.rs#L535) is the
+code for reference.
 
 :::
 
-If the amount of tokens staked goes below the ideal rate, then staking rewards for nominators
-go up incentivizing to stake more tokens on the network. On the contrary, if it goes above the 
-ideal rate, staking rewards drop. This is a result of the change in the percentage of staking 
-rewards that go to the Treasury.
+If the amount of tokens staked goes below the ideal rate, then staking rewards for nominators go up
+incentivizing to stake more tokens on the network. On the contrary, if it goes above the ideal rate,
+staking rewards drop. This is a result of the change in the percentage of staking rewards that go to
+the Treasury.
 
 ![staking](../assets/NPoS/staking-rate-with-parachains.png)
 
@@ -625,8 +634,10 @@ rewards that go to the Treasury.
 
 - **x-axis**: Proportion of {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} staked
 - **y-axis**: Inflation, annualized percentage
-- **Blue line**: Annual inflation rate of NPoS, i.e. total amount of tokens minted to pay validators and nominators.
-- **Green line**: Annual rewards rate for stakers. For instance, 0.2 corresponds to 20% of annual returns on the staked tokens.
+- **Blue line**: Annual inflation rate of NPoS, i.e. total amount of tokens minted to pay validators
+  and nominators.
+- **Green line**: Annual rewards rate for stakers. For instance, 0.2 corresponds to 20% of annual
+  returns on the staked tokens.
 
 You can determine the staking rewards by checking the staking overview on
 [Polkadot-JS Apps](https://polkadot.js.org/apps/#/staking).
@@ -653,9 +664,9 @@ Up until now, the network has been following an inflation model that excludes th
 parachains. The ideal staking rate is not always 50%, as the number of active parachains influences
 the available liquidity that is available to secure the network.
 
-Keep in mind that when the system's staking rate is lower than the ideal staking rate, the annual 
-nominal return rate will be higher, encouraging more users to use their tokens for staking. On the 
-contrary, when the system staking rate is higher than the ideal staking rate, the annual nominal 
+Keep in mind that when the system's staking rate is lower than the ideal staking rate, the annual
+nominal return rate will be higher, encouraging more users to use their tokens for staking. On the
+contrary, when the system staking rate is higher than the ideal staking rate, the annual nominal
 return will be less, encouraging some users to withdraw.
 
 ### Why not stake?
@@ -666,13 +677,13 @@ return will be less, encouraging some users to withdraw.
 
 ## How many validators does Polkadot have?
 
-Polkadot started with 20 open validator positions and has increased gradually 
-to <RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/>.
-The top bound on the number of validators has not been determined yet, but should only be limited by 
-the bandwidth strain of the network due to peer-to-peer message passing. The estimate of the number of
-validators that Polkadot will have at maturity is around 1000. Kusama, Polkadot's canary network, currently 
-has <RPC network="kusama" path="query.staking.validatorCount" defaultValue={1000}/>
-validator slots in the active set.
+Polkadot started with 20 open validator positions and has increased gradually to
+<RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/>. The top bound on
+the number of validators has not been determined yet, but should only be limited by the bandwidth
+strain of the network due to peer-to-peer message passing. The estimate of the number of validators
+that Polkadot will have at maturity is around 1000. Kusama, Polkadot's canary network, currently has
+<RPC network="kusama" path="query.staking.validatorCount" defaultValue={1000}/> validator slots in
+the active set.
 
 ## Resources
 

--- a/docs/learn/learn-validator.md
+++ b/docs/learn/learn-validator.md
@@ -7,6 +7,8 @@ keywords: [validate, validator, maintain, NPoS, stake]
 slug: ../learn-validator
 ---
 
+import RPC from "./../../components/RPC-Connection"
+
 Validators secure the [Relay Chain](learn-architecture.md#relay-chain) by staking DOT, validating
 proofs from collators and participating in consensus with other validators.
 
@@ -17,12 +19,14 @@ to the tx pool for a block producer to include on-chain. The Relay Chain validat
 each parachain follows its unique rules and can pass messages between shards in a trust-free
 environment.
 
-With parachains now on the network, para-validators are selected every epoch to validate parachain 
-blocks for all parachains connected to the Relay Chain. Para-validators work in groups to 
-validate parachain blocks. 
+With parachains now on the network, para-validators are selected every epoch to validate parachain
+blocks for all parachains connected to the Relay Chain. Para-validators work in groups to validate
+parachain blocks.
 
-The selected para-validators are one of {{ polkadot: 297 :polkadot }}{{ kusama: 1000 :kusama }}
-validators randomly selected (per epoch) to participate in the validation, creating a validator pool 
+The selected para-validators are one of
+{{ polkadot: <RPC network="polkadot" path="query.staking.validatorCount" defaultValue={297}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.validatorCount" defaultValue={1000}/> :kusama }}
+validators randomly selected (per epoch) to participate in the validation, creating a validator pool
 of 200 para-validators.
 
 Validators perform two functions:
@@ -37,18 +41,18 @@ Validators perform two functions:
 
 ## Guides
 
-- [How to Validate on Polkadot](../maintain/maintain-guides-how-to-validate-polkadot.md) - Guide on how to set
-  up a validator on the Polkadot live network.
-- [Validator Payout Overview](../maintain/maintain-guides-validator-payout.md) - A short overview on how the
-  validator payout mechanism works.
-- [How to run your validator as a systemd process](../maintain/maintain-guides-how-to-systemd.md) - Guide on
-  running your validator as a `systemd` process so that it will run in the background and start
-  automatically on reboots.
-- [How to Upgrade your Validator](../maintain/maintain-guides-how-to-upgrade.md) - Guide for securely upgrading
-  your validator when you want to switch to a different machine or begin running the latest version
-  of client code.
-- [How to Use Validator Setup](../maintain/maintain-guides-how-to-use-polkadot-validator-setup.md) - Guide on how
-  to use Polkadot / Kusama validator setup.
+- [How to Validate on Polkadot](../maintain/maintain-guides-how-to-validate-polkadot.md) - Guide on
+  how to set up a validator on the Polkadot live network.
+- [Validator Payout Overview](../maintain/maintain-guides-validator-payout.md) - A short overview on
+  how the validator payout mechanism works.
+- [How to run your validator as a systemd process](../maintain/maintain-guides-how-to-systemd.md) -
+  Guide on running your validator as a `systemd` process so that it will run in the background and
+  start automatically on reboots.
+- [How to Upgrade your Validator](../maintain/maintain-guides-how-to-upgrade.md) - Guide for
+  securely upgrading your validator when you want to switch to a different machine or begin running
+  the latest version of client code.
+- [How to Use Validator Setup](../maintain/maintain-guides-how-to-use-polkadot-validator-setup.md) -
+  Guide on how to use Polkadot / Kusama validator setup.
 
 ## Other References
 

--- a/docs/maintain/maintain-guides-validator-payout.md
+++ b/docs/maintain/maintain-guides-validator-payout.md
@@ -7,11 +7,13 @@ keywords: [validator payout, payments, rewards, era points]
 slug: ../maintain-guides-validator-payout
 ---
 
+import RPC from "./../../components/RPC-Connection"
+
 ## Era Points
 
 For every era (a period of time approximately 6 hours in length in Kusama, and 24 hours in
-Polkadot), validators are paid proportionally to the amount of *era points* they have collected. 
-Era points are reward points earned for payable actions like:
+Polkadot), validators are paid proportionally to the amount of _era points_ they have collected. Era
+points are reward points earned for payable actions like:
 
 - issuing validity statements for [parachain](../learn/learn-parachains.md) blocks.
 - producing a non-uncle block in the Relay Chain.
@@ -20,56 +22,59 @@ Era points are reward points earned for payable actions like:
 
 :::note
 
-An uncle block is a Relay Chain block that is valid in every regard, but which failed to
-become canonical. This can happen when two or more validators are block producers in a single slot,
-and the block produced by one validator reaches the next block producer before the others. We call
-the lagging blocks uncle blocks.
+An uncle block is a Relay Chain block that is valid in every regard, but which failed to become
+canonical. This can happen when two or more validators are block producers in a single slot, and the
+block produced by one validator reaches the next block producer before the others. We call the
+lagging blocks uncle blocks.
 
 :::
 
 Payments occur at the end of every era.
 
-Era points create a probabilistic component for staking rewards. 
+Era points create a probabilistic component for staking rewards.
 
-If the *mean* of staking rewards is the average rewards per era, then the *variance* is the variability 
-from the average staking rewards. 
+If the _mean_ of staking rewards is the average rewards per era, then the _variance_ is the
+variability from the average staking rewards.
 
-With parachains now on Polkadot, a large percentage of era points will come from parachain validation,
-as a subset of validators are selected to para-validate for all parachains each epoch, and those 
-para-validators can generate more era points as a result. Para-validators are rewarded 20 era points 
-each for each parachain block that they validate.
+With parachains now on Polkadot, a large percentage of era points will come from parachain
+validation, as a subset of validators are selected to para-validate for all parachains each epoch,
+and those para-validators can generate more era points as a result. Para-validators are rewarded 20
+era points each for each parachain block that they validate.
 
-In this case, analyzing the *expected value* of staking rewards will paint a better picture
-as the weight of era points of validators and para-validators in the reward average are taken into consideration.
+In this case, analyzing the _expected value_ of staking rewards will paint a better picture as the
+weight of era points of validators and para-validators in the reward average are taken into
+consideration.
 
-:::note High-level breakdown of reward variance 
+:::note High-level breakdown of reward variance
 
-This should only serve as a high-level overview of the probabilistic nature for staking 
-rewards.
+This should only serve as a high-level overview of the probabilistic nature for staking rewards.
 
-Let: 
+Let:
+
 - `pe` = para-validator era points,
 - `ne` = non-para-validator era points,
 - `EV` = expected value of staking rewards,
 
-Then, `EV(pe)` has more influence on the `EV` than `EV(ne)`. 
+Then, `EV(pe)` has more influence on the `EV` than `EV(ne)`.
 
-Since `EV(pe)` has a more weighted probability on the `EV`, the increase in variance against the 
-`EV` becomes apparent between the different validator pools (aka. validators in the active set and the ones chosen 
-to para-validate).
+Since `EV(pe)` has a more weighted probability on the `EV`, the increase in variance against the
+`EV` becomes apparent between the different validator pools (aka. validators in the active set and
+the ones chosen to para-validate).
 
-Also, let: 
+Also, let:
+
 - `v` = the variance of staking rewards,
 - `p` = number of para-validators,
 - `w` = number validators in the active set,
 - `e` = era,
 
-Then, `v` &#8593; if `w` &#8593;, as this reduces `p` : `w`, with respect to `e`. 
+Then, `v` &#8593; if `w` &#8593;, as this reduces `p` : `w`, with respect to `e`.
 
-Increased `v` is expected, and initially keeping `p` &#8595; using the same para-validator set for all parachains 
-ensures [availability](../learn/learn-availability.md) and [approval voting](../learn/learn-governance.md). 
-In addition, despite `v` &#8593; on an `e` to `e` basis, over time, the amount of rewards each validator 
-receives will equal out based on the continuous selection of para-validators.
+Increased `v` is expected, and initially keeping `p` &#8595; using the same para-validator set for
+all parachains ensures [availability](../learn/learn-availability.md) and
+[approval voting](../learn/learn-governance.md). In addition, despite `v` &#8593; on an `e` to `e`
+basis, over time, the amount of rewards each validator receives will equal out based on the
+continuous selection of para-validators.
 
 There are plans to scale the active para-validation set in the future
 
@@ -185,10 +190,11 @@ validator, then you will lose 1 DOT in each case.
 
 :::caution
 
-If a validator is oversubscribed in an era, staking rewards are distributed only to the the top 
-{{ polkadot_max_nominators }} nominators and the rest of the nominators do not receive any rewards. 
-This is not the case for slashing! Every active nominator of the validator committing slashable offence
-will be slashed.
+If a validator is oversubscribed in an era, staking rewards are distributed only to the the top
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+nominators and the rest of the nominators do not receive any rewards. This is not the case for
+slashing! Every active nominator of the validator committing slashable offence will be slashed.
 
 :::
 
@@ -200,14 +206,14 @@ their validator to "reimburse" themselves for the cost of running a validator no
 all rewards are shared based on the stake behind each validator. This includes the stake of the
 validator itself, plus any stake bonded by nominators.
 
-:::info 
+:::info
 
-Validators set their preference as a percentage of the block reward, _not_ an absolute
-number of DOT. Polkadot's block reward is based on the _total_ amount at stake, with the reward
-peaking when the amount staked is at 50% of the total supply. The commission is set as the amount
-taken by the validator; that is, 0% commission means that the validator does not receive any
-proportion of the rewards besides that owed to it from self-stake, and 100% commission means that
-the validator operator gets all rewards and gives none to its nominators.
+Validators set their preference as a percentage of the block reward, _not_ an absolute number of
+DOT. Polkadot's block reward is based on the _total_ amount at stake, with the reward peaking when
+the amount staked is at 50% of the total supply. The commission is set as the amount taken by the
+validator; that is, 0% commission means that the validator does not receive any proportion of the
+rewards besides that owed to it from self-stake, and 100% commission means that the validator
+operator gets all rewards and gives none to its nominators.
 
 :::
 

--- a/docs/maintain/maintain-guides-validator-payout.md
+++ b/docs/maintain/maintain-guides-validator-payout.md
@@ -191,8 +191,8 @@ validator, then you will lose 1 DOT in each case.
 :::caution
 
 If a validator is oversubscribed in an era, staking rewards are distributed only to the the top
-{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
 nominators and the rest of the nominators do not receive any rewards. This is not the case for
 slashing! Every active nominator of the validator committing slashable offence will be slashed.
 


### PR DESCRIPTION
This PR addresses several broken references to non-existent global variables and replaces hard-coded values with on-chain RPC values. 

Completed:
- `learn-nomination-pools.md` : Replace hard-coded unbonding duration with chain values
- `learn-phragmen.md` : Replace hard-coded max nominations value and replace _{{ polkadot_max_nominators }}_ reference with chain values
- `learn-validator.md` : Replace hard-coded validator count with chain-value
- `learn-staking-miner.md` : Replace _{{ signed_max_submissions }}_ & _{{ polkadot_max_nominators }}_ with RPC invocation to _consts.electionProviderMultiPhase.signedMaxSubmissions_
- `maintain-guides-validator-payout.md` : Replace _{{ polkadot_max_nominators }}_ reference with chain value
- `learn-simple-payouts.md` : Replace _{{ polkadot_max_nominators }}_ reference with chain value

Prettier was run after addressing the issues outlined above.