### PR TITLE
Fix ambiguous Ethereum Classic attack date

### DIFF
--- a/docs/learn/learn-security.md
+++ b/docs/learn/learn-security.md
@@ -23,7 +23,7 @@ suggests that transaction volumes will filter down to lower market cap altcoins 
 fill their blocks. A major flaw in this idea is that the lower market cap coins will have less
 economic security attached, and be easier to attack. A real life example of a 51% attack occurred
 recently (
-[Ethereum Classic attack on January 10](https://cointelegraph.com/news/ethereum-classic-51-attack-the-reality-of-proof-of-work)
+[Ethereum Classic attack on January 10, 2019](https://cointelegraph.com/news/ethereum-classic-51-attack-the-reality-of-proof-of-work)
 ), in which an unknown attacker double spent 219_500 ETC (~1.1 million USD). This was followed by
 two more 51% attacks on ETC.
 


### PR DESCRIPTION
Ethereum Classic's January 10, 2019 attack was ambiguously described to have happened on January 10, without indicating the year.

This PR adds the year of the attack so that readers don't think the attack happened in the current year the doc is being read.