### PR TITLE
Ensure import statements are not impacted by prettier and are consistently terminated

### DIFF
--- a/docs/general/kusama/kusama-ledger.md
+++ b/docs/general/kusama/kusama-ledger.md
@@ -7,7 +7,7 @@ keywords: [ledger, staking, kusama]
 slug: ../../kusama-ledger
 ---
 
-import RPC from "./../../../components/RPC-Connection"
+import RPC from "./../../../components/RPC-Connection";
 
 :::info
 

--- a/docs/general/kusama/kusama-parameters.md
+++ b/docs/general/kusama/kusama-parameters.md
@@ -7,7 +7,7 @@ keywords: [parameters, kusama, on-chain]
 slug: ../../kusama-parameters
 ---
 
-import RPC from "./../../../components/RPC-Connection"
+import RPC from "./../../../components/RPC-Connection";
 
 Many of these parameter values can be updated via on-chain governance. If you require absolute
 certainty of these parameter values, it is recommended you directly check the constants by looking

--- a/docs/general/kusama/kusama-statemine.md
+++ b/docs/general/kusama/kusama-statemine.md
@@ -6,7 +6,7 @@ description: Statemine and its features
 slug: ../../kusama-statemine
 ---
 
-import RPC from "./../../../components/RPC-Connection"
+import RPC from "./../../../components/RPC-Connection";
 
 Statemine is a generic assets parachain which provides functionality for deploying and transferring
 assets — both Fungible and Non-Fungible Tokens (NFTs). It is a common good parachain on Kusama (not

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -8,6 +8,7 @@ slug: ../learn-governance
 ---
 
 import RPC from "./../../components/RPC-Connection";
+
 import VLTable from "./../../components/Voluntary-Locking";
 
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses a sophisticated governance

--- a/docs/learn/learn-staking-advanced.md
+++ b/docs/learn/learn-staking-advanced.md
@@ -7,36 +7,41 @@ keywords: [staking, stake, nominate, nominating, NPoS, proxies]
 slug: ../learn-staking-advanced
 ---
 
-import RPC from "./../../components/RPC-Connection"
+import RPC from "./../../components/RPC-Connection";
 
-This page is meant to be an advanced guide to staking with {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}.
+This page is meant to be an advanced guide to staking with
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}.
 
 ## Pallets and Extrinsics
 
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} is built using
-[substrate](https://substrate.io/), a modular system to efficiently build blockchains. Within each module or **pallet**, one can **call** different
-functions that have similar logic. You can explore substrate pallets on [this dedicated page](https://docs.substrate.io/reference/frame-pallets/). For example, the staking pallet contains all functionalities
-related to staking such as bonding or unbonding funds. The combined information of pallets and calls
-constitutes an **extrinsic**, i.e. a transaction that is executed from outside the chain but that
-triggers an event on the chain. Continuing with the staking example, within the staking pallet
-a nominator can bond funds and nominate some validators. The signature of such
-extrinsic might lead to an event on the chain such as a reward payout to that nominator at the end of an era; this is an event inside the chain. 
+[substrate](https://substrate.io/), a modular system to efficiently build blockchains. Within each
+module or **pallet**, one can **call** different functions that have similar logic. You can explore
+substrate pallets on [this dedicated page](https://docs.substrate.io/reference/frame-pallets/). For
+example, the staking pallet contains all functionalities related to staking such as bonding or
+unbonding funds. The combined information of pallets and calls constitutes an **extrinsic**, i.e. a
+transaction that is executed from outside the chain but that triggers an event on the chain.
+Continuing with the staking example, within the staking pallet a nominator can bond funds and
+nominate some validators. The signature of such extrinsic might lead to an event on the chain such
+as a reward payout to that nominator at the end of an era; this is an event inside the chain.
 
 ## Staking Proxies
 
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} makes it possible to create accounts
-having special permissions also called **proxy accounts**. For mode details about proxy accounts visit the [dedicated page](./learn-proxies.md) on this wiki.
+having special permissions also called **proxy accounts**. For mode details about proxy accounts
+visit the [dedicated page](./learn-proxies.md) on this wiki.
 
 ![staking](../assets/staking/stash-stakingProxy.png)
 
-Proxy accounts are special
-accounts which can sign [**extrinsic calls**](#pallets-and-extrinsics) made to specific [**pallets**](#pallets-and-extrinsics) on behalf of the proxied account. There is thus the
-possibility to create staking proxy accounts that can be used to sign only extrinsic calls to staking,
-session and utility pallets. This makes the stash account even more isolated than using a controller
-account since one can bond / unbond / bond more funds using the staking proxy account. However,
-it is important to remember that actions that can be performed by the proxy accounts are limited, and in the case of staking
-proxy, extrinsic calls to the balances pallet cannot be signed. This means it is not possible to do balance transfers
-on the proxied account through a staking proxy.
+Proxy accounts are special accounts which can sign [**extrinsic calls**](#pallets-and-extrinsics)
+made to specific [**pallets**](#pallets-and-extrinsics) on behalf of the proxied account. There is
+thus the possibility to create staking proxy accounts that can be used to sign only extrinsic calls
+to staking, session and utility pallets. This makes the stash account even more isolated than using
+a controller account since one can bond / unbond / bond more funds using the staking proxy account.
+However, it is important to remember that actions that can be performed by the proxy accounts are
+limited, and in the case of staking proxy, extrinsic calls to the balances pallet cannot be signed.
+This means it is not possible to do balance transfers on the proxied account through a staking
+proxy.
 
 ## Bags List
 
@@ -74,10 +79,13 @@ left out.
 If one receives staking rewards and the amount of staked tokens within the stash account increases
 over time, the position within a bag changes and may also result in a change of bag. This may also
 happen if accounts within the bag bond more tokens or unbond tokens, one's account position and the
-position of other accounts in the bags list might change. These changes are not done automatically, requiring the nominator to submit the permissionless extrinsic `rebag` within the `voterList` pallet to update their position. This allows anyone to specify another account that is in the wrong bag, and place it in the correct one. The `voterList` pallet also comes with the extrinsic `putInFrontOf` which helps the node to move up in the bag. 
-Actions like bonding/unbonding tokens automatically rebags the nominator node, but events like
-staking rewards/slashing do not. See the [bags-list](learn-nominator.md#bags-list) section for
-more information.
+position of other accounts in the bags list might change. These changes are not done automatically,
+requiring the nominator to submit the permissionless extrinsic `rebag` within the `voterList` pallet
+to update their position. This allows anyone to specify another account that is in the wrong bag,
+and place it in the correct one. The `voterList` pallet also comes with the extrinsic `putInFrontOf`
+which helps the node to move up in the bag. Actions like bonding/unbonding tokens automatically
+rebags the nominator node, but events like staking rewards/slashing do not. See the
+[bags-list](learn-nominator.md#bags-list) section for more information.
 
 This sorting functionality using bags is extremely important for the
 [long-term improvements](https://gist.github.com/kianenigma/aa835946455b9a3f167821b9d05ba376) of the
@@ -85,59 +93,67 @@ staking/election system. The bags-list is capable of including an unlimited numb
 to the chain's runtime storage. In the current staking system configuration, the bags list keeps
 {{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorsCount" defaultValue={50000}/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="query.staking.maxNominatorsCount" defaultValue={20000}/> :kusama }}
-nomination intents, of which, at most {{ polkadot: <RPC network="polkadot" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={22500}/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={20000}/> :kusama }}
+nomination intents, of which, at most
+{{ polkadot: <RPC network="polkadot" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={22500}/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={20000}/> :kusama }}
 come out as the electing nominators. See
 [Staking Election Stages](learn-nominator.md#staking-election-stages) section for more info.
 
 :::caution Minimum active nomination threshold to earn rewards is dynamic
 
 Once again, submitting a nomination intent does not guarantee staking rewards. The stake of the top
-{{ polkadot: <RPC network="polkadot" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={22500}/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={20000}/>  :kusama }} nominators is applied to the
-validators in the active set. To avail of staking rewards, ensure that the number of tokens bonded is
-higher than the minimum active nomination. For more information, see the
-[nominator guide](learn-nominator.md)
+{{ polkadot: <RPC network="polkadot" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={22500}/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.electionProviderMultiPhase.maxElectingVoters" defaultValue={20000}/>  :kusama }}
+nominators is applied to the validators in the active set. To avail of staking rewards, ensure that
+the number of tokens bonded is higher than the minimum active nomination. For more information, see
+the [nominator guide](learn-nominator.md)
 
 :::
 
-The "election solution" which is a connected graph between nominators and validators with the stake as edge weights, has to meet certain requirements, such as maximizing the
-amount of stake to nominate validators and distributing the stake backing validators as evenly as
-possible. The objectives of this election mechanism are to maximize the security of the network, and
-achieve fair representation of the nominators. If you want to know more about how NPoS works (e.g.
-election, running time complexity, etc.), please read
+The "election solution" which is a connected graph between nominators and validators with the stake
+as edge weights, has to meet certain requirements, such as maximizing the amount of stake to
+nominate validators and distributing the stake backing validators as evenly as possible. The
+objectives of this election mechanism are to maximize the security of the network, and achieve fair
+representation of the nominators. If you want to know more about how NPoS works (e.g. election,
+running time complexity, etc.), please read
 [here](http://research.web3.foundation/en/latest/polkadot/NPoS.html).
 
 ## Rewards Distribution
 
 :::info
 
-The general rule for rewards across validators is that two validators get paid essentially
-the same amount of tokens for equal work, i.e. they are not paid proportional to their total stakes. There is a probabilistic component to staking rewards in the form of
+The general rule for rewards across validators is that two validators get paid essentially the same
+amount of tokens for equal work, i.e. they are not paid proportional to their total stakes. There is
+a probabilistic component to staking rewards in the form of
 [era points](../maintain/maintain-guides-validator-payout.md##era-points) and
 [tips](learn-transaction-fees.md#fee-calculation) but these should average out over time.
 
 :::
 
-Validators are paid the same regardless of stake backing them. Validators with less stake will generally pay more to nominators
-per-token than the ones with more stake. This gives nominators an economic incentive to gradually shift their preferences to lower-staked validators that gain a sufficient amount of reputation. A consequence of this is that the stake across validators will be as evenly distributed as possible which avoids concentration of power among a few validators. In the long term, validators will have similar levels of stake, with the stake
-being higher for validators with higher reputation. A nominator who is willing to risk more
-by backing a validator with a lower reputation will get paid more, provided there are no slashing events.
+Validators are paid the same regardless of stake backing them. Validators with less stake will
+generally pay more to nominators per-token than the ones with more stake. This gives nominators an
+economic incentive to gradually shift their preferences to lower-staked validators that gain a
+sufficient amount of reputation. A consequence of this is that the stake across validators will be
+as evenly distributed as possible which avoids concentration of power among a few validators. In the
+long term, validators will have similar levels of stake, with the stake being higher for validators
+with higher reputation. A nominator who is willing to risk more by backing a validator with a lower
+reputation will get paid more, provided there are no slashing events.
 
-Before distributing rewards to nominators, validators can create a cut of the reward (a commission) that is not shared with the nominators.
-This cut is a percentage of the block reward, not an absolute value. After the commission gets
-deducted, the remaining portion is distributed pro-rata based on their staked value and split between the validator and
-all of the nominators whose stake has backed this validator.
+Before distributing rewards to nominators, validators can create a cut of the reward (a commission)
+that is not shared with the nominators. This cut is a percentage of the block reward, not an
+absolute value. After the commission gets deducted, the remaining portion is distributed pro-rata
+based on their staked value and split between the validator and all of the nominators whose stake
+has backed this validator.
 
 For example, assume the block reward for a validator is 10 DOT. A validator may specify
 `validator_commission = 50%`, in which case the validator would receive 5 DOT. The remaining 5 DOT
 would then be split between the validator and their nominators based on the proportion of stake each
-nominator had. Note that for this calculation, validator's self-stake acts just as if they were another nominator.
+nominator had. Note that for this calculation, validator's self-stake acts just as if they were
+another nominator.
 
-Thus, a percentage of the reward goes thus to pay the validator's
-commission fees and the remainder is paid pro-rata (i.e. proportional to stake) to the
-nominators and validator. If a validator's commission is set to 100%, no tokens will be paid out to any
-of the nominators. Notice in particular that the validator is rewarded twice: once in
-commission fees for validating (if their commission rate is above 0%), and once for nominating
-itself with own stake.
+Thus, a percentage of the reward goes thus to pay the validator's commission fees and the remainder
+is paid pro-rata (i.e. proportional to stake) to the nominators and validator. If a validator's
+commission is set to 100%, no tokens will be paid out to any of the nominators. Notice in particular
+that the validator is rewarded twice: once in commission fees for validating (if their commission
+rate is above 0%), and once for nominating itself with own stake.
 
 The following example should clarify the above. For simplicity, we have the following assumptions:
 
@@ -152,58 +168,61 @@ The following example should clarify the above. For simplicity, we have the foll
   [here](../general/faq.md#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator)).
 
 |               | **Validator A** |                             |         |
-| :-----------: | :--------------------: | :-------------------------: | :-----: |
-| Nominator (4) |      Stake (600)       | Fraction of the Total Stake | Rewards |
-|      Jin      |          100           |            0.167            |  16.7   |
-|    **Sam**    |           50           |            0.083            |   8.3   |
-|     Anson     |          250           |            0.417            |  41.7   |
-|     Bobby     |          200           |            0.333            |  33.3   |
+| :-----------: | :-------------: | :-------------------------: | :-----: |
+| Nominator (4) |   Stake (600)   | Fraction of the Total Stake | Rewards |
+|      Jin      |       100       |            0.167            |  16.7   |
+|    **Sam**    |       50        |            0.083            |   8.3   |
+|     Anson     |       250       |            0.417            |  41.7   |
+|     Bobby     |       200       |            0.333            |  33.3   |
 
 |               | **Validator B** |                             |         |
-| :-----------: | :--------------------: | :-------------------------: | :-----: |
-| Nominator (4) |      Stake (400)       | Fraction of the Total Stake | Rewards |
-|     Alice     |          100           |            0.25             |   25    |
-|     Peter     |          100           |            0.25             |   25    |
-|     John      |          150           |            0.375            |  37.5   |
-|   **Kitty**   |           50           |            0.125            |  12.5   |
+| :-----------: | :-------------: | :-------------------------: | :-----: |
+| Nominator (4) |   Stake (400)   | Fraction of the Total Stake | Rewards |
+|     Alice     |       100       |            0.25             |   25    |
+|     Peter     |       100       |            0.25             |   25    |
+|     John      |       150       |            0.375            |  37.5   |
+|   **Kitty**   |       50        |            0.125            |  12.5   |
 
 _Both validators A & B have 4 nominators with a total stake 600 and 400 respectively._
 
-Based on the above rewards distribution, nominators of validator B get more rewards per DOT
-than those of validator A because A has more overall stake. Sam has staked 50 DOT with validator A, but he
-only gets 8.3 in return, whereas Kitty gets 12.5 with the same amount of stake.
+Based on the above rewards distribution, nominators of validator B get more rewards per DOT than
+those of validator A because A has more overall stake. Sam has staked 50 DOT with validator A, but
+he only gets 8.3 in return, whereas Kitty gets 12.5 with the same amount of stake.
 
-
-To estimate how many tokens you can get each month as a nominator or
-validator, you can use this [tool](https://www.stakingrewards.com/earn/polkadot/calculate) as a
-reference and play around with it by changing some parameters (e.g. how many days you would like to
-stake with your DOT, provider fees, compound rewards, etc.) to have a better estimate. Even though
-it may not be entirely accurate since staking participation is changing dynamically, it works well
-as an indicator.
+To estimate how many tokens you can get each month as a nominator or validator, you can use this
+[tool](https://www.stakingrewards.com/earn/polkadot/calculate) as a reference and play around with
+it by changing some parameters (e.g. how many days you would like to stake with your DOT, provider
+fees, compound rewards, etc.) to have a better estimate. Even though it may not be entirely accurate
+since staking participation is changing dynamically, it works well as an indicator.
 
 #### Oversubscription, Commission Fees & Slashes
 
 There is an additional factor to consider in terms of rewards. While there is no limit to the number
 of nominators a validator may have, a validator does have a limit to how many nominators to which it
-can pay rewards. In {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} this limit is currently {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}, although this can be
-modified via runtime upgrade. A validator with more than {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }} nominators is
-_oversubscribed_. When payouts occur, only the top {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }} nominators as measured by the amount of stake allocated to that validator will receive rewards. All other nominators
-are essentially "wasting" their stake - they used their nomination to elect that validator to the
-active stake, but receive no rewards in exchange for doing so.
+can pay rewards. In {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} this limit is
+currently
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }},
+although this can be modified via runtime upgrade. A validator with more than
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
+nominators is _oversubscribed_. When payouts occur, only the top
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}
+nominators as measured by the amount of stake allocated to that validator will receive rewards. All
+other nominators are essentially "wasting" their stake - they used their nomination to elect that
+validator to the active stake, but receive no rewards in exchange for doing so.
 
-Note that the network slashes a validator for a misbehavior (e.g. validator
-offline, equivocation, etc.) the slashed amount is a fixed percentage (and not a fixed amount),
-which means that validators with more stake get slashed more DOT. Again, this is done to
-provide nominators with an economic incentive to shift their preferences and back less popular
-validators whom they consider to be trustworthy.
+Note that the network slashes a validator for a misbehavior (e.g. validator offline, equivocation,
+etc.) the slashed amount is a fixed percentage (and not a fixed amount), which means that validators
+with more stake get slashed more DOT. Again, this is done to provide nominators with an economic
+incentive to shift their preferences and back less popular validators whom they consider to be
+trustworthy.
 
-Also, note that each validator candidate is free to name their desired commission
-fee (as a percentage of rewards) to cover operational costs. Since validators are paid the
-same, validators with lower commission fees pay more to nominators than validators with higher fees. Thus,
-each validator can choose between increasing their fees to earn more, or decreasing their fees to
-attract more nominators and increase their chances of being elected. In the long term, we expect
-that all validators will need to be cost-efficient to remain competitive, and that validators with
-higher reputation will be able to charge slightly higher commission fees (which is fair).
+Also, note that each validator candidate is free to name their desired commission fee (as a
+percentage of rewards) to cover operational costs. Since validators are paid the same, validators
+with lower commission fees pay more to nominators than validators with higher fees. Thus, each
+validator can choose between increasing their fees to earn more, or decreasing their fees to attract
+more nominators and increase their chances of being elected. In the long term, we expect that all
+validators will need to be cost-efficient to remain competitive, and that validators with higher
+reputation will be able to charge slightly higher commission fees (which is fair).
 
 ## Slashing
 
@@ -306,15 +325,15 @@ again gather support from nominators.
 There are 3 main difficulties to account for with slashing in NPoS:
 
 - A nominator can nominate multiple validators and be slashed via any of them.
-- Until slashed, the stake is reused from era to era. Nominating with N coins for E eras in a row does
-  not mean you have N\*E coins to be slashed - you've only ever had N.
+- Until slashed, the stake is reused from era to era. Nominating with N coins for E eras in a row
+  does not mean you have N\*E coins to be slashed - you've only ever had N.
 - Slashable offenses can be found after the fact and out of order.
 
 To balance this, we only slash for the maximum slash a participant can receive in some time period,
 rather than the sum. This ensures protection from overslashing. Likewise, the period over which
-maximum slashes are computed is finite and the validator is chilled with nominations withdrawn
-after a slashing event, as stated in the previous section. This prevents rage-quit attacks in which,
-once caught misbehaving, a participant deliberately misbehaves more because their slashing amount is
+maximum slashes are computed is finite and the validator is chilled with nominations withdrawn after
+a slashing event, as stated in the previous section. This prevents rage-quit attacks in which, once
+caught misbehaving, a participant deliberately misbehaves more because their slashing amount is
 already maxed out.
 
 ## Inflation
@@ -380,6 +399,6 @@ For instance, assuming that the ideal staking rate is 50%, all of the inflation 
 validators/nominators if 50% of all KSM / DOT are staked. Any deviation from the 50% - positive or
 negative - sends the proportional remainder to the treasury and effectively reduces staking rewards.
 
-For those who are interested in knowing more about the design of the inflation model for the network,
-please see
+For those who are interested in knowing more about the design of the inflation model for the
+network, please see
 [here](https://w3f-research.readthedocs.io/en/latest/polkadot/overview/2-token-economics.html).

--- a/docs/maintain/kusama/maintain-guides-how-to-nominate-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-how-to-nominate-kusama.md
@@ -7,7 +7,7 @@ keywords: [nominate, nominator, kusama, stake, staking]
 slug: ../../maintain-guides-how-to-nominate-kusama
 ---
 
-import RPC from "./../../../components/RPC-Connection"
+import RPC from "./../../../components/RPC-Connection";
 
 :::info
 

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -7,7 +7,8 @@ keywords: [validator setup, validator, validate, binary, runtime]
 slug: ../maintain-guides-how-to-validate-polkadot
 ---
 
-import RPC from "./../../components/RPC-Connection";;
+import RPC from "./../../components/RPC-Connection";
+
 import MinimumStake from "./../../components/Minimum-Stake";
 
 :::info


### PR DESCRIPTION
Simple formatting changes.

All imports should be spaced 1 line apart and terminated with semicolons, such as:
```js
import A from "./A-Lib";

import B from "./B-Lib";
```
This ensure prettier will not try to treat these statements like markdown which can break the import.

This PR also automatically applied formatting to [docs/learn/learn-staking-advanced.md](https://github.com/w3f/polkadot-wiki/compare/imports-formatting?expand=1#diff-6ddf372237d5116a49b13f59954f8fd55e30a16caec800f76e54befafbea956f) as it looks like this work was on-going when the repo formatting was completed.