### PR TITLE
Use Non-Transfer Proxies to join Nomination Pools

### DIFF
--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -95,6 +95,14 @@ pool's internal logic can access the account.
 
 :::
 
+:::tip Use Non-Transfer Proxy Accounts to join Nomination Pools
+
+Currently, only [non-transfer proxies](learn-proxies.md#non-transfer-proxy) can be used to
+participate in nomination pools. [staking proxies](learn-proxies.md#staking-proxy) cannot be used 
+as they are not enabled to make calls to the nomination pools pallet.
+
+:::
+
 Check the "How to join a pool" section in
 [this support article](https://support.polkadot.network/support/solutions/articles/65000181401-how-to-join-nomination-pools)
 for guidelines.

--- a/docs/learn/learn-proxies.md
+++ b/docs/learn/learn-proxies.md
@@ -117,6 +117,14 @@ as bonding extra funds or designating a new controller account. A proxy doesn't 
 of stash and controller accounts but does allow the stash to be accessed even less frequently than
 using a controller account.
 
+:::caution Do not use Staking proxy for participating in Nomination Pools
+
+Use a [non-transfer](#non-transfer-proxy) instead of a staking proxy to participate in nomination
+pools. The staking proxy is not enabled to make successful calls to the nomination pools pallet.
+
+:::
+
+
 ### Identity Judgement Proxy
 
 The **Identity Judgement** proxies are in charge of allowing registrars to make judgments on an


### PR DESCRIPTION
https://github.com/paritytech/polkadot/blob/3d6b56342e5e1313685aae6f4e222cbf91ba790f/runtime/kusama/src/lib.rs#L1041

Add a note that says Staking proxies are not supported