### PR TITLE
Add Academy to footer

### DIFF
--- a/polkadot-wiki/src/theme/Footer.js
+++ b/polkadot-wiki/src/theme/Footer.js
@@ -260,6 +260,14 @@ export default function Footer() {
             />
             <FooterLink
               content={translate({
+                message: "Academy",
+                id: "footer.body.community.academy",
+                description: "Academy link in Community column in Footer",
+              })}
+              href="https://polkadot.network/academy"
+            />
+            <FooterLink
+              content={translate({
                 message: "Auctions",
                 id: "footer.body.community.auctions",
                 description: "Auctions link in Community column in Footer",


### PR DESCRIPTION
This adds the new Academy landing page on polkadot.network to the footer, in the Community section. 

Henceforth, both footers shall be the same.