### PR TITLE
Change link to Kusama Discord server

### DIFF
--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -81,7 +81,7 @@ you face any issues, join the rooms individually.
 ### Chat
 
 - [Polkadot Discord](https://dot.li/discord) (RECOMMENDED)
-- [Kusama Discord](https://discord.gg/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/docs/general/kusama/kusama-community.md
+++ b/docs/general/kusama/kusama-community.md
@@ -46,7 +46,7 @@ application we use most often to interact with the Matrix protocol is the
   happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message
   [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ar/community.md
+++ b/polkadot-wiki/translated_docs/ar/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ar/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ar/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/de/community.md
+++ b/polkadot-wiki/translated_docs/de/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/de/kusama-community.md
+++ b/polkadot-wiki/translated_docs/de/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/es-ES/community.md
+++ b/polkadot-wiki/translated_docs/es-ES/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/es-ES/kusama-community.md
+++ b/polkadot-wiki/translated_docs/es-ES/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/fi/community.md
+++ b/polkadot-wiki/translated_docs/fi/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/fi/kusama-community.md
+++ b/polkadot-wiki/translated_docs/fi/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/fil-PH/community.md
+++ b/polkadot-wiki/translated_docs/fil-PH/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/fil-PH/kusama-community.md
+++ b/polkadot-wiki/translated_docs/fil-PH/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/fr/community.md
+++ b/polkadot-wiki/translated_docs/fr/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/fr/kusama-community.md
+++ b/polkadot-wiki/translated_docs/fr/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/hi-IN/community.md
+++ b/polkadot-wiki/translated_docs/hi-IN/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/hi-IN/kusama-community.md
+++ b/polkadot-wiki/translated_docs/hi-IN/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/hr-HR/community.md
+++ b/polkadot-wiki/translated_docs/hr-HR/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/hr-HR/kusama-community.md
+++ b/polkadot-wiki/translated_docs/hr-HR/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/id-ID/community.md
+++ b/polkadot-wiki/translated_docs/id-ID/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/id-ID/kusama-community.md
+++ b/polkadot-wiki/translated_docs/id-ID/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/it/community.md
+++ b/polkadot-wiki/translated_docs/it/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/it/kusama-community.md
+++ b/polkadot-wiki/translated_docs/it/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ja/community.md
+++ b/polkadot-wiki/translated_docs/ja/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ja/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ja/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ko/community.md
+++ b/polkadot-wiki/translated_docs/ko/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ko/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ko/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ms-MY/community.md
+++ b/polkadot-wiki/translated_docs/ms-MY/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ms-MY/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ms-MY/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/pt-BR/community.md
+++ b/polkadot-wiki/translated_docs/pt-BR/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/pt-BR/kusama-community.md
+++ b/polkadot-wiki/translated_docs/pt-BR/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ru/community.md
+++ b/polkadot-wiki/translated_docs/ru/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ru/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ru/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/sk-SK/community.md
+++ b/polkadot-wiki/translated_docs/sk-SK/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/sk-SK/kusama-community.md
+++ b/polkadot-wiki/translated_docs/sk-SK/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/th-TH/community.md
+++ b/polkadot-wiki/translated_docs/th-TH/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/th-TH/kusama-community.md
+++ b/polkadot-wiki/translated_docs/th-TH/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/tr/community.md
+++ b/polkadot-wiki/translated_docs/tr/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/tr/kusama-community.md
+++ b/polkadot-wiki/translated_docs/tr/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ur-IN/community.md
+++ b/polkadot-wiki/translated_docs/ur-IN/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ur-IN/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ur-IN/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/ur-PK/community.md
+++ b/polkadot-wiki/translated_docs/ur-PK/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/ur-PK/kusama-community.md
+++ b/polkadot-wiki/translated_docs/ur-PK/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/zh-CN/community.md
+++ b/polkadot-wiki/translated_docs/zh-CN/community.md
@@ -44,7 +44,7 @@ Web3 基金会主办了许多线上和线下的活动。你可以通过[这个 N
 ### 聊天
 
 - [Polkadot Discord](https://discord.gg/polkadot) (推荐）
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### 社交媒体和论坛
 

--- a/polkadot-wiki/translated_docs/zh-CN/kusama-community.md
+++ b/polkadot-wiki/translated_docs/zh-CN/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 

--- a/polkadot-wiki/translated_docs/zh-TW/community.md
+++ b/polkadot-wiki/translated_docs/zh-TW/community.md
@@ -44,7 +44,7 @@ We primarily use [Matrix](https://matrix.org) across the organization and to com
 ### Chat
 
 - [Polkadot Discord](https://discord.gg/polkadot) (RECOMMENDED)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Social media and forums
 

--- a/polkadot-wiki/translated_docs/zh-TW/kusama-community.md
+++ b/polkadot-wiki/translated_docs/zh-TW/kusama-community.md
@@ -28,7 +28,7 @@ We primarily use Matrix across the organization and to communicate with communit
 - [Kusama Direction](https://app.element.io/#/room/!QXMnIJzxlnVrvRzhUA:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) - Governance, and a place to discuss the future of Kusama.
 - [Polkadot Digest](https://matrix.to/#/!vMpYyTkvjXcevxSdsQ:web3.foundation) - News about what is happening in the Polkadot ecosystem, published every weekday except holidays, includes Kusama.
 - To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
-- [Kusama Discord](https://discord.com/invite/9AWjTf8wSk)
+- [Kusama Discord](https://kusa.ma/discord)
 
 ### Technical
 


### PR DESCRIPTION
There is now a proxy link to the Kusama Discord server (https://kusa.ma/discord)