### PR TITLE
Add new precision filter to RPC component

### DIFF
--- a/components/RPC-Connection.jsx
+++ b/components/RPC-Connection.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { ApiPromise, WsProvider } from "@polkadot/api";
-import { HumanReadable, BlocksToDays } from "./utilities/filters";
+import { HumanReadable, Precise, BlocksToDays } from "./utilities/filters";
 
 /*
 This component connects to the Polkadot/Kusama APIs and renders the response data.
@@ -135,11 +135,14 @@ async function syncData(network, path, setReturnValue) {
 function applyFilter(value, filter, network, setReturnValue) {
 	switch (filter) {
 		case "humanReadable":
-			HumanReadable(value, network, setReturnValue)
+			HumanReadable(value, network, setReturnValue);
     	break;
+		case "precise":
+			Precise(value, network, setReturnValue);
+			break;
 		case "blocksToDays":
 			BlocksToDays(value, setReturnValue);
-		break;
+			break;
 		default:
 			console.log("Ignoring unknown filter type");
 			return;

--- a/components/utilities/filters.js
+++ b/components/utilities/filters.js
@@ -47,8 +47,10 @@ module.exports = {
   },
 
   Precise: function (value, network, setReturnValue) {
+    // String to number
+    value = parseFloat(value);
     // Append symbol without rounding
-    value = `${value} ${values[network].symbol}`;
+    value = `${value / values[network].precision} ${values[network].symbol}`;
     // Update value
     setReturnValue(value);
   },

--- a/components/utilities/filters.js
+++ b/components/utilities/filters.js
@@ -46,6 +46,13 @@ module.exports = {
     setReturnValue(value.toString());
   },
 
+  Precise: function (value, network, setReturnValue) {
+    // Append symbol without rounding
+    value = `${value} ${values[network].symbol}`;
+    // Update value
+    setReturnValue(value);
+  },
+
   BlocksToDays: function (value, setReturnValue) {
     value = (value * 6) / 86400;
     // Update value

--- a/components/utilities/filters.js
+++ b/components/utilities/filters.js
@@ -49,7 +49,7 @@ module.exports = {
   Precise: function (value, network, setReturnValue) {
     // String to number
     value = parseFloat(value);
-    // Append symbol without rounding
+    // Apply precision and append symbol without additional rounding
     value = `${value / values[network].precision} ${values[network].symbol}`;
     // Update value
     setReturnValue(value);

--- a/docs/learn/learn-staking-miner.md
+++ b/docs/learn/learn-staking-miner.md
@@ -142,10 +142,8 @@ Current deposit per byte(`SignedDepositByte`) is
 {{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={97656} filter="precise"/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={32551} filter="precise"/> :kusama }}
 and the total is variable depending on the size of the solution data. For example, a solution
-weighing 200KB would require a (200 x
-{{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={97656} filter="precise"/>) :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={32551} filter="precise"/>) :kusama }}
-deposit for the given payload.
+weighing 200KB would yield {{ polkadot: 200 x 0.0000097656 = **0.00195312 DOT**. :polkadot }}
+{{ kusama: 200 x 0.00000032551 = **0.000065102 KSM**. :kusama }}
 
 And the weight deposit(`SignedDepositWeight`) is currently set to `0` and has no effect.
 

--- a/docs/learn/learn-staking-miner.md
+++ b/docs/learn/learn-staking-miner.md
@@ -16,20 +16,20 @@ discretion, as there is a risk of losing some funds.
 
 :::
 
-At the end of each era on Polkadot and Kusama, using [NPoS](learn-phragmen), a new set of validators 
-must be elected based on the nominator preferences. This is a computationally intensive process, hence 
-the usage of the term "mining" for computing the solution. The validators use 
-[off-chain workers](https://docs.substrate.io/reference/how-to-guides/offchain-workers/) to 
-compute the result and submit a transaction to propose the set of winners. This can also be delegated 
-to stand-alone programs, whose task is to mine the optimal solution. Staking miners compete with each other 
-to produce election solutions which consist of a validator set, stake distribution across that set, and a score 
-indicating how optimal the solution is. Staking miners run any given staking algorithms (as of now, 
-sequential Phragmén or PhragMMS, subject to change if improved algorithms are introduced) to produce results, 
-which are then sent as a transaction to the relay chain via a normal signed extrinsic. The transaction 
-requires a bond and a transaction fee. The best solution is rewarded, which the least covers the 
-transaction fee, and the bond is returned to the account. [The bond and the fee](learn-staking-miner#deposit-and-reward-mechanics)  are lost if the solution 
-is invalid.
-
+At the end of each era on Polkadot and Kusama, using [NPoS](learn-phragmen), a new set of validators
+must be elected based on the nominator preferences. This is a computationally intensive process,
+hence the usage of the term "mining" for computing the solution. The validators use
+[off-chain workers](https://docs.substrate.io/reference/how-to-guides/offchain-workers/) to compute
+the result and submit a transaction to propose the set of winners. This can also be delegated to
+stand-alone programs, whose task is to mine the optimal solution. Staking miners compete with each
+other to produce election solutions which consist of a validator set, stake distribution across that
+set, and a score indicating how optimal the solution is. Staking miners run any given staking
+algorithms (as of now, sequential Phragmén or PhragMMS, subject to change if improved algorithms are
+introduced) to produce results, which are then sent as a transaction to the relay chain via a normal
+signed extrinsic. The transaction requires a bond and a transaction fee. The best solution is
+rewarded, which the least covers the transaction fee, and the bond is returned to the account.
+[The bond and the fee](learn-staking-miner#deposit-and-reward-mechanics) are lost if the solution is
+invalid.
 
 Staking miner uses a pallet called `pallet_election_provider_multi_phase` and can only produce
 solutions during the
@@ -134,15 +134,10 @@ to receiving a `SignedRewardBase`.
 ### Deposit
 
 Current deposit(`SignedDepositBase`) is
-{{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositBase" defaultValue={400000000000} filter="humanReadable"/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositBase" defaultValue={133333332000} filter="humanReadable"/> :kusama }}
-which is a fixed amount.
-
-Current deposit per byte(`SignedDepositByte`) is
-{{ polkadot: 0.0000097656 DOT :polkadot }}{{ kusama: 0.00000032551 KSM :kusama }} and the total is
-variable depending on the size of the solution data. For example a solution weighing 200KB would
-yield {{ polkadot: 200 x 0.0000097656 = **0.00195312 DOT**. :polkadot }}
-{{ kusama: 200 x 0.00000032551 = **0.000065102 KSM**. :kusama }}
+{{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={97656} filter="precise"/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={32551} filter="precise"/> :kusama }}
+and the total is variable depending on the size of the solution data. For example a solution
+weighing 200KB would yield {{ polkadot: 200 x 0.0000097656 = **0.00195312 DOT**. :polkadot }}
 
 And the weight deposit(`SignedDepositWeight`) is currently set to `0` and has no effect.
 

--- a/docs/learn/learn-staking-miner.md
+++ b/docs/learn/learn-staking-miner.md
@@ -134,6 +134,11 @@ to receiving a `SignedRewardBase`.
 ### Deposit
 
 Current deposit(`SignedDepositBase`) is
+{{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositBase" defaultValue={400000000000} filter="humanReadable"/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositBase" defaultValue={133333332000} filter="humanReadable"/> :kusama }}
+which is a fixed amount.
+
+Current deposit per byte(`SignedDepositByte`) is
 {{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={97656} filter="precise"/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={32551} filter="precise"/> :kusama }}
 and the total is variable depending on the size of the solution data. For example a solution

--- a/docs/learn/learn-staking-miner.md
+++ b/docs/learn/learn-staking-miner.md
@@ -141,8 +141,11 @@ which is a fixed amount.
 Current deposit per byte(`SignedDepositByte`) is
 {{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={97656} filter="precise"/> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={32551} filter="precise"/> :kusama }}
-and the total is variable depending on the size of the solution data. For example a solution
-weighing 200KB would yield {{ polkadot: 200 x 0.0000097656 = **0.00195312 DOT**. :polkadot }}
+and the total is variable depending on the size of the solution data. For example, a solution
+weighing 200KB would require a (200 x
+{{ polkadot: <RPC network="polkadot" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={97656} filter="precise"/>) :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.electionProviderMultiPhase.signedDepositByte" defaultValue={32551} filter="precise"/>) :kusama }}
+deposit for the given payload.
 
 And the weight deposit(`SignedDepositWeight`) is currently set to `0` and has no effect.
 


### PR DESCRIPTION
This PR addresses https://github.com/w3f/polkadot-wiki/issues/3986 and replaces the hard-coded values in https://github.com/w3f/polkadot-wiki/pull/3954.

This issue was caused by the use of the `HumanReadable` filter which was rounding the total values to zero due to a lack of precision in supporting smaller values.  To address the issue we add a new `Precise` filter that still adequately converts the chain values to the appropriate denomination, but avoids the `toFixed()` invocation.

Before:
![image](https://user-images.githubusercontent.com/13341935/200002102-45e05004-27f1-4432-a16d-8a712c58b01d.png)

After:
![image](https://user-images.githubusercontent.com/13341935/200006388-0eae18e8-b966-469b-a3ba-1810a1f4edfa.png)
