### PR TITLE
Polkadot spec wiki/guide integration

### DIFF
--- a/docs/build/build-index.md
+++ b/docs/build/build-index.md
@@ -7,8 +7,8 @@ keywords: [build, index, tools, resources]
 slug: ../build-index
 ---
 
-Welcome to the builder's section of the {{ polkadot: Polkadot Wiki :polkadot }}
-{{ kusama: Kusama Guide :kusama }}.
+Welcome to the builder's section of the {{ polkadot: Polkadot Wiki. :polkadot }}
+{{ kusama: Kusama Guide. :kusama }}
 
 Here, you will discover many development tools and resources in the Polkadot ecosystem. We are
 always adding new tools and frameworks as we learn about them so if you are working on something

--- a/docs/build/build-index.md
+++ b/docs/build/build-index.md
@@ -8,13 +8,13 @@ slug: ../build-index
 ---
 
 Welcome to the builder's section of the {{ polkadot: Polkadot Wiki :polkadot }}
-{{ kusama: Kusama Guide:kusama }}.
+{{ kusama: Kusama Guide :kusama }}.
 
 Here, you will discover many development tools and resources in the Polkadot ecosystem. We are
 always adding new tools and frameworks as we learn about them so if you are working on something
 that should be included please reach out to us on
-{{ polkadot: [Element](https://matrix.to/#/#polkadot-watercooler:matrix.org) :polkadot }}
-{{ kusama: [Element](https://matrix.to/#/#kusama-watercooler:matrix.org) :kusama }}. This section of
+{{ polkadot: [Element](https://matrix.to/#/#polkadot-watercooler:matrix.org). :polkadot }}
+{{ kusama: [Element](https://matrix.to/#/#kusama-watercooler:matrix.org). :kusama }} This section of
 the wiki is divided into the following parts:
 
 ## Development Guide

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -137,6 +137,29 @@ More info:
 
 ## Extrinsics and Events
 
+### Block Format
+
+A Polkadot block consists a block header and a block body. The block body in turn is made up out of
+extrinsics, which represent the generalization of the concept of transactions. Extrinsics can
+contain any set of external data the underlying chain wishes to validate and track.
+
+The block header is a 5-tuple containing the following elements:
+
+- `parent_hash`: 32-byte Blake2b hash of the SCALE encoded parent block header.
+- `number`: an integer, which represents the index of the current block in the chain. It is equal to
+  the number of the ancestor blocks. The genesis state has number 0.
+- `state_root`: the root of the Merkle trie, whose leaves implement the storage for the system.
+- `extrinsics_root`: field which is reserved for the Runtime to validate the integrity of the
+  extrinsics composing the block body.
+- `digest`: field used to store any chain-specific auxiliary data, which could help the light
+  clients interact with the block without the need of accessing the full storage as well as
+  consensus-related data including the block signature.
+
+When a node creates or receives a new block, it must be announced to the network. Other nodes within
+the network will track this announcement and can request information about this block. Additional
+details on the process are outlined [here](https://spec.polkadot.network/#sect-msg-block-announce)
+in the Polkadot Spec.
+
 ### Extrinsics
 
 Extrinsics constitute information from the outside world and take on three forms:

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -140,14 +140,14 @@ More info:
 ### Block Format
 
 A Polkadot block consists of a block header and a block body. The block body is made up of
-extrinsics representing the generalization of the concept of transactions. Extrinsics can
-contain any external data the underlying chain wishes to validate and track.
+extrinsics representing the generalization of the concept of transactions. Extrinsics can contain
+any external data the underlying chain wishes to validate and track.
 
 The block header is a 5-tuple containing the following elements:
 
 - `parent_hash`: a 32-byte Blake2b hash of the SCALE encoded parent block header.
-- `number`: an integer representing the index of the current block in the chain. It is equal to
-  the number of the ancestor blocks. The genesis state has number 0.
+- `number`: an integer representing the index of the current block in the chain. It is equal to the
+  number of the ancestor blocks. The genesis state has number 0.
 - `state_root`: the root of the Merkle tree, used as storage for the system.
 - `extrinsics_root`: field which is reserved for the Runtime to validate the integrity of the
   extrinsics composing the block body.
@@ -155,10 +155,10 @@ The block header is a 5-tuple containing the following elements:
   clients interact with the block without the need of accessing the full storage as well as
   consensus-related data including the block signature.
 
-A node creating or receiving a block must gossip that block to the network (i.e. to the other nodes). Other nodes within
-the network will track this announcement and can request information about the block. Additional
-details on the process are outlined [here](https://spec.polkadot.network/#sect-msg-block-announce)
-in the Polkadot Spec.
+A node creating or receiving a block must gossip that block to the network (i.e. to the other
+nodes). Other nodes within the network will track this announcement and can request information
+about the block. Additional details on the process are outlined
+[here](https://spec.polkadot.network/#sect-msg-block-announce) in the Polkadot Spec.
 
 ### Extrinsics
 
@@ -174,8 +174,8 @@ however, see other extrinsics within the blocks that you decode. Find more infor
 
 Inherent extrinsics are unsigned and contain information that is not provably true, but validators
 agree on based on some measure of reasonability. For example, a timestamp cannot be proved, but
-validators can agree that it is within some time difference on their system clock. Inherents are broadcasted
-as part of the produced blocks rather than being gossiped as individual extrinsics.
+validators can agree that it is within some time difference on their system clock. Inherents are
+broadcasted as part of the produced blocks rather than being gossiped as individual extrinsics.
 
 Signed transactions contain a signature of the account that issued the transaction and stands to pay
 a fee to have the transaction included on chain. Because the value of including signed transactions

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -155,7 +155,7 @@ The block header is a 5-tuple containing the following elements:
   clients interact with the block without the need of accessing the full storage as well as
   consensus-related data including the block signature.
 
-When a node creates or receives a new block, it must be announced to the network. Other nodes within
+A node creating or receiving a block must gossip that block to the network (i.e. to the other nodes). Other nodes within
 the network will track this announcement and can request information about the block. Additional
 details on the process are outlined [here](https://spec.polkadot.network/#sect-msg-block-announce)
 in the Polkadot Spec.
@@ -174,7 +174,7 @@ however, see other extrinsics within the blocks that you decode. Find more infor
 
 Inherent extrinsics are unsigned and contain information that is not provably true, but validators
 agree on based on some measure of reasonability. For example, a timestamp cannot be proved, but
-validators can agree that it is within some time difference of their system clock. Inherents are broadcasted
+validators can agree that it is within some time difference on their system clock. Inherents are broadcasted
 as part of the produced blocks rather than being gossiped as individual extrinsics.
 
 Signed transactions contain a signature of the account that issued the transaction and stands to pay

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -139,16 +139,16 @@ More info:
 
 ### Block Format
 
-A Polkadot block consists a block header and a block body. The block body in turn is made up out of
-extrinsics, which represent the generalization of the concept of transactions. Extrinsics can
-contain any set of external data the underlying chain wishes to validate and track.
+A Polkadot block consists of a block header and a block body. The block body is made up of
+extrinsics representing the generalization of the concept of transactions. Extrinsics can
+contain any external data the underlying chain wishes to validate and track.
 
 The block header is a 5-tuple containing the following elements:
 
 - `parent_hash`: 32-byte Blake2b hash of the SCALE encoded parent block header.
-- `number`: an integer, which represents the index of the current block in the chain. It is equal to
+- `number`: an integer representing the index of the current block in the chain. It is equal to
   the number of the ancestor blocks. The genesis state has number 0.
-- `state_root`: the root of the Merkle trie, whose leaves implement the storage for the system.
+- `state_root`: the root of the Merkle tree, used as storage for the system.
 - `extrinsics_root`: field which is reserved for the Runtime to validate the integrity of the
   extrinsics composing the block body.
 - `digest`: field used to store any chain-specific auxiliary data, which could help the light
@@ -156,7 +156,7 @@ The block header is a 5-tuple containing the following elements:
   consensus-related data including the block signature.
 
 When a node creates or receives a new block, it must be announced to the network. Other nodes within
-the network will track this announcement and can request information about this block. Additional
+the network will track this announcement and can request information about the block. Additional
 details on the process are outlined [here](https://spec.polkadot.network/#sect-msg-block-announce)
 in the Polkadot Spec.
 
@@ -174,7 +174,7 @@ however, see other extrinsics within the blocks that you decode. Find more infor
 
 Inherent extrinsics are unsigned and contain information that is not provably true, but validators
 agree on based on some measure of reasonability. For example, a timestamp cannot be proved, but
-validators can agree that it is within some delta of their system clock. Inherents are broadcasted
+validators can agree that it is within some time difference of their system clock. Inherents are broadcasted
 as part of the produced blocks rather than being gossiped as individual extrinsics.
 
 Signed transactions contain a signature of the account that issued the transaction and stands to pay

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -145,7 +145,7 @@ contain any external data the underlying chain wishes to validate and track.
 
 The block header is a 5-tuple containing the following elements:
 
-- `parent_hash`: 32-byte Blake2b hash of the SCALE encoded parent block header.
+- `parent_hash`: a 32-byte Blake2b hash of the SCALE encoded parent block header.
 - `number`: an integer representing the index of the current block in the chain. It is equal to
   the number of the ancestor blocks. The genesis state has number 0.
 - `state_root`: the root of the Merkle tree, used as storage for the system.

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -149,10 +149,10 @@ As an infrastructure provider, you will deal almost exclusively with signed tran
 however, see other extrinsics within the blocks that you decode. Find more information in the
 [Substrate documentation](https://docs.substrate.io/main-docs/build/tx-weights-fees/).
 
-Inherents contain information that is not provably true, but validators agree on based on some
-measure of reasonability. For example, a timestamp cannot be proved, but validators can agree that
-it is within some delta of their system clock. Inherents are not gossiped on the network, and only
-block authors insert them into blocks.
+Inherent extrinsics are unsigned and contain information that is not provably true, but validators
+agree on based on some measure of reasonability. For example, a timestamp cannot be proved, but
+validators can agree that it is within some delta of their system clock. Inherents are broadcasted
+as part of the produced blocks rather than being gossiped as individual extrinsics.
 
 Signed transactions contain a signature of the account that issued the transaction and stands to pay
 a fee to have the transaction included on chain. Because the value of including signed transactions
@@ -163,6 +163,9 @@ Bitcoin.
 Some transactions cannot be signed by a fee-paying account and use unsigned transactions. For
 example, when a user claims their DOT from the Ethereum DOT indicator contract to a new DOT address,
 the new address doesn't yet have any funds with which to pay fees.
+
+The Polkadot Host does not specify or limit the internals of each extrinsics and those are defined
+and dealt with by the Runtime.
 
 ### Transaction Mortality
 

--- a/docs/build/build-substrate.md
+++ b/docs/build/build-substrate.md
@@ -42,12 +42,10 @@ with their applications.
 
 ### Substrate (full node) vs. Substrate connect (light client)
 
-A light client is a client that lets you utilize all the possibilities of the chain, but it does not
-require you to run a full copy of the entire blockchain. Light clients fetch the required data that
+A light client lets you utilize all basic features of the chain such as fetching data and transferring tokens, but it does not
+require you to run a full copy of the entire blockchain or having to trust remote peers. Light clients fetch the required data that
 they need from a {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} node with an
-associated proof to validate the data. This makes it possible to interact with the
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} network without requiring to run a
-full node or having to trust the remote peers.
+associated proof to validate the data.
 
 | Substrate: Full node                                                                                        | Substrate connect: Light client                                                                               |
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |

--- a/docs/build/build-substrate.md
+++ b/docs/build/build-substrate.md
@@ -42,10 +42,11 @@ with their applications.
 
 ### Substrate (full node) vs. Substrate connect (light client)
 
-A light client lets you utilize all basic features of the chain such as fetching data and transferring tokens, but it does not
-require you to run a full copy of the entire blockchain or having to trust remote peers. Light clients fetch the required data that
-they need from a {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} node with an
-associated proof to validate the data.
+A light client lets you utilize all basic features of the chain such as fetching data and
+transferring tokens, but it does not require you to run a full copy of the entire blockchain or
+having to trust remote peers. Light clients fetch the required data that they need from a
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} node with an associated proof to
+validate the data.
 
 | Substrate: Full node                                                                                        | Substrate connect: Light client                                                                               |
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |

--- a/docs/build/build-substrate.md
+++ b/docs/build/build-substrate.md
@@ -43,7 +43,11 @@ with their applications.
 ### Substrate (full node) vs. Substrate connect (light client)
 
 A light client is a client that lets you utilize all the possibilities of the chain, but it does not
-require you to run a full copy of the entire blockchain.
+require you to run a full copy of the entire blockchain. Light clients fetch the required data that
+they need from a {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} node with an
+associated proof to validate the data. This makes it possible to interact with the
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} network without requiring to run a
+full node or having to trust the remote peers.
 
 | Substrate: Full node                                                                                        | Substrate connect: Light client                                                                               |
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -96,7 +96,7 @@ at capacity cannot be oversubscribed unless more nominators select it before the
 
 ## Collations
 
-Pparachain blocks or candidates that are being proposed to the Polkadot relay chain validators. More
+Parachain blocks or candidates that are being proposed to the Polkadot relay chain validators. More
 specifically, a collation is a [data structure](https://spec.polkadot.network/#defn-collation) which
 contains the proposed parachain candidate, including an optional validation parachain Runtime update
 and upward messages.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -37,7 +37,7 @@ such as Polkadot's NPoS algorithm.
 
 ## Availability Cores
 
-Slots used to process parachains. The Runtime assigns each parachain to a availability core and
+Slots used to process parachains. The Runtime assigns each parachain to an availability core and
 validators can fetch information about the cores, such as parachain block candidates, by calling the
 appropriate Runtime API.
 

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -94,6 +94,13 @@ the number of nominators necessary to oversubscribe a validator. Any validator w
 capacity" or higher may potentially be oversubscribed in the next session; a validator that is not
 at capacity cannot be oversubscribed unless more nominators select it before the next election.
 
+## Collations
+
+Pparachain blocks or candidates that are being proposed to the Polkadot relay chain validators. More
+specifically, a collation is a [data structure](https://spec.polkadot.network/#defn-collation) which
+contains the proposed parachain candidate, including an optional validation parachain Runtime update
+and upward messages.
+
 ## Collator
 
 A node that maintains a parachain by collecting parachain transactions and producing state

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -35,9 +35,22 @@ mechanisms. In [GRANDPA](#grandpa-finality-gadget), the authorities vote on chai
 final. In BABE, the authorities are block producers. Authority sets can be chosen to be mechanisms
 such as Polkadot's NPoS algorithm.
 
+## Availability Cores
+
+Slots used to process parachains. The Runtime assigns each parachain to a availability core and
+validators can fetch information about the cores, such as parachain block candidates, by calling the
+appropriate Runtime API.
+
 ## BABE
 
 Blind Assignment for Blockchain Extension (BABE) is Polkadot's block production mechanism.
+
+## Bitfield Array
+
+A bitfield array contains single-bit values which indicate whether a [candidate](#candidate) is
+available. The number of items is equal of to the number of
+[availability cores](#availability-cores) and each bit represents a vote on the corresponding core
+in the given order.
 
 ## Block
 
@@ -93,6 +106,11 @@ potentially actively nominate that validator in the next session). This maximum 
 the number of nominators necessary to oversubscribe a validator. Any validator which is "at
 capacity" or higher may potentially be oversubscribed in the next session; a validator that is not
 at capacity cannot be oversubscribed unless more nominators select it before the next election.
+
+## Candidate
+
+A candidate is a submitted parachain block to the relay chain validators. A parachain block stops
+being referred to as a candidate as soon it has been finalized.
 
 ## Collations
 
@@ -614,6 +632,15 @@ Networks are often executed on a testnet before they are deployed to a [mainnet]
 ## Tokenization
 
 The process of replacing sensitive data with non-sensitive data.
+
+## Tranche
+
+Validators use a subjective, tick-based system to determine when the approval process should start.
+A validator starts the tick-based system when a new availability core candidates have been proposed,
+which can be retrieved via the
+[Runtime API](https://spec.polkadot.network/#sect-rt-api-availability-cores), and increments the
+tick every 500 milliseconds. Each tick/increment is referred to as a “tranche”, represented as an
+integer, starting at 0.
 
 ## Transfer
 

--- a/docs/learn/learn-architecture.md
+++ b/docs/learn/learn-architecture.md
@@ -87,9 +87,8 @@ isolation.
 the Relay Chain. They also accept proofs of valid state transition from collators and receive
 staking rewards in return.
 
-Validators are required to keep enough parachain blocks that should be included in the relay chain
-available in their local storage in order to make those retrievable by peers, who lack the
-information, to reliably confirm the issued validity statements about parachain blocks. The
+Validators are required to keep enough parachain blocks available for later use in their local storage. Those blocks are retrievable by peers who lack that
+information, so that they can reliably confirm the issued validity statements about parachain blocks. The
 [Availability & Validity](https://spec.polkadot.network/#chapter-anv) (AnV) protocol consists of
 multiple steps for successfully upholding those responsibilities.
 

--- a/docs/learn/learn-architecture.md
+++ b/docs/learn/learn-architecture.md
@@ -84,8 +84,14 @@ isolation.
 ## Validators
 
 [Validators](../general/glossary.md#validator), if elected to the validator set, produce blocks on
-the Relay Chain. They also accept proofs of valid state transition from collators. In return, they
-will receive staking rewards.
+the Relay Chain. They also accept proofs of valid state transition from collators and receive
+staking rewards in return.
+
+Validators are required to keep enough parachain blocks that should be included in the relay chain
+available in their local storage in order to make those retrievable by peers, who lack the
+information, to reliably confirm the issued validity statements about parachain blocks. The
+[Availability & Validity](https://spec.polkadot.network/#chapter-anv) (AnV) protocol consists of
+multiple steps for successfully upholding those responsibilities.
 
 ## Nominators
 
@@ -98,6 +104,9 @@ nominators are generally rewarded with a portion of the staking rewards from tha
 [Collators](../general/glossary.md#collator) are full nodes on both a parachain and the Relay Chain.
 They collect parachain transactions and produce state transition proofs for the validators on the
 Relay Chain. They can also send and receive messages from other parachains using XCMP.
+
+Parachain blocks themselves are produced by collators, whereas the relay chain validators only
+verify their validity (and later, their availability).
 
 ---
 

--- a/docs/learn/learn-architecture.md
+++ b/docs/learn/learn-architecture.md
@@ -87,8 +87,9 @@ isolation.
 the Relay Chain. They also accept proofs of valid state transition from collators and receive
 staking rewards in return.
 
-Validators are required to keep enough parachain blocks available for later use in their local storage. Those blocks are retrievable by peers who lack that
-information, so that they can reliably confirm the issued validity statements about parachain blocks. The
+Validators are required to keep enough parachain blocks available for later use in their local
+storage. Those blocks are retrievable by peers who lack that information, so that they can reliably
+confirm the issued validity statements about parachain blocks. The
 [Availability & Validity](https://spec.polkadot.network/#chapter-anv) (AnV) protocol consists of
 multiple steps for successfully upholding those responsibilities.
 

--- a/docs/learn/learn-availability.md
+++ b/docs/learn/learn-availability.md
@@ -8,7 +8,7 @@ slug: ../learn-availability
 ---
 
 The [Availability and Validity](https://spec.polkadot.network/#chapter-anv) (AnV) protocol of
-Polkadot is what allows for the network to be efficiently sharded among parachains while maintaining
+Polkadot allows the network to be efficiently sharded among parachains while maintaining
 strong security guarantees.
 
 ## Phases of the AnV protocol

--- a/docs/learn/learn-availability.md
+++ b/docs/learn/learn-availability.md
@@ -40,7 +40,7 @@ parachain's registered code. If the verification succeeds, then the validators w
 candidate block to the other validators in the gossip network. However, if the verification fails,
 the validators immediately reject the candidate block as invalid.
 
-validators need to determine their assignments for each parachain and issue approvals for valid
+Validators need to determine their assignments for each parachain and issue approvals for valid
 candidates, respectively disputes for invalid candidates. Since it cannot be expected that each
 validator verifies every single parachain candidate, this mechanism ensures that enough honest
 validators are selected to verify parachain candidates in order prevent the finalization of invalid

--- a/docs/learn/learn-availability.md
+++ b/docs/learn/learn-availability.md
@@ -40,6 +40,14 @@ parachain's registered code. If the verification succeeds, then the validators w
 candidate block to the other validators in the gossip network. However, if the verification fails,
 the validators immediately reject the candidate block as invalid.
 
+validators need to determine their assignments for each parachain and issue approvals for valid
+candidates, respectively disputes for invalid candidates. Since it cannot be expected that each
+validator verifies every single parachain candidate, this mechanism ensures that enough honest
+validators are selected to verify parachain candidates in order prevent the finalization of invalid
+blocks. If an honest validator detects an invalid block which was approved by one or more
+validators, the honest validator must issue a disputes which wil cause escalations, resulting in
+consequences for all malicious parties.
+
 When more than half of the parachain validators agree that a particular parachain block candidate is
 a valid state transition, they prepare a _candidate receipt_. The candidate receipt is what will
 eventually be included into the Relay Chain state. It includes:

--- a/docs/learn/learn-availability.md
+++ b/docs/learn/learn-availability.md
@@ -7,8 +7,9 @@ keywords: [availability, validity, sharding, AnV]
 slug: ../learn-availability
 ---
 
-The Availability and Validity (AnV) protocol of Polkadot is what allows for the network to be
-efficiently sharded among parachains while maintaining strong security guarantees.
+The [Availability and Validity](https://spec.polkadot.network/#chapter-anv) (AnV) protocol of
+Polkadot is what allows for the network to be efficiently sharded among parachains while maintaining
+strong security guarantees.
 
 ## Phases of the AnV protocol
 

--- a/docs/learn/learn-collator.md
+++ b/docs/learn/learn-collator.md
@@ -17,14 +17,20 @@ meaning they retain all necessary information to be able to author new blocks an
 transactions in much the same way as miners do on current PoW blockchains. Under normal
 circumstances, they will collate and execute transactions to create an unsealed block and provide
 it, together with a proof of state transition, to one or more validators responsible for proposing a
-parachain block.
+parachain block.relay chain validator
 
 Unlike validators, collator nodes do not secure the network. If a parachain block is invalid, it
-will get rejected by validators. Therefore the assumption that having more collators is better or
-more secure is not correct. On the contrary, too many collators may slow down the network. The only
-nefarious power collators have is transaction censorship. To prevent censorship, a parachain only
-needs to ensure that there exist some neutral collators - but not necessarily a majority.
-Theoretically, the censorship problem is solved with having just one honest collator.
+will get rejected by validators. The validators are required to check the validity of submitted
+candidates, followed by issuing and collecting statements about the validity of candidates to other
+validators. This process is known as **candidate backing**. Once a candidate meets a specified
+criteria for inclusion, the selected relay chain block author then choses any of the backed
+candidates for each parachain and includes those into the relay chain block.
+
+The assumption that having more collators is better or more secure is not correct. On the contrary,
+too many collators may slow down the network. The only nefarious power collators have is transaction
+censorship. To prevent censorship, a parachain only needs to ensure that there exist some neutral
+collators - but not necessarily a majority. Theoretically, the censorship problem is solved with
+having just one honest collator.
 
 ## XCM
 

--- a/docs/learn/learn-collator.md
+++ b/docs/learn/learn-collator.md
@@ -22,9 +22,9 @@ parachain block.
 Unlike validators, collator nodes do not secure the network. If a parachain block is invalid, it
 will get rejected by validators. The validators are required to check the validity of submitted
 candidates, followed by issuing and collecting statements about the validity of candidates to other
-validators. This process is known as **candidate backing**. The Polkadot validator receives an
+validators. This process is known as **candidate backing**. Validators receive an
 arbitrary number of parachain candidates with associated proofs from untrusted collators. A
-candidate is considered backable when at least 2/3 of all assigned validators have issued a Valid
+candidate is considered backable when at least 2/3 of all assigned validators have issued a valid
 statement about that candidate.
 
 The validator must successfully verify the following conditions in the following order:
@@ -41,7 +41,7 @@ block.
 
 The assumption that having more collators is better or more secure is not correct. On the contrary,
 too many collators may slow down the network. The only nefarious power collators have is transaction
-censorship. To prevent censorship, a parachain only needs to ensure that there exist some neutral
+censorship. To prevent censorship, a parachain only needs to ensure that there are some neutral
 collators - but not necessarily a majority. Theoretically, the censorship problem is solved with
 having just one honest collator.
 

--- a/docs/learn/learn-collator.md
+++ b/docs/learn/learn-collator.md
@@ -17,7 +17,7 @@ meaning they retain all necessary information to be able to author new blocks an
 transactions in much the same way as miners do on current PoW blockchains. Under normal
 circumstances, they will collate and execute transactions to create an unsealed block and provide
 it, together with a proof of state transition, to one or more validators responsible for proposing a
-parachain block.relay chain validator
+parachain block.
 
 Unlike validators, collator nodes do not secure the network. If a parachain block is invalid, it
 will get rejected by validators. The validators are required to check the validity of submitted
@@ -25,7 +25,15 @@ candidates, followed by issuing and collecting statements about the validity of 
 validators. This process is known as **candidate backing**. The Polkadot validator receives an
 arbitrary number of parachain candidates with associated proofs from untrusted collators. A
 candidate is considered backable when at least 2/3 of all assigned validators have issued a Valid
-statement about that candidate
+statement about that candidate.
+
+The validator must successfully verify the following conditions in the following order:
+
+1. The candidate does not exceed any parameters in the persisted validation data (Definition 231).
+
+2. The signature of the collator is valid.
+
+3. Validate the candidate by executing the parachain Runtime.
 
 Once a candidate meets a specified criteria for inclusion, the selected relay chain block author
 then choses any of the backed candidates for each parachain and includes those into the relay chain

--- a/docs/learn/learn-collator.md
+++ b/docs/learn/learn-collator.md
@@ -22,9 +22,14 @@ parachain block.relay chain validator
 Unlike validators, collator nodes do not secure the network. If a parachain block is invalid, it
 will get rejected by validators. The validators are required to check the validity of submitted
 candidates, followed by issuing and collecting statements about the validity of candidates to other
-validators. This process is known as **candidate backing**. Once a candidate meets a specified
-criteria for inclusion, the selected relay chain block author then choses any of the backed
-candidates for each parachain and includes those into the relay chain block.
+validators. This process is known as **candidate backing**. The Polkadot validator receives an
+arbitrary number of parachain candidates with associated proofs from untrusted collators. A
+candidate is considered backable when at least 2/3 of all assigned validators have issued a Valid
+statement about that candidate
+
+Once a candidate meets a specified criteria for inclusion, the selected relay chain block author
+then choses any of the backed candidates for each parachain and includes those into the relay chain
+block.
 
 The assumption that having more collators is better or more secure is not correct. On the contrary,
 too many collators may slow down the network. The only nefarious power collators have is transaction

--- a/docs/learn/learn-collator.md
+++ b/docs/learn/learn-collator.md
@@ -29,7 +29,7 @@ statement about that candidate.
 
 The validator must successfully verify the following conditions in the following order:
 
-1. The candidate does not exceed any parameters in the persisted validation data (Definition 231).
+1. The candidate does not exceed any parameters in the persisted validation data.
 
 2. The signature of the collator is valid.
 

--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -111,15 +111,14 @@ the validator nodes and determines the authors of new blocks. BABE is comparable
 selection rule and slot time adjustments. BABE assigns block production slots to validators
 according to stake and using the Polkadot [randomness cycle](learn-randomness.md).
 
-BABE execution happens in sequential non-overlapping phases known as an epoch. Each epoch on its
-turn is divided into a predefined number of slots. All slots in each epoch are sequentially indexed
+BABE execution happens in sequential non-overlapping phases known as epochs. Each epoch is divided into a predefined number of slots. All slots in each epoch are sequentially indexed
 starting from 0 (slot number). At the beginning of each epoch, the BABE node needs to run the
 [Block-Production-Lottery algorithm](https://spec.polkadot.network/#algo-block-production-lottery)
 to find out in which slots it should produce a block and gossip to the other block producers.
 
-Validators in Polkadot participate in a lottery for every slot, which will inform whether or not
-they are the block producer candidate for that slot. Slots are discrete units of time, nominally 6
-seconds in length. Because of this randomness mechanism, multiple validators could be candidates for
+Validators participate in a lottery for every slot, which will inform whether or not
+they are the block producer candidate for that slot. Slots are discrete units of time of approximately 6
+seconds in length. Because the mechanism of allocating slots to validators is based on a randomized design, multiple validators could be candidates for
 the same slot. Other times, a slot could be empty, resulting in inconsistent block time.
 
 ### Multiple Validators per Slot

--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -111,15 +111,17 @@ the validator nodes and determines the authors of new blocks. BABE is comparable
 selection rule and slot time adjustments. BABE assigns block production slots to validators
 according to stake and using the Polkadot [randomness cycle](learn-randomness.md).
 
-BABE execution happens in sequential non-overlapping phases known as epochs. Each epoch is divided into a predefined number of slots. All slots in each epoch are sequentially indexed
-starting from 0 (slot number). At the beginning of each epoch, the BABE node needs to run the
+BABE execution happens in sequential non-overlapping phases known as epochs. Each epoch is divided
+into a predefined number of slots. All slots in each epoch are sequentially indexed starting from 0
+(slot number). At the beginning of each epoch, the BABE node needs to run the
 [Block-Production-Lottery algorithm](https://spec.polkadot.network/#algo-block-production-lottery)
 to find out in which slots it should produce a block and gossip to the other block producers.
 
-Validators participate in a lottery for every slot, which will inform whether or not
-they are the block producer candidate for that slot. Slots are discrete units of time of approximately 6
-seconds in length. Because the mechanism of allocating slots to validators is based on a randomized design, multiple validators could be candidates for
-the same slot. Other times, a slot could be empty, resulting in inconsistent block time.
+Validators participate in a lottery for every slot, which will inform whether or not they are the
+block producer candidate for that slot. Slots are discrete units of time of approximately 6 seconds
+in length. Because the mechanism of allocating slots to validators is based on a randomized design,
+multiple validators could be candidates for the same slot. Other times, a slot could be empty,
+resulting in inconsistent block time.
 
 ### Multiple Validators per Slot
 

--- a/docs/learn/learn-polkadot-host.md
+++ b/docs/learn/learn-polkadot-host.md
@@ -35,9 +35,10 @@ A host node...
 1. must populate the state storage with the official genesis state.
 2. should maintain a set of around 50 active peers at any time. New peers can be found using the
    discovery protocols.
-3. should open and maintain the various required streams with each of its active peers. 4.should
-   send block requests to these peers to receive all blocks in the chain and execute each of them.
-4. should exchange neighbor packets.
+3. should open and maintain the various required streams with each of its active peers.
+4. should send block requests to these peers to receive all blocks in the chain and execute each of
+   them.
+5. should exchange neighbor packets.
 
 Additional information on each of these requirements can be found
 [here](https://spec.polkadot.network/#chapter-bootstrapping).

--- a/docs/learn/learn-polkadot-host.md
+++ b/docs/learn/learn-polkadot-host.md
@@ -16,11 +16,11 @@ static over the lifetime of Polkadot.
 The Polkadot host interacts with the Polkadot runtime in limited, and well-specified ways. For this
 reason, implementation teams can build an alternative implementation of the Polkadot host while
 treating the Polkadot runtime as a black box. For more details of the interactions between the host
-and the runtime, please see the [specification][].
+and the runtime, please see the [specification][https://spec.polkadot.network/].
 
 ## Components of the Polkadot host
 
-- Networking components such as Libp2p that facilitates network interactions.
+- Networking components such as `Libp2p` that facilitates network interactions.
 - State storage and the storage trie along with the database layer.
 - Consensus engine for GRANDPA and BABE.
 - Wasm interpreter and virtual machine.
@@ -30,6 +30,18 @@ A compiled Polkadot runtime, a blob of Wasm code, can be uploaded into the Polka
 the logic for the execution of state transitions. Without a runtime, the Polkadot host is unable to
 make state transitions or produce any blocks.
 
+A host node...
+
+1. must populate the state storage with the official genesis state.
+2. should maintain a set of around 50 active peers at any time. New peers can be found using the
+   discovery protocols.
+3. should open and maintain the various required streams with each of its active peers. 4.should
+   send block requests to these peers to receive all blocks in the chain and execute each of them.
+4. should exchange neighbor packets.
+
+Additional information on each of these requirements can be found
+[here](https://spec.polkadot.network/#chapter-bootstrapping).
+
 ## Diagram
 
 Below is a diagram that displays the Polkadot host surrounding the Polkadot runtime. Think of the
@@ -38,11 +50,16 @@ parts in grey are stable and can not change without an explicit hard fork.
 
 ![polkadot host](../assets/updated_pre.png)
 
+## Code Executor
+
+The Polkadot Host executes the calls of Runtime entrypoints inside a Wasm Virtual Machine (VM),
+which in turn provides the Runtime with access to the Polkadot Host API. This part of the Polkadot
+Host is referred to as the Executor. For additional technical implementation details, check out
+[this section](https://spec.polkadot.network/#sect-code-executor) of the Polkadot Spec.
+
 ## Resources
 
 - [Polkadot Host Protocol Specification](https://github.com/w3f/polkadot-spec) - Incubator for the
   Polkadot Host spec, including tests.
 - [Gossamer: A Go implementation of the Polkadot Host](https://github.com/ChainSafe/gossamer)
 - [Kagome - C++ implementation of Polkadot Host](https://github.com/soramitsu/kagome)
-
-[specification]: https://github.com/w3f/polkadot-spec/

--- a/docs/learn/learn-polkadot-host.md
+++ b/docs/learn/learn-polkadot-host.md
@@ -40,6 +40,10 @@ A host node...
    them.
 5. should exchange neighbor packets.
 
+Consensus in the Polkadot Host is achieved during the execution of two different procedures,
+block-production and finality. The Polkadot Host must run these procedures if (and only if) it is
+running on a validator node.
+
 Additional information on each of these requirements can be found
 [here](https://spec.polkadot.network/#chapter-bootstrapping).
 

--- a/docs/learn/learn-wasm.md
+++ b/docs/learn/learn-wasm.md
@@ -36,7 +36,7 @@ block height, upgrades can be small, isolated, and very specific.
 
 As a result of storing the Runtime as part of the state, the Runtime code itself becomes state
 sensitive and calls to Runtime can change the Runtime code itself. Therefore the Polkadot Host needs
-to always make sure to provide the Runtime corresponding to the state in which the entrypoint has
+to always make sure it provides the Runtime corresponding to the state in which the entrypoint has
 been called.
 
 ## Resources

--- a/docs/learn/learn-wasm.md
+++ b/docs/learn/learn-wasm.md
@@ -34,6 +34,11 @@ levels of offline coordination required, and thus, the propensity to bundle many
 large-scale event. By deploying Wasm on-chain and having nodes auto-enact the new logic at a certain
 block height, upgrades can be small, isolated, and very specific.
 
+As a result of storing the Runtime as part of the state, the Runtime code itself becomes state
+sensitive and calls to Runtime can change the Runtime code itself. Therefore the Polkadot Host needs
+to always make sure to provide the Runtime corresponding to the state in which the entrypoint has
+been called.
+
 ## Resources
 
 - [WebAssembly.org](https://webassembly.org/) - WebAssembly homepage that contains a link to the

--- a/docs/maintain/maintain-guides-how-to-setup-a-validator-with-reverse-proxy.md
+++ b/docs/maintain/maintain-guides-how-to-setup-a-validator-with-reverse-proxy.md
@@ -175,20 +175,19 @@ Nodes will use [libp2p](https://libp2p.io/) as the networking layer to establish
 messages, but uses NGINX as a load balancer which acts as a _first listener_ of the streaming data
 to help balance the load.
 
-Each Polkadot Host node maintains an ED25519 key pair which is used to identify the node. The public
-key is shared with the rest of the network allowing the nodes to establish secure communication
-channels.
+Each host node maintains an ED25519 key pair which is used to identify the node. The public key is
+shared with the rest of the network allowing the nodes to establish secure communication channels.
 
-The Polkadot Host uses various mechanisms to locate peers within the network and allows them to
-share this information with one another.
+The node uses various mechanisms to locate peers within the network and allows them to share this
+information with one another.
 
-Polkadot nodes connect to peers by establishing a TCP connection. Once established, the node
-initiates a handshake with the remote peers on the encryption layer. An additional layer on top of
-the encryption layer, known as the multiplexing layer, allows a connection to be split into
-substreams, as described by the [yamux specification](https://docs.libp2p.io/concepts/multiplex/),
-either by the local or remote node.
+Nodes connect to peers by establishing a TCP connection. Once established, the node initiates a
+handshake with the remote peers on the encryption layer. An additional layer on top of the
+encryption layer, known as the multiplexing layer, allows a connection to be split into substreams,
+as described by the [yamux specification](https://docs.libp2p.io/concepts/multiplex/), either by the
+local or remote node.
 
-The Polkadot node supports two types of substream protocols:
+Nodes supports two types of substream protocols:
 
 - Request-Response substreams
 - Notification substreams

--- a/docs/maintain/maintain-guides-how-to-setup-a-validator-with-reverse-proxy.md
+++ b/docs/maintain/maintain-guides-how-to-setup-a-validator-with-reverse-proxy.md
@@ -175,6 +175,38 @@ Nodes will use [libp2p](https://libp2p.io/) as the networking layer to establish
 messages, but uses NGINX as a load balancer which acts as a _first listener_ of the streaming data
 to help balance the load.
 
+Each Polkadot Host node maintains an ED25519 key pair which is used to identify the node. The public
+key is shared with the rest of the network allowing the nodes to establish secure communication
+channels.
+
+The Polkadot Host uses various mechanisms to locate peers within the network and allows them to
+share this information with one another.
+
+Polkadot nodes connect to peers by establishing a TCP connection. Once established, the node
+initiates a handshake with the remote peers on the encryption layer. An additional layer on top of
+the encryption layer, known as the multiplexing layer, allows a connection to be split into
+substreams, as described by the [yamux specification](https://docs.libp2p.io/concepts/multiplex/),
+either by the local or remote node.
+
+The Polkadot node supports two types of substream protocols:
+
+- Request-Response substreams
+- Notification substreams
+
+More technical details on the connection establishment can be found
+[here](https://spec.polkadot.network/#sect-connection-establishment).
+
+The encryption layer leverages the libp2p Noise framework in order to establish encrypted
+communication channels. The three following steps are required to complete the handshake process:
+
+1. The initiator generates a keypair and sends the public key to the responder.
+2. The responder generates its own key pair and sends its public key back to the initiator. After
+   that, the responder derives a shared secret and uses it to encrypt all further communication. The
+   responder now sends its static Noise public key, its libp2p public key and a signature of the
+   static Noise public key signed with the libp2p public key.
+3. The initiator derives a shared secret and uses it to encrypt all further communication. They also
+   send its static Noise public key, libp2p public key and signature to the responder.
+
 ##### public-addr
 
 `public-addr` - a flexible encoding of multiple layers of protocols into a human-readable addressing

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -404,14 +404,21 @@ validator mode right away:
 :::tip Use Warp sync for faster syncing
 
 By default, the node performs `full` sync, which downloads and validates the full blockchain
-history. `warp` sync can be used as a faster way to sync the validator node.
+history. Full sync works by listening to announced blocks and requesting the blocks from the
+announcing peers, or just the block headers in case of light clients.
+
+`Fast` sync is another option that works by downloading the block header history and validating the
+authority set changes in order to arrive at a specific (usually the most recent) header. After the
+desired header has been reached and verified, the state can be downloaded and imported. Once this
+process has been completed, the node can proceed with a full sync.
 
 `./target/production/polkadot --sync warp`
 
-Warp sync initially downloads and validates the finality proofs from [GRANDPA](../learn/learn-consensus.md#finality-gadget-grandpa)
-and then downloads the state of the latest finalized block. After the warp sync, the node is ready to
-import the latest blocks from the network and can be used as a Validator. The blocks from genesis
-will be downloaded in the background. Check
+`Warp sync` initially downloads and validates the finality proofs from
+[GRANDPA](../learn/learn-consensus.md#finality-gadget-grandpa) and then downloads the state of the
+latest finalized block. After the warp sync, the node is ready to import the latest blocks from the
+network and can be used as a Validator. The blocks from genesis will be downloaded in the
+background. Check
 [this discussion](https://substrate.stackexchange.com/questions/334/what-kinds-of-sync-mechanisms-does-substrate-implement/)
 for more information about the different sync options available.
 


### PR DESCRIPTION
Initial pass on reviewing the following content which is outlined in #3861.

Part 1 - Host Spec:
- [x] [Preliminaries](https://spec.polkadot.network/#_preliminaries)
- [x] [State Specification](https://spec.polkadot.network/#chap-state-spec)
- [x] [State Transition](https://spec.polkadot.network/#chap-state-transit)
- [x] [Networking](https://spec.polkadot.network/#chap-networking)
- [x] [Consensus](https://spec.polkadot.network/#chap-consensus)
- [x] [Availability & Validity](https://spec.polkadot.network/#chapter-anv)

Part 2 - Runtime Spec: #4087