### PR TITLE
if statement logic should be wrapped in brackets

### DIFF
--- a/.github/workflows/audit-links.yml
+++ b/.github/workflows/audit-links.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Create GitHub Issue
-        if: ${{ env.audit_result }} == true
+        if: ${{ env.audit_result == true }}
         uses: "JasonEtco/create-an-issue@v2"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have been testing this GH action now that the script has been deployed to master.  This last step is executing when the audit produces no results (failures) and appears will always execute.  I believe this change will address the issue.