### PR TITLE
Restore conditional check bool to string

### DIFF
--- a/.github/workflows/audit-links.yml
+++ b/.github/workflows/audit-links.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Create GitHub Issue
-        if: ${{ env.audit_result == true }}
+        if: ${{ env.audit_result == 'true' }}
         uses: "JasonEtco/create-an-issue@v2"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR basically reverts #4024 as #4024 fixed the conditional check.  The boolean values are stored in env variables, which converts them to strings.  This can be seen in the final line of the logs below:

![image](https://user-images.githubusercontent.com/13341935/200363640-3b7f089c-8eb7-4eda-a8be-a6e96a4de7dc.png)