### PR TITLE
Extend kusama coverage for several additional documents

### DIFF
--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -80,7 +80,8 @@ serialized call data specific to your transaction. You can read more about the m
 and how to get it in the
 [Substrate documentation](https://docs.substrate.io/reference/command-line-tools/subxt/#metadata).
 
-\* Polkadot supports sr25519, ed25519, and ECDSA as signing schemes.
+\* {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} supports sr25519, ed25519, and
+ECDSA as signing schemes.
 
 **Summary**
 
@@ -133,7 +134,7 @@ Save the output and bring it to the machine that you will broadcast from, enter 
 signature field, and send the transaction (or just return the serialized transaction if using
 `sendOffline`).
 
-## Tx Wrapper Polkadot
+## Tx Wrapper
 
 If you do not want to use the CLI for signing operations, Parity provides an SDK called
 [TxWrapper Core](https://github.com/paritytech/txwrapper-core) to generate and sign transactions

--- a/docs/learn/learn-account-advanced.md
+++ b/docs/learn/learn-account-advanced.md
@@ -49,9 +49,11 @@ them in the [address conversion tools](#address-conversion-tools) section.
 
 If you would like to create and manage several accounts on the network using the same seed, you can
 use derivation paths. We can think of the derived accounts as child accounts of the root account
-created using the original mnemonic seed phrase. Many Polkadot key generation tools support hard and
-soft derivation. For instance, if you intend to create an account to be used on the Polkadot chain,
-you can derive a **hard key** child account using **//** after the mnemonic phrase.
+created using the original mnemonic seed phrase. Many
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} key generation tools support hard and
+soft derivation. For instance, if you intend to create an account to be used on the
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} chain, you can derive a **hard key**
+child account using **//** after the mnemonic phrase.
 
 ```
 'caution juice atom organ advance problem want pledge someone senior holiday very//0'
@@ -387,4 +389,3 @@ for (var key in accounts) {
 
 11. Refresh Polkadot-JS App browser and check Accounts and Addresses pages. All of your accounts and
     addresses should now be available.
-

--- a/docs/learn/learn-account-multisig.md
+++ b/docs/learn/learn-account-multisig.md
@@ -11,9 +11,9 @@ import RPC from "./../../components/RPC-Connection";
 
 ## Introduction to Multisig Accounts
 
-It is possible to create multi-signature accounts (multisig) in Substrate-based chains. A multisig is composed of one or more addresses and a threshold. The threshold defines how many
-signatories (participating addresses) need to agree on submitting an extrinsic for the call to be
-successful.
+It is possible to create multi-signature accounts (multisig) in Substrate-based chains. A multisig
+is composed of one or more addresses and a threshold. The threshold defines how many signatories
+(participating addresses) need to agree on submitting an extrinsic for the call to be successful.
 
 For example, Alice, Bob, and Charlie set up a multisig with a threshold of 2. This means Alice and
 Bob can execute any call even if Charlie disagrees with it. Likewise, Charlie and Bob can execute
@@ -22,11 +22,11 @@ but can also be equal to it, which means they all have to agree.
 
 :::note Explainer on multisig accounts
 
-Learn more about using multisig accounts with the [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) from our
+Learn more about using multisig accounts with the
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) from our
 [technical explainer video](https://www.youtube.com/watch?v=-cPiKMslZqI).
 
 :::
-
 
 :::info
 
@@ -61,17 +61,25 @@ threshold, they will immediately have access to these tokens.
 There are three types of actions you can take with a multisig account:
 
 - Executing a call `asMulti`. This is used to begin or end a multisig transaction.
-- Approving a call `approveAsMulti`. This is used to approve an extrinsic and pass-on to the next signatory (see [example below](#example-using-multi-signature-accounts) for more information).
+- Approving a call `approveAsMulti`. This is used to approve an extrinsic and pass-on to the next
+  signatory (see [example below](#example-using-multi-signature-accounts) for more information).
 - Cancelling a call `cancelAsMulti`.
 
 :::info
 
-Check out [this page](https://polkadot.js.org/docs/substrate/extrinsics#multisig) for more information about the actions you can take with a multi-signature account.
+Check out [this page](https://polkadot.js.org/docs/substrate/extrinsics#multisig) for more
+information about the actions you can take with a multi-signature account.
 
 :::
 
 In scenarios where only a single approval is needed, a convenience method `as_multi_threshold_1`
-should be used. This function takes only the other signatories and the raw call as arguments. Note that the Polkadot-JS UI does not have integration for this call because it is not possible to create multisig accounts with `threshold=1`. If you want to create a multisig with threshold 1, you can use [txwrapper-core](https://github.com/paritytech/txwrapper-core), which is developed and supported by Parity Technologies. There is a detailed [multisig example](https://github.com/paritytech/txwrapper-core/tree/main/packages/txwrapper-examples/multisig) that you can try out and change to see how it works.
+should be used. This function takes only the other signatories and the raw call as arguments. Note
+that the Polkadot-JS UI does not have integration for this call because it is not possible to create
+multisig accounts with `threshold=1`. If you want to create a multisig with threshold 1, you can use
+[txwrapper-core](https://github.com/paritytech/txwrapper-core), which is developed and supported by
+Parity Technologies. There is a detailed
+[multisig example](https://github.com/paritytech/txwrapper-core/tree/main/packages/txwrapper-examples/multisig)
+that you can try out and change to see how it works.
 
 However, in anything but the simple one approval case, you will likely need more than one of the
 signatories to approve the call before finally executing it. When you create a new call or approve a
@@ -87,44 +95,76 @@ The deposit is dependent on the `threshold` parameter and is calculated as follo
 Deposit = depositBase + threshold * depositFactor
 ```
 
-Where `depositBase` and `depositFactor` are chain constants (in {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} units) set in the runtime code. Currently, the deposit base equals <RPC network="polkadot" path="query.multisig.depositBase" defaultValue={200880000000} filter="humanReadable"/> DOT and the deposit factor equals <RPC network="polkadot" path="query.multisig.depositFactor" defaultValue={320000000} filter="humanReadable"/> DOT.
+Where `depositBase` and `depositFactor` are chain constants (in
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} units) set in the runtime code. Currently,
+the deposit base equals
+{{ polkadot: <RPC network="polkadot" path="query.multisig.depositBase" defaultValue={200880000000} filter="humanReadable"/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.multisig.depositBase" defaultValue={669599996400} filter="humanReadable"/> :kusama }}
+and the deposit factor equals
+{{ polkadot: <RPC network="polkadot" path="query.multisig.depositFactor" defaultValue={320000000} filter="humanReadable"/>. :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.multisig.depositFactor" defaultValue={1066665600} filter="humanReadable"/>. :kusama }}
 
 ### Example using Multisig Accounts
 
 :::info Walk-through video tutorial
 
-You can also see [this video tutorial](https://www.youtube.com/watch?v=-cPiKMslZqI) for more information about transacting with multisigs using the Accounts Tab, or [this other video](https://www.youtube.com/watch?v=T0vIuJcTJeQ) using the Extrinsic Tab in the [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts).
+You can also see [this video tutorial](https://www.youtube.com/watch?v=-cPiKMslZqI) for more
+information about transacting with multisigs using the Accounts Tab, or
+[this other video](https://www.youtube.com/watch?v=T0vIuJcTJeQ) using the Extrinsic Tab in the
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts).
 
 :::
 
 ![multisig diagram](../assets/multisig-diagram.png)
 
 Let's consider an example of a multisig on Polkadot with a threshold of 2 and 3 signers: Charlie,
-Dan, and Eleanor. First, Charlie will create the call on-chain by calling the `multisig.asMulti` extrinsic with the raw
-call, in this case, a balance transfer (`balances.transferKeepAlive` extrinsic) from multisig CDE to Frank's account. When doing this, Charlie will have to deposit `DepositBase + (2 * DepositFactor) = 20.152 DOT`
-while he waits for either Dan or Eleanor also to approve the balance transfer call using the `multisig.approveAsMulti` or the `multisig.asMulti` extrinsics.
+Dan, and Eleanor. First, Charlie will create the call on-chain by calling the `multisig.asMulti`
+extrinsic with the raw call, in this case, a balance transfer (`balances.transferKeepAlive`
+extrinsic) from multisig CDE to Frank's account. When doing this, Charlie will have to deposit
+`DepositBase + (2 * DepositFactor) = 20.152 DOT` while he waits for either Dan or Eleanor also to
+approve the balance transfer call using the `multisig.approveAsMulti` or the `multisig.asMulti`
+extrinsics.
 
-If Dan submits the `multisig.approveAsMulti` extrinsic, he approves Charlie's call but he passes on the final approval to Eleanor. So, although the multisig has threshold 2, in this case all 3/3 signatories need to participate in the transaction approval. Eleanor will need to submit a `multisig.asMulti` or `multisig.approveAsMulti` extrinsic to transfer funds from CDE to Frank.
+If Dan submits the `multisig.approveAsMulti` extrinsic, he approves Charlie's call but he passes on
+the final approval to Eleanor. So, although the multisig has threshold 2, in this case all 3/3
+signatories need to participate in the transaction approval. Eleanor will need to submit a
+`multisig.asMulti` or `multisig.approveAsMulti` extrinsic to transfer funds from CDE to Frank.
 
-Alternatively, Dan or Eleanor can just submit a `multisig.asMulti` extrinsic after Charlie to transfer the funds. In this case, 2/3 signatories will participate in the transaction approval. The accounts approving Charlie's call will not need to place the deposit, and Charlie will receive his
-deposit back once the transfer is successful or canceled. To cancel the transaction, Dan or Eleanor can use the `multisig.cancelAsMulti` extrinsic.
+Alternatively, Dan or Eleanor can just submit a `multisig.asMulti` extrinsic after Charlie to
+transfer the funds. In this case, 2/3 signatories will participate in the transaction approval. The
+accounts approving Charlie's call will not need to place the deposit, and Charlie will receive his
+deposit back once the transfer is successful or canceled. To cancel the transaction, Dan or Eleanor
+can use the `multisig.cancelAsMulti` extrinsic.
 
-Note that multisigs are **deterministic**, which means that multisig addresses are generated from the addresses of signers and the threshold of the multisig wallet. No matter the order of the signatories' accounts, the multisig will always have the same address because accounts' addresses are sorted in ascending order.
+Note that multisigs are **deterministic**, which means that multisig addresses are generated from
+the addresses of signers and the threshold of the multisig wallet. No matter the order of the
+signatories' accounts, the multisig will always have the same address because accounts' addresses
+are sorted in ascending order.
 
 :::note Addresses that are provided to the multisig wallet are sorted
 
-Public keys of signers' wallets are compared byte-for-byte and sorted ascending before
-being used to generate the multisig address.
+Public keys of signers' wallets are compared byte-for-byte and sorted ascending before being used to
+generate the multisig address.
 
 :::
 
-This has some implications when using the Extrinsics tab on the [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) to perform multisig transactions. If the order of the _other signatories_ is wrong, the transaction will fail. This does not happen if the multisig is executed directly from the Accounts tab (recommended). The Polkadot-JS UI supports multisig accounts, as documented on the [Account Generation page](learn-account-generation.md#multi-signature-accounts). You can see our video tutorials for more information about creating multisig accounts and transacting with them using both the [Accounts Tab](https://www.youtube.com/watch?v=-cPiKMslZqI) and the [Extrinsic Tab](https://www.youtube.com/watch?v=T0vIuJcTJeQ) in the Polkadot-JS UI.
+This has some implications when using the Extrinsics tab on the
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) to perform multisig transactions. If the
+order of the _other signatories_ is wrong, the transaction will fail. This does not happen if the
+multisig is executed directly from the Accounts tab (recommended). The Polkadot-JS UI supports
+multisig accounts, as documented on the
+[Account Generation page](learn-account-generation.md#multi-signature-accounts). You can see our
+video tutorials for more information about creating multisig accounts and transacting with them
+using both the [Accounts Tab](https://www.youtube.com/watch?v=-cPiKMslZqI) and the
+[Extrinsic Tab](https://www.youtube.com/watch?v=T0vIuJcTJeQ) in the Polkadot-JS UI.
 
 ## Decoding Multisig Call Data
 
 :::info
 
-Before signing a transaction, it is important to know the exact specifics of what is being signed. Check the ["How to use a multisig account"](https://support.polkadot.network/support/solutions/articles/65000181826-how-to-create-and-use-a-multisig-account) in the support docs on how to
-decode the multisig call data
+Before signing a transaction, it is important to know the exact specifics of what is being signed.
+Check the
+["How to use a multisig account"](https://support.polkadot.network/support/solutions/articles/65000181826-how-to-create-and-use-a-multisig-account)
+in the support docs on how to decode the multisig call data
 
 :::

--- a/docs/learn/learn-proxies.md
+++ b/docs/learn/learn-proxies.md
@@ -34,7 +34,7 @@ risk their lives to ensure the VIP's protection. But proxies are also useful in 
 as efficient account management at the corporate level. They also provide an elegant solution to
 change signatories within multi-signature accounts, and they can be used within proxy calls and
 nested proxy calls. In this page we will explore all these interesting use cases of proxies within
-the Polkadot ecosystem.
+the {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} ecosystem.
 
 Shown below is an example of how you might use these accounts. Imagine you have one stash account as
 your primary token-holding account and don't want to access it very often, but you want to
@@ -77,9 +77,11 @@ proxy for the relationship. {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama 
 - Identity Judgement
 - Auction
 
-When a proxy account makes a transaction, Polkadot filters the desired transaction to ensure that
-the proxy account has the appropriate permission to make that transaction on behalf of the cold
-account. For example, staking proxies have permission to do only staking-related transactions.
+When a proxy account makes a transaction,
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} filters the desired transaction to
+ensure that the proxy account has the appropriate permission to make that transaction on behalf of
+the cold account. For example, staking proxies have permission to do only staking-related
+transactions.
 
 ### Any Proxy
 
@@ -110,7 +112,8 @@ on governance proxies or watch our
 
 :::info
 
-Visit the [Advanced Staking Concepts page](./learn-staking-advanced.md/#staking-proxies) for more detailed information about staking proxies.
+Visit the [Advanced Staking Concepts page](./learn-staking-advanced.md/#staking-proxies) for more
+detailed information about staking proxies.
 
 :::
 
@@ -129,7 +132,6 @@ Use a [non-transfer](#non-transfer-proxy) instead of a staking proxy to particip
 pools. The staking proxy is not enabled to make successful calls to the nomination pools pallet.
 
 :::
-
 
 ### Identity Judgement Proxy
 
@@ -287,9 +289,10 @@ change the name of _anonymous_ proxy. People suggested _keyless accounts_ since 
 private key and are proxied accounts. However, multisig accounts are also keyless (but
 deterministic). Moreover, even if _anonymous_ proxies are proxied accounts, they can still act as
 proxies and control other accounts via proxy calls (see multisig example below). Thus, the name that
-has been chosen is **pure proxy**. If you want to know more about the reasoning behind renaming of 
-pure proxies, see the discussion in [this PR](https://github.com/paritytech/substrate/pull/12283) or 
-the discussion on [Polkadot forum](https://forum.polkadot.network/t/parachain-technical-summit-next-steps/51/14).
+has been chosen is **pure proxy**. If you want to know more about the reasoning behind renaming of
+pure proxies, see the discussion in [this PR](https://github.com/paritytech/substrate/pull/12283) or
+the discussion on
+[Polkadot forum](https://forum.polkadot.network/t/parachain-technical-summit-next-steps/51/14).
 
 :::
 


### PR DESCRIPTION
Extend kusama coverage for:

- [x] build-transaction-construction
- [x] learn-account-advanced
- [x] learn-account-multisig
- [x] learn-proxies

as part of initiative outlined in #4110 