### PR TITLE
Extend kusama coverage for gov1, gov2, how-to-dyor docs

### DIFF
--- a/components/RPC-Connection.jsx
+++ b/components/RPC-Connection.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { ApiPromise, WsProvider } from "@polkadot/api";
-import { HumanReadable, Precise, BlocksToDays } from "./utilities/filters";
+import { HumanReadable, Precise, BlocksToDays, ArrayLength } from "./utilities/filters";
 
 /*
 This component connects to the Polkadot/Kusama APIs and renders the response data.
@@ -142,6 +142,9 @@ function applyFilter(value, filter, network, setReturnValue) {
 			break;
 		case "blocksToDays":
 			BlocksToDays(value, setReturnValue);
+			break;
+		case "arrayLength":
+			ArrayLength(value, setReturnValue);
 			break;
 		default:
 			console.log("Ignoring unknown filter type");

--- a/components/Voluntary-Locking.jsx
+++ b/components/Voluntary-Locking.jsx
@@ -86,9 +86,9 @@ function VoluntaryLocking({ network }) {
 		// can't be used to render a table (can't put a <table> in a <p>).
 		// So, we use the same component for Polkadot and Kusama and figure it out here.
 		const title = document.title;
-		if (title === "Governance · Polkadot Wiki") {
+		if (title === "Governance · Polkadot Wiki" || title === "Governance V2 · Polkadot Wiki") {
 			updateTable("polkadot")
-		} else if (title === "Governance · Guide") {
+		} else if (title === "Governance · Guide" || title === "Governance V2 · Guide") {
 			updateTable("kusama");
 		} else {
 			console.log("Unknown wiki/guide type");

--- a/components/utilities/filters.js
+++ b/components/utilities/filters.js
@@ -59,5 +59,12 @@ module.exports = {
     value = (value * 6) / 86400;
     // Update value
     setReturnValue(value.toString());
+  },
+
+  ArrayLength: function (value, setReturnValue) {
+    value = value.split(',').length;
+    // Update value
+    setReturnValue(value.toString());
   }
+
 }

--- a/docs/general/how-to-dyor.md
+++ b/docs/general/how-to-dyor.md
@@ -48,10 +48,12 @@ milestones, then their code is most likely of reasonable quality.
 Furthermore, Web3 Foundation is not the only entity in the ecosystem that provides grants. Other
 reputable teams in the ecosystem that have developed platforms or prospective parachains provide
 grants for projects to build on or expand their project. These are also indicators that a project is
-committed to building on the broader Polkadot ecosystem.
+committed to building on the broader {{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }}
+ecosystem.
 
-Receiving funding from reputable VCs and are known to be involved with other reputable Polkadot
-projects can also be a good indicator. Or participating in the
+Receiving funding from reputable VCs and are known to be involved with other reputable
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} projects can also be a good
+indicator. Or participating in the
 [Substrate Builders Program](https://www.substrate.io/builders-program/).
 
 **However**, claiming such associations and having them is not always the same thing. **You always
@@ -168,16 +170,19 @@ community, providing guidance and answers, which is always a good sign.
 But if the team are ghosts that do not show up anywhere and only engage with the community through
 proxies, this can be considered a red flag and extra precaution should be taken.
 
-Besides their community, projects that are serious about building on Polkadot usually engage with
-the broader Polkadot community. They are active in the various
-[Polkadot and Kusama channels](https://wiki.polkadot.network/docs/community/), and some of them are
-[Polkadot Ambassadors](https://polkadot.network/polkadot-ambassador-program/), or generally
+Besides their community, projects that are serious about building on
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} usually engage with the broader
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} community. They are active in the
+various [Polkadot and Kusama channels](https://wiki.polkadot.network/docs/community/), and some of
+them are [Polkadot Ambassadors](https://polkadot.network/polkadot-ambassador-program/), or generally
 prominent members of the ecosystem.
 
-#### 6. Clear integration with Polkadot
+#### 6. Clear integration
 
-There are many ways for a project to build on Polkadot and Kusama. Perhaps the most direct one is to
-aim to become a parachain. Some of the most notable Polkadot projects are already parachains on
+There are many ways for a project to build on
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }}. Perhaps the most direct one is to
+aim to become a parachain. Some of the most notable
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} projects are already parachains on
 Kusama or gearing up to become one, and most of them may also bid for Polkadot parachain slots when
 live.
 
@@ -198,13 +203,16 @@ parachain. Some use it simply because of its infrastructure to build their custo
 any plans to connect to the Relay Chain. And other projects may aim to become a parachain only on
 Kusama or directly on Polkadot.
 
-However, building a potential parachain is not the only way to build on Polkadot and expand its
-ecosystem. A project might aim to build a DeFi platform on a parachain, launch a stablecoin or other
-token on Statemint, build a decentralized exchange, or any other dApp that one might think of,
-without ever touching the Relay Chain. And that's the beauty of Polkadot!
+However, building a potential parachain is not the only way to build on
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} and expand its ecosystem. A project
+might aim to build a DeFi platform on a parachain, launch a stablecoin or other token on Statemint,
+build a decentralized exchange, or any other dApp that one might think of, without ever touching the
+Relay Chain. And that's the beauty of
+{{ polkadot: Polkadot! :Polkadot }}{{ kusama: Kusama! :kusama }}
 
-But in all of those cases, their plans to build on Polkadot, whatever they may be, should be clearly
-stated on their site and in their documentation. Most importantly, you should look for an
+But in all of those cases, their plans to build on
+{{ polkadot: Polkadot, :Polkadot }}{{ kusama: Kusama, :kusama }} whatever they may be, should be
+clearly stated on their site and in their documentation. Most importantly, you should look for an
 explanation of _how_ they plan to achieve that integration. A roadmap that places the integration at
 some point in the future means close to nothing without clearly stating the steps to get there.
 These plans should be evaluated in tandem with your research on the technical expertise of the team.
@@ -213,8 +221,9 @@ This is especially true for projects that are already running on another network
 or Binance Smart Chain, and have issued tokens there. Many projects do that either to raise funds
 and test their infrastructure or because they aim to build a "multi-chain" solution or both. But
 because those projects are not currently built on Substrate, the existence of a clear and robust
-integration plan with Polkadot should be essential in your research to ensure that they will indeed
-build on Polkadot one day.
+integration plan with {{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} should be
+essential in your research to ensure that they will indeed build on
+{{ polkadot: Polkadot :Polkadot }}{{ kusama: Kusama :kusama }} one day.
 
 ## "Soft" metrics
 

--- a/docs/learn/learn-gov2.md
+++ b/docs/learn/learn-gov2.md
@@ -113,7 +113,7 @@ outcome, i.e. being voted on.
 
 If a proposal is submitted by the public or council there is a fixed enactment delay period of
 {{ polkadot: <RPC network="polkadot" path="consts.democracy.enactmentPeriod" defaultValue={403200} filter="blocksToDays" /> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.democracy.maxProposals" defaultValue={115,200} filter="blocksToDays" /> :kusama }}
+{{ kusama: <RPC network="kusama" path="consts.democracy.enactmentPeriod" defaultValue={115200} filter="blocksToDays" /> :kusama }}
 days. Proposals submitted as part of the enactment of a prior referendum can set the enactment delay
 period as desired. Emergency proposals deal with major problems with the network that need to be
 "fast-tracked", which leads to shorter enactment times.
@@ -148,8 +148,9 @@ to show support
   selected to be a referendum in the next voting cycle.
 
 Note that this may be different from the absolute number of endorsements; for instance, three
-accounts bonding {{ polkadot: 20 DOT each would "outweigh" ten accounts bonding a
-single DOT each :polkadot }}{{ kusama: 3 KSM each would "outweigh" six accounts bonding 0.5 KSM each }}.
+accounts bonding
+{{ polkadot: 20 DOT each would "outweigh" ten accounts bonding a single DOT each. :polkadot }}
+{{ kusama: 3 KSM each would "outweigh" six accounts bonding 0.5 KSM each. }}
 
 The bonded tokens will be released once the proposal is tabled (that is, brought to a vote).
 
@@ -258,7 +259,8 @@ votes = tokens * conviction_multiplier
 The `conviction multiplier` increases the vote multiplier by one every time the number of lock
 periods double.
 
-<VLTable network="polkadot"/>
+{{ polkadot: <VLTable network="polkadot"/> :polkadot }}
+{{ kusama: <VLTable network="kusama"/> :kusama }}
 
 The maximum number of "doublings" of the lock period is set to 6 (and thus 32 lock periods in
 total), and one lock period equals
@@ -267,7 +269,8 @@ total), and one lock period equals
 days. Only doublings are allowed; you cannot lock for, say, 24 periods and increase your conviction
 by 5.5. For additional information regarding the timeline of governance events, check out the
 governance section on the
-{{ polkadot: [Polkadot Parameters page](../docs/maintain-polkadot-parameters/#governance) :polkadot }}{{ kusama: [Kusama Parameters page](../docs/kusama-parameters/#governance) :kusama }}.
+{{ polkadot: [Polkadot Parameters page](../docs/maintain-polkadot-parameters/#governance). :polkadot }}
+{{ kusama: [Kusama Parameters page](../docs/kusama-parameters/#governance). :kusama }}
 
 While a token is locked, you can still use it for voting and staking; you are only prohibited from
 transferring these tokens to another account.
@@ -285,7 +288,7 @@ system.
 In Governance v1, passive stakeholders are represented on
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} via a governing body known as the
 "council". The council is an on-chain entity comprising several actors, each represented as an
-on-chain account. On {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, the council
+on-chain account. On {{ polkadot: Polkadot, :polkadot }}{{ kusama: Kusama, :kusama }} the council
 currently consists of
 {{ polkadot: <RPC network="polkadot" path="query.council.members" defaultValue={Array(13)} filter="arrayLength" /> :polkadot }}
 {{ kusama: <RPC network="kusama" path="query.council.members" defaultValue={Array(19)} filter="arrayLength" /> :kusama }}
@@ -336,8 +339,9 @@ In Governance v1, the Technical Committee (TC) was introduced in the
 [Kusama rollout and governance post](https://polkadot.network/kusama-rollout-and-governance/) as one
 of the three chambers of Kusama governance (along with the Council and the Referendum chamber). The
 TC is composed of the teams that have successfully implemented or specified either a
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} runtime or Polkadot Host. Teams are
-added or removed from the TC via a simple majority vote of the [Council](#council).
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} runtime or
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} host. Teams are added or removed from
+the TC via a simple majority vote of the [Council](#council).
 
 The purpose of the TC is to safeguard against malicious referenda, implement bug fixes, reverse
 faulty runtime updates, or add new but battle-tested features. The TC has the power to fast-track
@@ -356,10 +360,10 @@ details below.
 ## Polkadot Fellowship
 
 The Fellowship is a mostly self-governing expert body with a primary goal of representing humans who
-embody and contain the technical knowledge base of the Polkadot network and protocol. This is
-accomplished by associating a rank with members to categorize the degree to which the system expects
-their opinion to be well-informed, of a sound technical basis and in line with the interests of
-Polkadot.
+embody and contain the technical knowledge base of the Kusama and/or Polkadot networks and
+protocols. This is accomplished by associating a rank with members to categorize the degree to which
+the system expects their opinion to be well-informed, of a sound technical basis and in line with
+the interests of Polkadot and Kusama.
 
 Unlike the current Technical Collective, it is designed to be far broader in membership (i.e. to
 work well with even tens of thousands of members) and with far lower barrier to entry (both in terms
@@ -369,8 +373,8 @@ Fellowship is as easy as placing a small deposit.
 Members of the Fellowship can vote on any given Fellowship proposal and the aggregate opinion of the
 members (weighted by their rank) constitutes the Fellowship's considered opinion.
 
-The mechanism by which the Fellowship votes is the same as what is used for Polkadot stakeholder
-voting for a proposed referendum.
+The mechanism by which the Fellowship votes is the same as what is used for Polkadot and Kusama
+stakeholder voting for a proposed referendum.
 
 ### Ranking System
 
@@ -419,8 +423,8 @@ If both conditions are true, the operation executes with Root-level privileges.
 
 This system enables the ability to have a new parallel Track (Whitelisted-Root Origin), whose
 parameters allow for a shorter voting turnaround. Through an open and transparent process, a body of
-global experts on the Polkadot protocol have determined that the action is both safe and
-time-critical.
+global experts on the {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} protocol have
+determined that the action is both safe and time-critical.
 
 ### Blacklisting
 

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -18,16 +18,17 @@ network.
 
 :::info Gov2 is live on Kusama Network
 
-Learn about the upcoming changes to the governance on Polkadot in this
+Learn about the upcoming changes to the governance on
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} in this
 [Wiki doc on Gov2](learn-gov2.md).
 
 :::
 
 :::caution Upcoming governance changes
 
-The contents in this guide are subject to change as per the recent efforts to modify Polkadot
-Governance. See this [pull request](https://github.com/paritytech/substrate/pull/10195) for more
-details\*\*.
+The contents in this guide are subject to change as per the recent efforts to modify
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} Governance. See this
+[pull request](https://github.com/paritytech/substrate/pull/10195) for more details\*\*.
 
 :::
 

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -18,7 +18,8 @@ network.
 
 :::info Gov2 is live on Kusama Network
 
-Learn about the upcoming changes to the governance on Polkadot in this [Wiki doc on Gov2](learn-gov2.md).
+Learn about the upcoming changes to the governance on Polkadot in this
+[Wiki doc on Gov2](learn-gov2.md).
 
 :::
 
@@ -255,7 +256,8 @@ votes = tokens * conviction_multiplier
 The conviction multiplier increases the vote multiplier by one every time the number of lock periods
 double.
 
-<VLTable network="polkadot"/>
+{{ polkadot: <VLTable network="polkadot"/> :polkadot }}
+{{ kusama: <VLTable network="kusama"/> :kusama }}
 
 The maximum number of "doublings" of the lock period is set to 6 (and thus 32 lock periods in
 total), and one lock period equals


### PR DESCRIPTION
Extend kusama coverage for:

- [x] how-to-dyor
- [x] learn-governance
- [x] learn-gov2

as part of initiative outlined in #4110 