### PR TITLE
Unify url formatting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -100,13 +100,12 @@ of classes of individuals.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at

--- a/docs/build/build-oracle.md
+++ b/docs/build/build-oracle.md
@@ -23,22 +23,20 @@ Oracles serve many purposes for application builders. For example:
 
 Oracle solutions range from centralized and trusted to decentralized and game-theory based. On the
 centralized end of the spectrum, an oracle could be a single account that has the authority to
-dictate the real-world data on-chain. On the decentralized end, a [complex game of
-"chicken"][schellingcoin] can be played among various staked actors who risk getting slashed if they
-don't submit the same data as everyone else. Solutions such as [Chainlink][chainlink] fit somewhere
-in the middle, where the amount of trust you put into the reporting oracles can be adjusted based on
-your preferences. A Chainlink [Feed Pallet][feed pallet] was recently released to allow smart
-contract applications across {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} to
-access price reference data, made available as a Substrate oracle pallet.
+dictate the real-world data on-chain. On the decentralized end, a
+[complex game of "chicken"](https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed/)
+can be played among various staked actors who risk getting slashed if they don't submit the same
+data as everyone else. Solutions such as
+[Chainlink](https://polkadot.network/chainlink-reaches-milestone-with-polkadot/) fit somewhere in
+the middle, where the amount of trust you put into the reporting oracles can be adjusted based on
+your preferences. A Chainlink
+[Feed Pallet](https://github.com/smartcontractkit/chainlink-polkadot/blob/master/pallet-chainlink-feed/README.md)
+was recently released to allow smart contract applications across
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} to access price reference data, made
+available as a Substrate oracle pallet.
 
 When using an oracle in your application you should be aware of the benefits and risks that are
 baked into its specific model. As the {{ polkadot: Polkadot :polkadot }}
 {{ kusama: Kusama :kusama }} ecosystem develops and oracle parachains begin to appear, this article
 will be updated with a comparison of the different solutions and the benefits and drawbacks that
 each provide.
-
-[schellingcoin]:
-  https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed/
-[chainlink]: https://polkadot.network/chainlink-reaches-milestone-with-polkadot/
-[feed pallet]:
-  https://github.com/smartcontractkit/chainlink-polkadot/blob/master/pallet-chainlink-feed/README.md

--- a/docs/build/build-smart-contracts.md
+++ b/docs/build/build-smart-contracts.md
@@ -59,14 +59,16 @@ transitions, they can support smart contracts.
 
 Substrate presently supports smart contracts out-of-the-box in two ways:
 
-- The EVM pallet offered by [Frontier][].
-- The [Contracts pallet][] in the FRAME library for Wasm-based contracts.
+- The EVM pallet offered by [Frontier](https://github.com/paritytech/frontier).
+- The [Contracts pallet](https://github.com/paritytech/substrate/blob/master/frame/contracts/) in
+  the FRAME library for Wasm-based contracts.
 
 ### Frontier EVM Contracts
 
-[Frontier][] is the suite of tools that enables a Substrate chain to run Ethereum contracts (EVM)
-natively with the same API/RPC interface, Ethereum exposes on Substrate. Ethereum Addresses can also
-be mapped directly to and from Substrate's SS58 scheme from existing accounts.
+[Frontier](https://github.com/paritytech/frontier) is the suite of tools that enables a Substrate
+chain to run Ethereum contracts (EVM) natively with the same API/RPC interface, Ethereum exposes on
+Substrate. Ethereum Addresses can also be mapped directly to and from Substrate's SS58 scheme from
+existing accounts.
 
 ### Substrate Contracts
 
@@ -140,8 +142,8 @@ Some of these PSPs are targeting Substrate's `contracts` pallet:
 in Rust and compiles to Wasm code. As it states in its README, it is still in an experimental phase
 so brave developers should be aware that they might have a bumpy - but workable - development
 experience. There are some projects that have built projects in ink! with a decent level of
-complexity such as Plasm's [Plasma contracts][plasm plasma], so it is mature enough to start
-building interesting things.
+complexity such as Plasm's [Plasma contracts](https://github.com/staketechnologies/Plasm), so it is
+mature enough to start building interesting things.
 
 For interested developers, they can get started writing smart contracts using ink! by studying the
 [examples](https://github.com/paritytech/ink/tree/master/examples) that were already written. These
@@ -198,7 +200,8 @@ launched as a parachain on Kusama. Parachain functionality is live, and features
 incrementally released. The final phase of the launch will include EVM functionality and balance
 transfers.
 
-Try deploying a smart contract to Moonbeam by following their [documentation][moonbeam docs].
+Try deploying a smart contract to Moonbeam by following their
+[documentation](https://docs.moonbeam.network/).
 
 #### Astar
 
@@ -246,21 +249,11 @@ head start on your project, allowing you to innovate and create something truly 
 If you have interesting ideas for smart contracts on
 {{ polkadot: Polkadot, :polkadot }}{{ kusama: Kusama, :kusama }} feel free to drop into the
 {{ polkadot: [Polkadot Watercooler](https://matrix.to/#/#polkadot-watercooler:matrix.org) :polkadot }}
-{{ kusama: [Kusama Watercooler](https://matrix.to/#/#kusama-watercooler:matrix.org) :kusama }} to talk about
-them. Developers may be interested in joining the
+{{ kusama: [Kusama Watercooler](https://matrix.to/#/#kusama-watercooler:matrix.org) :kusama }} to
+talk about them. Developers may be interested in joining the
 [Polkadot Beginners Lounge](https://matrix.to/#/#polkadotnoobs:matrix.org) :polkadot }} or
 [Substrate Technical](https://area51.stackexchange.com/proposals/126136/substrate) to ask their
 questions. As always, keep up to date with Polkadot and Kusama by following the
 [social channels](../general/community.md).
 
 All the best.
-
-[frontier]: https://github.com/paritytech/frontier
-[contracts pallet]: https://github.com/paritytech/substrate/blob/master/frame/contracts/
-[edgeware]: https://edgewa.re
-[edgeware documentation]: https://docs.edgewa.re/
-[edgeware contracts documentation]: https://main.edgeware.wiki/development/develop/smart-contracts
-[plasm plasma]: https://github.com/staketechnologies/Plasm
-[moonbeam]: https://moonbeam.network
-[moonbeam docs]: https://docs.moonbeam.network/
-[frontier]: (https://github.com/paritytech/frontier)

--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -288,38 +288,48 @@ platform for everyone. This wiki offers a place for builders and maintainers to 
 
 For brand-new learners of Blockchain technology:
 
-- The [Blockchain Fundamentals MOOC course][mooc] is a great introduction to start familiarizing
-  yourself with blockchain concepts such as cryptography and networks, and how these play into
-  things like decentralization and cryptocurrency.
+- The
+  [Blockchain Fundamentals MOOC course](https://mooc.web3.foundation/course/blockchain-fundamentals/)
+  is a great introduction to start familiarizing yourself with blockchain concepts such as
+  cryptography and networks, and how these play into things like decentralization and
+  cryptocurrency.
 
 This is recommended for users with backgrounds of all levels, and the course is free!
 
 ### Brand-New Polkadot learners
 
-- [Polkadot's original white paper][white-paper] is a technical summary around one possible
-  direction of implementing the Polkadot network. This paper uses rationale and technical details to
-  support why this direction is beneficial. This original white paper also explains how Polkadot's
-  core components work together to build this decentralized network.
-- [Polkadot's overview paper][overview-paper] is an updated version of the white paper that
-  describes the protocol in more technical terms. We would recommend reading this overview paper if
-  you are interested in digging more into the protocol itself.
-- [Polkadot's light paper][light-paper] is a visual, easy to read, and less technical introduction
-  into its blockchain technology. This paper dives into the components of Polkadot but is
-  understandable for both a non-technical and technical reader.
-- [Polkadot for Beginners: A non-technical guide to decentralization, blockchains &
-  Polkadot][book] - a book funded by the Polkadot Treasury
-- [Polkadot's specification][spec] is a GitHub repository that holds the latest Polkadot Host
-  protocol specification, Polkadot's specification tests of the many components of the network, and
-  the Polkadot Runtime specification. This repo holds algorithms and explores how various processes
-  function in the Polkadot network. The Polkadot specification takes Polkadot's ideas and concepts
-  from the light and the white paper but focuses on the technical specs of the technology.
-- [Watching the Technical Explainer Videos][teched videos]: These are great introductory videos that
-  explain and demonstrate how to use Polkadot and its [User Interface][ui].
-- Reading [What is Polkadot? A Brief Introduction][article] on Medium. There are also other great
-  articles to read on [Polkadot's Medium][p medium] or [Web3 Foundation's Medium][w medium].
+- [Polkadot's original white paper](https://polkadot.network/PolkaDotPaper.pdf) is a technical
+  summary around one possible direction of implementing the Polkadot network. This paper uses
+  rationale and technical details to support why this direction is beneficial. This original white
+  paper also explains how Polkadot's core components work together to build this decentralized
+  network.
+- [Polkadot's overview paper](https://github.com/w3f/research/blob/master/docs/papers/OverviewPaper-V1.pdf)
+  is an updated version of the white paper that describes the protocol in more technical terms. We
+  would recommend reading this overview paper if you are interested in digging more into the
+  protocol itself.
+- [Polkadot's light paper](https://polkadot.network/Polkadot-lightpaper.pdf) is a visual, easy to
+  read, and less technical introduction into its blockchain technology. This paper dives into the
+  components of Polkadot but is understandable for both a non-technical and technical reader.
+- [Polkadot for Beginners: A non-technical guide to decentralization, blockchains & Polkadot](https://linktr.ee/polkadotbook) -
+  a book funded by the Polkadot Treasury
+- [Polkadot's specification](https://github.com/w3f/polkadot-spec) is a GitHub repository that holds
+  the latest Polkadot Host protocol specification, Polkadot's specification tests of the many
+  components of the network, and the Polkadot Runtime specification. This repo holds algorithms and
+  explores how various processes function in the Polkadot network. The Polkadot specification takes
+  Polkadot's ideas and concepts from the light and the white paper but focuses on the technical
+  specs of the technology.
+- [Watching the Technical Explainer Videos](https://www.youtube.com/watch?v=mNStMPZjiHM&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8):
+  These are great introductory videos that explain and demonstrate how to use Polkadot and its
+  [User Interface](https://polkadot.js.org/apps/).
+- Reading
+  [What is Polkadot? A Brief Introduction](https://medium.com/polkadot-network/what-is-polkadot-a-brief-introduction-ca3eac9ddca5)
+  on Medium. There are also other great articles to read on
+  [Polkadot's Medium](https://medium.com/polkadot-network) or
+  [Web3 Foundation's Medium](https://medium.com/web3foundation).
 
 For brand-new learners of Kusama, Polkadot's canary cousin network: To learn more about how to build
-and maintain on the Kusama network, please head over to our [Kusama Guide][kusama guide].
+and maintain on the Kusama network, please head over to our
+[Kusama Guide](https://guide.kusama.network/).
 
 ## Resources
 
@@ -344,26 +354,3 @@ and maintain on the Kusama network, please head over to our [Kusama Guide][kusam
 - [Contributing Guide](contributing.md) - Rules for contributing to the wiki.
 - [Polkadot Knowledge Base](https://support.polkadot.network/) - Troubleshooting resources for
   specific errors and problems.
-
-[mooc]: https://mooc.web3.foundation/course/blockchain-fundamentals/
-[white-paper]: https://polkadot.network/PolkaDotPaper.pdf
-[overview-paper]: https://github.com/w3f/research/blob/master/docs/papers/OverviewPaper-V1.pdf
-[light-paper]: https://polkadot.network/Polkadot-lightpaper.pdf
-[spec]: https://github.com/w3f/polkadot-spec
-[teched videos]: https://www.youtube.com/watch?v=mNStMPZjiHM&list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8
-[article]: https://medium.com/polkadot-network/what-is-polkadot-a-brief-introduction-ca3eac9ddca5
-[p medium]: https://medium.com/polkadot-network
-[w medium]: https://medium.com/web3foundation
-[ui]: https://polkadot.js.org/apps/
-[account generation]: ../learn/learn-account-generation.md
-[transfer]: ../learn/learn-balance-transfers.md
-[nominator]: ../maintain/maintain-guides-how-to-nominate-polkadot.md
-[validator]: ../maintain/maintain-guides-how-to-validate-polkadot.md
-[identity]: ../learn/learn-identity.md
-[proxy]: ../learn/learn-proxies.md
-[democracy]: ../maintain/maintain-guides-democracy.md
-[council]: ../maintain/maintain-guides-how-to-join-council.md
-[council voting]: ../maintain/maintain-guides-how-to-vote-councillor.md
-[treasury]: ../learn/learn-treasury.md
-[kusama guide]: https://guide.kusama.network/
-[book]: https://linktr.ee/polkadotbook

--- a/docs/general/kusama/kusama-getting-started.md
+++ b/docs/general/kusama/kusama-getting-started.md
@@ -19,8 +19,8 @@ Kusama is owned by those who hold the Kusama tokens (KSM). There's no central ki
 changes are made through the protocol's on-chain governance.
 
 The network is a permissionless and anyone can come along and start using it. Those who participated
-in the Polkadot sale can claim a proportional amount of KSM through the [Kusama Claims
-process][claims].
+in the Polkadot sale can claim a proportional amount of KSM through the
+[Kusama Claims process](kusama-claims).
 
 Kusama is experimental. **Expect Chaos**.
 
@@ -178,8 +178,8 @@ nominating), governance, parachain auctions, basic transfers and everything else
 
 <br />
 
-For brand-new learners of Kusama's cousin network, Polkadot, please head over to the [Polkadot
-Wiki][].
+For brand-new learners of Kusama's cousin network, Polkadot, please head over to the
+[Polkadot Wiki](https://wiki.polkadot.network/).
 
 ### Kusama Gifts
 

--- a/docs/general/kusama/kusama-ledger.md
+++ b/docs/general/kusama/kusama-ledger.md
@@ -16,9 +16,9 @@ like Brave and Chrome.
 
 :::
 
-Kusama has a [Ledger][] application that is compatible with the Ledger Nano S and Ledger Nano X
-devices. The Ledger devices are hardware wallets that keep your private key secured on a physical
-device that does not get directly exposed to your computer or the internet.
+Kusama has a [Ledger](https://www.ledger.com/) application that is compatible with the Ledger Nano S
+and Ledger Nano X devices. The Ledger devices are hardware wallets that keep your private key
+secured on a physical device that does not get directly exposed to your computer or the internet.
 
 The Kusama application allows you to manage Kusama's native asset, KSM. It supports most of the
 transaction types of the network, including batch transactions from the Utility pallet.
@@ -41,7 +41,8 @@ Here is a list of what you will need before starting:
 - The latest firmware installed.
 - Ledger Live is installed and at version 2.19 or newer (see settings -> about to find out if you're
   up to date).
-- A web browser is installed that you can use to access [Polkadot-JS Apps UI][apps].
+- A web browser is installed that you can use to access
+  [Polkadot-JS Apps UI](https://kusama.dotapps.io).
 
 ## Installing the Ledger Application
 
@@ -64,11 +65,13 @@ application from Ledger Live unless you _know exactly what you're doing_.
 
 :::
 
-Instructions for downloading the pre-release binary from the GitHub releases is written [on the
-README][prerelease instructions] for the Kusama Ledger application GitHub repository.
+Instructions for downloading the pre-release binary from the GitHub releases is written
+[on the README](https://github.com/Zondax/ledger-kusama#download-and-install) for the Kusama Ledger
+application GitHub repository.
 
-On the [releases page][] you can download the shell script `install_app.sh` and then make it
-executable in your shell by typing the command `chmod +x install_app.sh`.
+On the [releases page](https://github.com/Zondax/ledger-kusama/releases) you can download the shell
+script `install_app.sh` and then make it executable in your shell by typing the command
+`chmod +x install_app.sh`.
 
 Using `install_app.sh` help command will show you the available options:
 
@@ -104,13 +107,14 @@ written format, read through this
 [article](https://support.polkadot.network/support/solutions/articles/65000175387-how-to-add-your-ledger-through-the-polkadot-extension).
 For importing your account to the UI, read through the instructions below.
 
-[Polkadot-JS Apps UI][apps] already has an integration with the Ledger application so that your
-device will work with the browser interface after installation. The functionality is currently gated
-behind a feature setting that you will need to turn on.
+[Polkadot-JS Apps UI](https://kusama.dotapps.io) already has an integration with the Ledger
+application so that your device will work with the browser interface after installation. The
+functionality is currently gated behind a feature setting that you will need to turn on.
 
 In order to turn on the interoperability with the Kusama Ledger application, go to the "Settings"
-tab in [Polkadot-JS Apps UI][apps]. Find the option for attaching Ledger devices and switch the
-option from the default "Do not attach Ledger devices" to "Attach Ledger via WebUSB".
+tab in [Polkadot-JS Apps UI](https://kusama.dotapps.io). Find the option for attaching Ledger
+devices and switch the option from the default "Do not attach Ledger devices" to "Attach Ledger via
+WebUSB".
 
 ![Dropdown selector for allowing Ledger connections in Polkadot-JS Apps UI Settings](../../assets/ledger.png)
 
@@ -140,8 +144,9 @@ You should now be able to scroll down and find a new account on the page with th
 
 ![Displaying the Ledger account in the list](../../assets/ledger/ledger-balance.png)
 
-You can now use this account to interact with Kusama on [Polkadot-JS Apps UI][apps] and it will
-prompt your ledger for confirmation when you initiate a transaction.
+You can now use this account to interact with Kusama on
+[Polkadot-JS Apps UI](https://kusama.dotapps.io) and it will prompt your ledger for confirmation
+when you initiate a transaction.
 
 ### Confirming the Address on your Device
 
@@ -151,13 +156,14 @@ option to display the address on your device.
 
 ![Options menu of an account in the Accounts screen of Polkadot-JS Apps UI](../../assets/ledger-4.png)
 
-Here you can scroll through and make sure the address matches to what is displayed on [Polkadot-JS
-Apps UI][apps].
+Here you can scroll through and make sure the address matches to what is displayed on
+[Polkadot-JS Apps UI](https://kusama.dotapps.io).
 
 ### Checking the Balance of Your Account
 
 There are a few methods to check the balance of your account. You can use Polkadot-JS Apps or you
-can use a block explorer like [Polkascan][] or [Subscan][].
+can use a block explorer like [Polkascan](https://polkascan.io/kusama) or
+[Subscan](https://kusama.subscan.io/).
 
 #### Using Polkadot-JS Apps
 
@@ -170,7 +176,7 @@ balance arrow, it will show details of your balance such as locks or reserved am
 ### Sending a Transfer
 
 If you would like to send a transfer from your account housed on the Ledger device, the easiest
-method is to use [Polkadot-JS Apps UI][apps].
+method is to use [Polkadot-JS Apps UI](https://kusama.dotapps.io).
 
 - Click on the "Transfer" button in "Accounts" dropdown in the top navigation menu.
 - In the top input, select "Ledger" as your sending account.
@@ -250,7 +256,8 @@ account stored on a Ledger device, as follows:
 
 Despite the Polkadot ledger application being compatible with both the Ledger Nano S and the Ledger
 Nano X, none of the [Democracy](../../maintain/maintain-guides-democracy.md) extrinsics are
-available in the light version. The following [repo by Zondax][] lists the currently supported
+available in the light version. The following
+[repo by Zondax](https://github.com/Zondax/ledger-polkadot#democracy) lists the currently supported
 Democracy extrinsics on the full ledger.
 
 :::
@@ -287,11 +294,3 @@ account.
 ## Support
 
 If you need support, please visit the [Polkadot Support page](https://support.polkadot.network).
-
-[ledger]: https://www.ledger.com/
-[repo by zondax]: https://github.com/Zondax/ledger-polkadot#democracy
-[apps]: https://kusama.dotapps.io
-[prerelease instructions]: https://github.com/Zondax/ledger-kusama#download-and-install
-[releases page]: https://github.com/Zondax/ledger-kusama/releases
-[polkascan]: https://polkascan.io/kusama
-[subscan]: https://kusama.subscan.io/

--- a/docs/general/kusama/kusama-statemine-ledger.md
+++ b/docs/general/kusama/kusama-statemine-ledger.md
@@ -14,9 +14,9 @@ like Brave, Chrome or Edge.
 
 :::
 
-Statemine has a [Ledger][] application that is compatible with the Ledger Nano S and Ledger Nano X
-devices. The Ledger devices are hardware wallets that keep your private key secured on a physical
-device that does not get directly exposed to your computer or the internet.
+Statemine has a [Ledger](https://www.ledger.com/) application that is compatible with the Ledger
+Nano S and Ledger Nano X devices. The Ledger devices are hardware wallets that keep your private key
+secured on a physical device that does not get directly exposed to your computer or the internet.
 
 The Statemine application allows you to manage your KSM and other tokens on the Statemine parachain.
 It supports most of the available transaction types of the network in the XL version of the app
@@ -40,7 +40,8 @@ Here is a list of what you will need before starting:
 - The latest firmware installed.
 - Ledger Live is installed and at version 2.29 or newer (see settings -> about to find out if you're
   up to date).
-- A web browser is installed that you can use to access [Polkadot-JS Apps UI][apps].
+- A web browser is installed that you can use to access
+  [Polkadot-JS Apps UI](https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer).
 
 ## Installing the Ledger Application
 
@@ -51,7 +52,8 @@ Here is a list of what you will need before starting:
 There are two versions of the Statemine app: the normal (light) version and the XL version. The
 light version has smaller size but it supports only basic functionality. If you want access to all
 the supported extrinsics, you need to install the XL version of the app. You can see
-[here][prerelease instructions] a full list of the extrinsics supported by both versions.
+[here](https://github.com/Zondax/ledger-statemine) a full list of the extrinsics supported by both
+versions.
 
 :::
 
@@ -83,14 +85,16 @@ instructions [below](#working-on-both-kusama-and-statemine).
 
 :::
 
-[Polkadot-JS Apps UI][apps] already has an integration with the Ledger application so that your
-device will work with the browser interface after installation. The functionality is currently gated
-behind a feature setting that you will need to turn on.
+[Polkadot-JS Apps UI](https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer)
+already has an integration with the Ledger application so that your device will work with the
+browser interface after installation. The functionality is currently gated behind a feature setting
+that you will need to turn on.
 
 In order to turn on the interoperability with the Statemine Ledger application, go to the "Settings"
-tab in [Polkadot-JS Apps UI][apps]. Find the option for attaching Ledger devices and switch the
-option from the default "Do not attach Ledger devices" to "Attach Ledger via WebUSB" (**but see note
-above**).
+tab in
+[Polkadot-JS Apps UI](https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer).
+Find the option for attaching Ledger devices and switch the option from the default "Do not attach
+Ledger devices" to "Attach Ledger via WebUSB" (**but see note above**).
 
 ![Dropdown selector for allowing Ledger connections in Polkadot-JS Apps UI Settings](../../assets/ledger.png)
 
@@ -121,8 +125,9 @@ You should now be able to scroll down and find a new account on the page with th
 
 ![Displaying the Ledger account in the list](../../assets/ledger/ledger-balance.png)
 
-You can now use this account to interact with Statemine on [Polkadot-JS Apps UI][apps] and it will
-prompt your ledger for confirmation when you initiate a transaction.
+You can now use this account to interact with Statemine on
+[Polkadot-JS Apps UI](https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer)
+and it will prompt your ledger for confirmation when you initiate a transaction.
 
 ### Working on both Kusama and Statemine
 
@@ -166,8 +171,8 @@ option to display the address on your device.
 
 ![Options menu of an account in the Accounts screen of Polkadot-JS Apps UI](../../assets/ledger-4.png)
 
-Here you can scroll through and make sure the address matches to what is displayed on [Polkadot-JS
-Apps UI][apps].
+Here you can scroll through and make sure the address matches to what is displayed on
+[Polkadot-JS Apps UI](https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer).
 
 #### Using Polkadot-JS Apps
 
@@ -180,7 +185,8 @@ balance arrow, it will show details of your balance such as locks or reserved am
 ### Sending a Transfer
 
 If you would like to send a transfer from your account housed on the Ledger device, the easiest
-method is to use [Polkadot-JS Apps UI][apps].
+method is to use
+[Polkadot-JS Apps UI](https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer).
 
 :::info Transfers
 
@@ -258,9 +264,3 @@ Teleporting **to** a Ledger account from a non-Ledger account doesn't require th
 ## Support
 
 If you need support, please visit the [Polkadot Support page](https://support.polkadot.network).
-
-[ledger]: https://www.ledger.com/
-[apps]:
-  https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Fkusama-statemine-rpc.paritytech.net#/explorer
-[prerelease instructions]: https://github.com/Zondax/ledger-statemine
-[releases page]: https://github.com/Zondax/ledger-statemine/releases

--- a/docs/general/kusama/kusama-statemine.md
+++ b/docs/general/kusama/kusama-statemine.md
@@ -54,7 +54,7 @@ account using the teleport functionality. For instructions on teleporting KSM, c
 Assuming you have the required KSM balance on your Statemine account, the following instructions
 should let you successfully create an asset on Statemine
 
-- Access Statemine through [Polkdot-JS UI][].
+- Access Statemine through [Polkdot-JS UI](https://polkadot.js.org/apps/#/explorer).
 - Navigate to Network > Assets.
 
 ![Navigate to Assets page](../../assets/kusama/statemine-asset-0.png)
@@ -84,5 +84,3 @@ Network > Assets page on Statemine.
 Checkout
 [this support article](https://support.polkadot.network/support/solutions/articles/65000181118-how-to-transfer-tether-usdt-on-statemine),
 for a step by step guide covering how to make a transfer on the Statemine and the risks associated.
-
-[polkadot-js ui]: https://polkadot.js.org/apps/#/explorer

--- a/docs/general/ledger.md
+++ b/docs/general/ledger.md
@@ -63,7 +63,8 @@ Here is a list of what you will need before using Polkadot with Ledger:
   under the "Manager" tab, you will need to allow access with your nano).
 - Ledger Live is installed and at version 2.1 or newer (see settings -> about to find out if you're
   up to date).
-- A Chromium-based web browser is installed that you can use to access the [Polkadot-JS UI][].
+- A Chromium-based web browser is installed that you can use to access the
+  [Polkadot-JS UI](https://www.ledger.com/).
 
 ## Using Ledger Live
 
@@ -86,10 +87,10 @@ using Polkadot JS. For more information about derived accounts and derivation pa
 
 ### Loading Your Account
 
-:::info 
+:::info
 
-Ledger Live should be off while using Ledger with Polkadot-JS UI as it can interfere with
-normal operation.
+Ledger Live should be off while using Ledger with Polkadot-JS UI as it can interfere with normal
+operation.
 
 :::
 
@@ -139,8 +140,8 @@ more information about signing transactions using your ledger.
 
 To display your Polkadot ledger account address on your Ledger Nano you can follow the guidelines on
 [this support article](https://support.polkadot.network/support/solutions/articles/65000181854-how-to-confirm-your-account-address-on-your-ledger-device).
-Here you can scroll through and make sure the address matches to what is displayed on [Polkadot-JS
-UI][].
+Here you can scroll through and make sure the address matches to what is displayed on
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/explorer).
 
 ### Checking the Balance of Your Account
 
@@ -191,19 +192,20 @@ Democracy extrinsics on the full ledger.
 
 :::warning
 
-This section is for developers only. It is recommended to install the
-application from Ledger Live unless you _know exactly what you're doing_.
+This section is for developers only. It is recommended to install the application from Ledger Live
+unless you _know exactly what you're doing_.
 
 :::
 
 ### Why you might need the Developer Release
 
 Ledger apps for the Polkadot and Kusama ecosystems are developed by [Zondax](https://zondax.ch/).
-When new functionalities are added to the Ledger apps, they are made available on a developer release for testing purposes. After a successful audit and review, the apps would be available for download and
-installation using [Ledger Live](https://www.ledger.com/ledger-live). As it takes some
-time for Ledger to audit and review the release, the app upgrade option may not be 
-available on Ledger Live when the new runtime is deployed on the network. If this happens, users cannot use Ledger
-devices with the Polkadot-JS UI, and while signing for a transaction, they will most likely
+When new functionalities are added to the Ledger apps, they are made available on a developer
+release for testing purposes. After a successful audit and review, the apps would be available for
+download and installation using [Ledger Live](https://www.ledger.com/ledger-live). As it takes some
+time for Ledger to audit and review the release, the app upgrade option may not be available on
+Ledger Live when the new runtime is deployed on the network. If this happens, users cannot use
+Ledger devices with the Polkadot-JS UI, and while signing for a transaction, they will most likely
 incur the error message "txn version not supported". Please do not panic if this happens, as there
 are solutions to this problem. If you cannot wait a couple of days until the app passes the Ledger
 audit, you can install the developer release from the shell using the latest version published on
@@ -213,7 +215,8 @@ audit, you can install the developer release from the shell using the latest ver
 
 :::info
 
-See [**this video tutorial**](https://youtu.be/4SyVQrlXZ_Q) to learn how to install the developer release of your ledger app.
+See [**this video tutorial**](https://youtu.be/4SyVQrlXZ_Q) to learn how to install the developer
+release of your ledger app.
 
 :::
 
@@ -240,6 +243,3 @@ below:
 - If you wish to revert the version back to stable release just go to Ledger Live, the app will
   automatically detect the developer release and give the option to install the previous stable
   release.
-
-[ledger]: https://www.ledger.com/
-[polkadot-js ui]: https://polkadot.js.org/apps/#/explorer

--- a/docs/general/redenomination.md
+++ b/docs/general/redenomination.md
@@ -61,8 +61,9 @@ social consensus around where to put the decimal place when we talk about what c
 
 ## Origins
 
-The initial vote for redenomination occurred as a [referendum][referendum 52] on the Kusama
-blockchain. The referendum was summarized as having four effects if approved by KSM holders.
+The initial vote for redenomination occurred as a
+[referendum](https://kusama.polkassembly.io/referendum/52) on the Kusama blockchain. The referendum
+was summarized as having four effects if approved by KSM holders.
 
 :::info Referendum Summary
 
@@ -79,9 +80,10 @@ blockchain. The referendum was summarized as having four effects if approved by 
 The initial referendum was proposed prior to the Polkadot genesis block under the assumption that
 making a redenomination would be simpler before the Polkadot chain was live. However, many in the
 community pointed out the disconnect of the two networks and how it was unfair for holders of DOT to
-be impacted by a vote by a different token holder set. For this reason, Web3 Foundation [decided to
-make a new vote on Polkadot][blog 1] when it went live, although the Kusama vote ended with a
-majority in favor of the redenomination change.
+be impacted by a vote by a different token holder set. For this reason, Web3 Foundation
+[decided to make a new vote on Polkadot](https://polkadot.network/results-of-dot-redenomination-referendum/)
+when it went live, although the Kusama vote ended with a majority in favor of the redenomination
+change.
 
 Web3 Foundation summarized the decision not to change:
 
@@ -101,11 +103,12 @@ topic up to a vote again. This time, the vote was explicitly binding &mdash; mea
 be executed if voted through. In comparison, the vote on Kusama was of course non-binding, being at
 best a way to capture a signal without a direct way to affect the Polkadot chain.
 
-Based on the feedback received during the Kusama referendum, the [Polkadot vote][blog 2] was held as
-an approval vote, with four available options. DOT holders could issue votes for any configuration
-of the four options: no change, a change of 10x, a change of 100x, or a change of 1000x. The vote
-logic was contained in a specially-built Substrate pallet that was included in Polkadot's runtime
-for this poll.
+Based on the feedback received during the Kusama referendum, the
+[Polkadot vote](https://polkadot.network/the-first-polkadot-vote/) was held as an approval vote,
+with four available options. DOT holders could issue votes for any configuration of the four
+options: no change, a change of 10x, a change of 100x, or a change of 1000x. The vote logic was
+contained in a specially-built Substrate pallet that was included in Polkadot's runtime for this
+poll.
 
 :::info Summary of the Vote
 
@@ -130,9 +133,10 @@ community for a final, binding decision.
 
 ![redenomination](../assets/redenomination.png)
 
-After two weeks of voting, the [results][blog 3] of the redenomination vote were tallied. About one
-third of the total DOT in the network participated in the vote. The redenominaton proposal passed
-with 86% of the voters favoring a 100x factor increase (or two decimal places of precision loss).
+After two weeks of voting, the [results](https://polkadot.network/the-results-are-in/) of the
+redenomination vote were tallied. About one third of the total DOT in the network participated in
+the vote. The redenominaton proposal passed with 86% of the voters favoring a 100x factor increase
+(or two decimal places of precision loss).
 
 Polkadot's redenomination then took place on 21 August, now known as Denomination Day, at block
 #1_248_328.
@@ -155,14 +159,9 @@ However &mdash; if you are a builder of a tool that displays DOT balances to use
 or handles DOT balances in an off-chain or custodial way, then you will need to ensure that you
 display the correct denomination of DOT to users.
 
-Please see our [Ecosystem Redenomination Guide][ecosystem guide] for recommendations.
+Please see our
+[Ecosystem Redenomination Guide](https://docs.google.com/document/d/1yAzoDh99PgR_7dYAKTWLMVu2Fy5Ga-J6t9lof4f4JUw/edit#)
+for recommendations.
 
 Please reach out to [support@polkadot.network](mailto:support@polkadot.network) if you need any
 assistance in making sure your software is compatible with the redenomination.
-
-[referendum 52]: https://kusama.polkassembly.io/referendum/52
-[blog 1]: https://polkadot.network/results-of-dot-redenomination-referendum/
-[blog 2]: https://polkadot.network/the-first-polkadot-vote/
-[blog 3]: https://polkadot.network/the-results-are-in/
-[ecosystem guide]:
-  https://docs.google.com/document/d/1yAzoDh99PgR_7dYAKTWLMVu2Fy5Ga-J6t9lof4f4JUw/edit#

--- a/docs/general/thousand-validators.md
+++ b/docs/general/thousand-validators.md
@@ -131,15 +131,17 @@ information on how to [secure a validator](../maintain/maintain-guides-secure-va
 ## How to Apply
 
 {{ polkadot: **Entrance to the Polkadot programme requires a rank of 25 or higher in the Kusama programme.**
-Attaining a rank of 25 usually takes around two months. The leaderboard is available [here][leaderboard]. In order to apply to the Polkadot programme, set up your node to adhere to the requirements below
-and fill in the [application form][polkadot 1kv form]. You will hear back from the team shortly. :polkadot }}
+Attaining a rank of 25 usually takes around two months. The leaderboard is available
+[here](https://thousand-validators.kusama.network/#/leaderboard).
+In order to apply to the Polkadot programme, set up your node to adhere to the requirements below
+and fill in the [application form](https://forms.gle/xqYLoceTwg1qvc9i6). You will hear back from the team shortly. :polkadot }}
 
 {{ kusama: In order to apply to the Kusama programme, set up your node to adhere to the requirements below
-and fill in the [application form][kusama 1kv form].  The process of review and addition is a manual one; you'll be invited to the 1KV Kusama channel and added to the leader board, if accepted. :kusama }}
+and fill in the [application form](https://forms.gle/xqYLoceTwg1qvc9i6).  The process of review and addition is a manual one; you'll be invited to the 1KV Kusama channel and added to the leader board, if accepted. :kusama }}
 
 #### Requirements
 
-- Verified identity (see [here][identity instructions] for instructions)
+- Verified identity (see [here](../learn/learn-identity.md#setting-an-identity) for instructions)
 - Connect to dedicated telemetry (use
   `--telemetry-url 'wss://telemetry-backend.w3f.community/submit 1'` when starting the node)
 - {{ polkadot: Minimum of 5_000 DOTs self stake :polkadot }}{{ kusama: Minimum of 10 KSM self-stake :kusama }}
@@ -177,9 +179,3 @@ to nominate based on the lowest amount staked for a validator and the amount of 
 can be anywhere from a few validators receiving nomination from a single nominator, to the max of
 {{ polkadot: 16 :polkadot }}{{ kusama: 24 :kusama }} nominators on
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}.
-
-[leaderboard]: https://thousand-validators.kusama.network/#/leaderboard
-[kusama 1kv form]: https://forms.gle/xqYLoceTwg1qvc9i6
-[polkadot 1kv form]:
-  https://docs.google.com/forms/d/e/1FAIpQLSdS-alI-J2wgIRCQVjQC7ZbFiTnf36hYBdmO-1ARMjKbC7H9w/viewform
-[identity instructions]: ../learn/learn-identity.md#setting-an-identity

--- a/docs/learn/learn-availability.md
+++ b/docs/learn/learn-availability.md
@@ -80,10 +80,11 @@ original message padded with some extra data that enables the reconstruction of 
 of erasures.
 
 The type of erasure codes used by {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}'s
-availability scheme are [Reed-Solomon][reed solomon] codes, which already enjoys a battle-tested
-application in technology outside the blockchain industry. One example is found in the compact disk
-industry. CDs use Reed-Solomon codes to correct any missing data due to inconsistencies on the disk
-face such as dust particles or scratches.
+availability scheme are
+[Reed-Solomon](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) codes, which
+already enjoys a battle-tested application in technology outside the blockchain industry. One
+example is found in the compact disk industry. CDs use Reed-Solomon codes to correct any missing
+data due to inconsistencies on the disk face such as dust particles or scratches.
 
 In {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, the erasure codes are used to
 keep parachain state available to the system without requiring all validators to keep tabs on all
@@ -118,13 +119,8 @@ secondary checker.
 
 ## Further Resources
 
-- [Path of a Parachain Block][life of] - Article by Parity analyst Joe Petrowski expounding on the
-  validity checks that a parachain block must pass in order to progress the parachain.
-- [Availability and Validity][anv paper] - Paper by the W3F Research Team that specifies the
-  availability and validity protocol in detail.
-
-[reed solomon]: https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction
-[pruning]: https://example.org
-[life of]: https://polkadot.network/the-path-of-a-parachain-block/
-[anv paper]:
-  https://github.com/w3f/research/tree/85cd4adfccb7d435f21cd9fd249cd1b7f5167537/docs/papers/AnV
+- [Path of a Parachain Block](https://polkadot.network/the-path-of-a-parachain-block/) - Article by
+  Parity analyst Joe Petrowski expounding on the validity checks that a parachain block must pass in
+  order to progress the parachain.
+- [Availability and Validity](https://github.com/w3f/research/tree/85cd4adfccb7d435f21cd9fd249cd1b7f5167537/docs/papers/AnV) -
+  Paper by the W3F Research Team that specifies the availability and validity protocol in detail.

--- a/docs/learn/learn-bridges.md
+++ b/docs/learn/learn-bridges.md
@@ -23,7 +23,7 @@ Bridges are specifically for making the
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} ecosystem compatible with external
 blockchains such as Bitcoin, Ethereum, or Tezos (among others). For information on XCM, the native
 interoperability technology that allows parachains to communicate trustlessly, please see the
-dedicated [cross consensus][] page on the Wiki.
+dedicated [cross consensus](learn-xcm.md) page on the Wiki.
 
 :::
 
@@ -38,7 +38,7 @@ following methods (ordered by suggested methodology):
   non-Substrate chain to bridge (e.g. Ethereum mainnet will have a bridge smart contract that
   initiates Eth transactions based on incoming XCMP messages).
 - _Higher-order protocols_ - If your chain does not support smart contracts (e.g. Bitcoin), you
-  should use [XClaim][xclaim] or similar protocols to bridge.
+  should use [XClaim](https://eprint.iacr.org/2018/643.pdf) or similar protocols to bridge.
 
 ### via Bridge Pallets
 
@@ -62,13 +62,13 @@ Given the generality of blockchain platforms with Turing-complete smart contract
 possible to bridge {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} and any other
 smart contract capable blockchain.
 
-Those who are already familiar with Ethereum may know of the now archived [Parity Bridge][] and the
-efforts being made to connect PoA sidechains to the Ethereum mainnet. The Parity bridge is a
-combination of two smart contracts, one deployed on each chain, that allow for cross-chain transfers
-of value. As an example of usage, the initial Parity Bridge proof of concept connects two Ethereum
-chains, `main` and `side`. Ether deposited into the contract on `main` generates a balance
-denominated in ERC-20 tokens on `side`. Conversely, ERC-20 tokens deposited back into the contract
-on `side` can free up Ether on `main`.
+Those who are already familiar with Ethereum may know of the now archived
+[Parity Bridge](https://github.com/paritytech/parity-bridge) and the efforts being made to connect
+PoA sidechains to the Ethereum mainnet. The Parity bridge is a combination of two smart contracts,
+one deployed on each chain, that allow for cross-chain transfers of value. As an example of usage,
+the initial Parity Bridge proof of concept connects two Ethereum chains, `main` and `side`. Ether
+deposited into the contract on `main` generates a balance denominated in ERC-20 tokens on `side`.
+Conversely, ERC-20 tokens deposited back into the contract on `side` can free up Ether on `main`.
 
 :::note
 
@@ -80,9 +80,10 @@ To learn more on how Bitcoin and Ethereum can cooperate and collaborate Through
 
 ### via Higher-Order Protocols
 
-Higher-order protocols (like [XCLAIM][xclaim]) can be used to bridge but should only be used when
-other options are not available. XCLAIM, in particular, requires any swappable asset to be backed by
-a collateral of higher value than the swappable assets, which adds additional overhead.
+Higher-order protocols (like [XCLAIM](https://eprint.iacr.org/2018/643.pdf)) can be used to bridge
+but should only be used when other options are not available. XCLAIM, in particular, requires any
+swappable asset to be backed by a collateral of higher value than the swappable assets, which adds
+additional overhead.
 
 An example of a network that would be well-suited for higher-order protocols would be Bitcoin, since
 it does not support smart-contracts and it's not based on Substrate.
@@ -91,9 +92,11 @@ it does not support smart-contracts and it's not based on Substrate.
 
 ### Ethereum Bridge (Smart Contracts <-> Polkadot)
 
-As explained by Dr. Gavin Wood in a [blog post][eth bridging blog] from late 2019, there are three
-ways that the {{ polkadot: Polkadot :polkadot }}{{ kusama: KUsama :kusama }} and Substrate ecosystem
-can be bridged to the Ethereum ecosystem.
+As explained by Dr. Gavin Wood in a
+[blog post](https://medium.com/polkadot-network/polkadot-substrate-and-ethereum-f0bf1ccbfd13) from
+late 2019, there are three ways that the
+{{ polkadot: Polkadot :polkadot }}{{ kusama: KUsama :kusama }} and Substrate ecosystem can be
+bridged to the Ethereum ecosystem.
 
 1. {{ polkadot: Polkadot :polkadot }}{{ kusama: KUsama :kusama }} <-> Ethereum Public Bridge.
 1. Substrate <-> Parity Ethereum (Openethereum) Bridge.
@@ -103,10 +106,11 @@ Please read the blog article for fuller descriptions of each one of these option
 
 ### Bitcoin Bridge (XCLAIM <-> Substrate <-> Polkadot)
 
-The Interlay team has written a [specification][interlay] on a Bitcoin bridge that is based on the
-[XCLAIM][] design paper. The protocol enables a two-way bridge between Polkadot and Bitcoin. It
-allows holders of BTC to "teleport" their assets to Polkadot as PolkaBTC, and holders of PolkaBTC to
-burn their assets for BTC on the Bitcoin chain.
+The Interlay team has written a [specification](https://interlay.gitlab.io/polkabtc-spec/) on a
+Bitcoin bridge that is based on the [XCLAIM](https://eprint.iacr.org/2018/643.pdf) design paper. The
+protocol enables a two-way bridge between Polkadot and Bitcoin. It allows holders of BTC to
+"teleport" their assets to Polkadot as PolkaBTC, and holders of PolkaBTC to burn their assets for
+BTC on the Bitcoin chain.
 
 The Bitcoin bridge, as documented in the specification, is composed of two logically different
 components:
@@ -123,13 +127,21 @@ There is now a
 
 - [Parity Bridges Common Resources](https://github.com/paritytech/parity-bridges-common)
 - [Substrate/Ethereum Bridge](https://github.com/ChainSafe/ChainBridge) - ChainSafe and Centrifuge
-  were awarded a grant in W3F Grants [Wave 5][] to build a Substrate to Ethereum two-way bridge.
+  were awarded a grant in W3F Grants
+  [Wave 5](https://medium.com/web3foundation/web3-foundation-grants-wave-5-recipients-2205f4fde096)
+  to build a Substrate to Ethereum two-way bridge.
 - [PolkaBTC (Bitcoin <-> Polkadot Bridge)](https://docs.polkabtc.io/#/)
-- [EOS Bridge][bifrost] - The Bifrost team was awarded a grant in W3F Grants [Wave 5][] to build a
-  bridge to EOS.
+- [EOS Bridge](https://github.com/bifrost-codes/bifrost) - The Bifrost team was awarded a grant in
+  W3F Grants
+  [Wave 5](https://medium.com/web3foundation/web3-foundation-grants-wave-5-recipients-2205f4fde096)
+  to build a bridge to EOS.
 - [Tendermint Bridge](https://github.com/ChorusOne/tendermint-light-client) - ChorusOne was awarded
-  a grant in [Wave 5][] to build a GRANDPA light client in Tendermint.
-- [Interlay BTC Bridge][interlay] - The Interlay team was awarded a grant in W3F grants [Wave 5][]
+  a grant in
+  [Wave 5](https://medium.com/web3foundation/web3-foundation-grants-wave-5-recipients-2205f4fde096)
+  to build a GRANDPA light client in Tendermint.
+- [Interlay BTC Bridge](https://interlay.gitlab.io/polkabtc-spec/) - The Interlay team was awarded a
+  grant in W3F grants
+  [Wave 5](https://medium.com/web3foundation/web3-foundation-grants-wave-5-recipients-2205f4fde096)
   to build a trust-minimized BTC bridge.
 - [ChainX BTC Bridge](https://github.com/chainx-org/ChainX/tree/master/xpallets/gateway/bitcoin) -
   ChainX have implemented a BTC to Substrate bridge for their parachain.
@@ -138,14 +150,5 @@ There is now a
   Network's implementation of Parity's bridge chain solution.
 - [Edgeth Bridge](https://github.com/hicommonwealth/edgeth_bridge/) - a bridge from Ethereum to
   Edgeware chain (a Substrate-based chain) - now defunct and not maintained, but a good example.
-- [XCLAIM][] - XCLAIM is a framework for achieving trustless and efficient cross-chain exchanges
-  using cryptocurrency-backed assets.
-
-[cross consensus]: learn-xcm.md
-[parity bridge]: https://github.com/paritytech/parity-bridge
-[interlay]: https://interlay.gitlab.io/polkabtc-spec/
-[xclaim]: https://eprint.iacr.org/2018/643.pdf
-[bifrost]: https://github.com/bifrost-codes/bifrost
-[wave 5]: https://medium.com/web3foundation/web3-foundation-grants-wave-5-recipients-2205f4fde096
-[eth bridging blog]:
-  https://medium.com/polkadot-network/polkadot-substrate-and-ethereum-f0bf1ccbfd13
+- [XCLAIM](https://eprint.iacr.org/2018/643.pdf) - XCLAIM is a framework for achieving trustless and
+  efficient cross-chain exchanges using cryptocurrency-backed assets.

--- a/docs/learn/learn-comparison-ethereum-2.md
+++ b/docs/learn/learn-comparison-ethereum-2.md
@@ -103,7 +103,7 @@ These validators get assigned to "committees", which are randomly selected group
 in the network. Ethereum 2.0 relies on having a large validator set to provide availability and
 validity guarantees: They need at least 111 validators per shard to run the network and 256
 validators per shard to finalize all shards within one epoch. With 64 shards, that's 16_384
-validators (given 256 validators per shard). [4][5]
+validators (given 256 validators per shard). `[4][5]`
 
 Polkadot can provide strong finality and availability guarantees with much fewer validators.
 Polkadot uses [Nominated Proof of Stake (NPoS)](learn-staking.md) to select validators from a

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -462,15 +462,16 @@ be an error, the council _may_ consider a governance motion to correct it.
 The first step to appeal to the council is to get in contact with the councillors. There is no
 singular place where you are guaranteed to grab every councillor's ear with your message. However,
 there are a handful of good places to start where you can get the attention of some of them. The
-{{ polkadot: [Polkadot Direction][] :polkadot }}{{ kusama: [Kusama Direction][] :kusama }} matrix
-room is one such place. After creating an account and joining this room, you can post a
+{{ polkadot: [Polkadot Direction](https://matrix.to/#/#polkadot-direction:matrix.parity.io) :polkadot }}
+{{ kusama: [Kusama Direction](https://matrix.to/#/#kusama:matrix.parity.io) :kusama }} matrix room
+is one such place. After creating an account and joining this room, you can post a
 well-thought-through message here that lays down your case and provides justification for why you
 think the council should consider enacting a change to the protocol on your behalf.
 
 At some point you will likely need a place for a longer-form discussion. For this, making a post on
-[Polkassembly][] is the recommended place to do so. When you write a post on Polkassembly make sure
-you present all the evidence for your circumstances and state clearly what kind of change you would
-suggest to the councillors to enact.
+[Polkassembly](https://polkadot.polkassembly.io/) is the recommended place to do so. When you write
+a post on Polkassembly make sure you present all the evidence for your circumstances and state
+clearly what kind of change you would suggest to the councillors to enact.
 
 :::info
 
@@ -487,7 +488,3 @@ case for why the change should be made.
   Gavin Wood presents the initial governance structure for Polkadot. (Video)
 - [Governance on Polkadot](https://www.crowdcast.io/e/governance-on-polkadot--) - A webinar
   explaining how governance works in Polkadot and Kusama.
-
-[polkadot direction]: https://matrix.to/#/#polkadot-direction:matrix.parity.io
-[kusama direction]: https://matrix.to/#/#kusama:matrix.parity.io
-[polkassembly]: https://polkadot.polkassembly.io/

--- a/docs/learn/learn-implementations.md
+++ b/docs/learn/learn-implementations.md
@@ -7,12 +7,12 @@ keywords: [implementations, wasm, meta protocol]
 slug: ../learn-implementations
 ---
 
-Polkadot is the flagship protocol of the [Web3 Foundation][], and while Polkadot can be defined as a
-protocol, a network, or, a type of infrastructure, it best serves to be an ecosystem. For true
-decentralization, there should be multiple implementations of Polkadot. Even being a _layer 0_
-protocol that attempts to build an interconnected, interoperable and secure Web3 ecosystem, Polkadot
-is a complex piece of software, and its formal implementation depends on being built on top of a
-tech stack.
+Polkadot is the flagship protocol of the [Web3 Foundation](https://web3.foundation/), and while
+Polkadot can be defined as a protocol, a network, or, a type of infrastructure, it best serves to be
+an ecosystem. For true decentralization, there should be multiple implementations of Polkadot. Even
+being a _layer 0_ protocol that attempts to build an interconnected, interoperable and secure Web3
+ecosystem, Polkadot is a complex piece of software, and its formal implementation depends on being
+built on top of a tech stack.
 
 > This page will focus on implementations of **Polkadot's underlying infrastructure** (i.e. runtime,
 > host).
@@ -23,11 +23,12 @@ Polkadot uses WebAssembly ([Wasm](learn-wasm.md)) as a "meta-protocol". This all
 any programming language that can be interpreted or compiled into Wasm - being the driver for
 Polkadot's multiple implementations.
 
-### Parity Technologies: A [Rustic Vision for Polkadot][]
+### Parity Technologies: A [Rustic Vision for Polkadot](https://github.com/paritytech/polkadot)
 
-[Parity Technologies][] is often in the spotlight for its core development of Polkadot, and while
-this is true, Parity Polkadot also serves to be the [Rust][] client. Parity Tech has a rustic vision
-for Polkadot through the use of their main product, [Substrate][]. Substrate can also be used for
+[Parity Technologies](https://www.parity.io/) is often in the spotlight for its core development of
+Polkadot, and while this is true, Parity Polkadot also serves to be the
+[Rust](https://www.rust-lang.org/) client. Parity Tech has a rustic vision for Polkadot through the
+use of their main product, [Substrate](https://www.substrate.io/). Substrate can also be used for
 different chains and different networks, but in the case of Polkadot, Substrate acts as the tech
 stack that is used to implement Polkadot's sharded heterogeneous multi-chain model.
 
@@ -58,46 +59,31 @@ As stated in the Soramitsu grant announcement:
 
 ## Alternative Implementations
 
-### ChainSafe Systems: [Gossamer][]
+### ChainSafe Systems: [Gossamer](https://github.com/ChainSafe/gossamer#a-go-implementation-of-the-polkadot-host)
 
 **Gossamer** is a Go implementation being built by
 [ChainSafe Systems](https://github.com/ChainSafeSystems), a blockchain R&D firm based in Toronto,
 Canada that is also building an Eth2.0 Serenity client. They were awarded a grant from the Web3
 Foundation.
 
-### SORAMITSU: [Kagome][]
+### SORAMITSU: [Kagome](https://github.com/soramitsu/kagome#intro)
 
-**Kagome** is a C++ implementation of the Polkadot Host being built by [Soramitsu][], a Japanese
-digital identity company that previously developed [Hyperledger Iroha][]. They were awarded a grant
-from the Web3 Foundation and released the first version of Kagome in April 2020. As part of the
-process, they also released a [libp2p][] networking layer in C++.
+**Kagome** is a C++ implementation of the Polkadot Host being built by
+[Soramitsu](https://soramitsu.co.jp/), a Japanese digital identity company that previously developed
+[Hyperledger Iroha](https://iroha.tech). They were awarded a grant from the Web3 Foundation and
+released the first version of Kagome in April 2020. As part of the process, they also released a
+[libp2p](https://github.com/soramitsu/libp2p-grpc) networking layer in C++.
 
-### Polkadot-JS Project: [Polkadot-JS][]
+### Polkadot-JS Project: [Polkadot-JS](https://github.com/polkadot-js)
 
-**Polkadot-JS** is a [JavaScript client][] and offers a collection of tools, interfaces, and
-libraries for Polkadot and Substrate.
+**Polkadot-JS** is a [JavaScript client](https://github.com/polkadot-js/client) and offers a
+collection of tools, interfaces, and libraries for Polkadot and Substrate.
 
 ### Other implementations that have received grants
 
-- [Golkadot][]
-- [Polkadot in Java][]
+- [Golkadot](https://github.com/opennetsys/golkadot)
+- [Polkadot in Java](https://github.com/polkadot-java)
 
 While the ecosystem continues to grow rapidly, the continued development of alternative
 implementations will only make Polkadot stronger. Consider becoming a contributor to the ecosystem,
 and learn about the how you can receieve a [grant](../general/grants.md) for your development.
-
-[web3 foundation]: https://web3.foundation/
-[parity technologies]: https://www.parity.io/
-[substrate]: https://www.substrate.io/
-[rust]: https://www.rust-lang.org/
-[chainsafe systems]: https://chainsafe.io/
-[soramitsu]: https://soramitsu.co.jp/
-[polkadot-js]: https://github.com/polkadot-js
-[rustic vision for polkadot]: https://github.com/paritytech/polkadot
-[gossamer]: https://github.com/ChainSafe/gossamer#a-go-implementation-of-the-polkadot-host
-[kagome]: https://github.com/soramitsu/kagome#intro
-[hyperledger iroha]: https://iroha.tech
-[libp2p]: https://github.com/soramitsu/libp2p-grpc
-[javascript client]: https://github.com/polkadot-js/client
-[golkadot]: https://github.com/opennetsys/golkadot
-[polkadot in java]: https://github.com/polkadot-java

--- a/docs/learn/learn-spree.md
+++ b/docs/learn/learn-spree.md
@@ -25,12 +25,12 @@ SPREE in brief was described with the following properties and functions:
 ## Origin
 
 On 28 March, 2019 u/Tawaren, a member of the Polkadot community, made a post on
-[r/dot][polkadot reddit] called "SmartProtocols Idea" and laid out a proposal for [Smart
-Protocols][smart protocols reddit post]. The core insight of the post was that XCMP had a
-complication in that it was difficult to verify and prove code was executed on a parachain without
-trust. A solution was to install the SmartProtocols in the Relay Chain that would be isolated blobs
-of code with their own storage per instance that could only be changed through an interface with
-each parachain. SmartProtocols are the precursor to SPREE.
+[r/dot](https://www.reddit.com/r/dot/) called "SmartProtocols Idea" and laid out a proposal for
+[Smart Protocols](https://www.reddit.com/r/dot/comments/b6kljn/smartprotocols_idea/). The core
+insight of the post was that XCMP had a complication in that it was difficult to verify and prove
+code was executed on a parachain without trust. A solution was to install the SmartProtocols in the
+Relay Chain that would be isolated blobs of code with their own storage per instance that could only
+be changed through an interface with each parachain. SmartProtocols are the precursor to SPREE.
 
 ## What is a SPREE module?
 
@@ -106,6 +106,3 @@ with the previous state root of the SPREE module instances, the data of the XCMP
 instances, and the next state root of the instance. They do this validation by checking it against
 the `validate` function as provided by the SPREE module API. Collators are expected to be able to
 provide this information to progress their parachains.
-
-[polkadot reddit]: https://www.reddit.com/r/dot/
-[smart protocols reddit post]: https://www.reddit.com/r/dot/comments/b6kljn/smartprotocols_idea/

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -509,7 +509,8 @@ disabled, but if the number of disabled validators gets too large,
 to get a full set. Disabled validators will need to resubmit their intention to validate and
 re-garner support from nominators.
 
-For more on chilling, see the "[How to Chill][]" page on this wiki.
+For more on chilling, see the "[How to Chill](../maintain/maintain-guides-how-to-chill.md)" page on
+this wiki.
 
 ## Why and Why not to Stake?
 
@@ -519,7 +520,8 @@ For more on chilling, see the "[How to Chill][]" page on this wiki.
 - Low barrier of entry through [Nomination Pools](learn-nomination-pools.md).
 - Can choose up-to
   {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominations" defaultValue={16}/> :polkadot }}
- {{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }} validators which can help to decentralize the network through the sophisticated
+  {{ kusama: <RPC network="kusama" path="consts.staking.maxNominations" defaultValue={24}/> :kusama }}
+  validators which can help to decentralize the network through the sophisticated
   [NPoS system](learn-consensus.md/#nominated-proof-of-stake)
 - 10% inflation/year of the tokens is primarily intended for staking rewards.
 
@@ -540,8 +542,10 @@ users to withdraw. For in-depth understanding, check the
 ### Cons of Staking
 
 - Tokens will be locked for about {{ polkadot: 28 :polkadot }}{{ kusama: 7 :kusama }} days on
-  {{ polkadot: Polkadot. :polkadot }}{{ kusama: Kusama. :kusama }} No rewards will be earned during the unbonding period.
-- Possible punishment in case of the active validator found to be misbehaving (see [slashing](#slashing)).
+  {{ polkadot: Polkadot. :polkadot }}{{ kusama: Kusama. :kusama }} No rewards will be earned during
+  the unbonding period.
+- Possible punishment in case of the active validator found to be misbehaving (see
+  [slashing](#slashing)).
 - Lack of liquidity i.e. You would not be able to use the tokens for participating in crowdloans or
   transfer them to different account etc.
 
@@ -561,6 +565,3 @@ be limited by the bandwidth strain of the network due to peer-to-peer message pa
 - [How Nominated Proof of Stake will work in Polkadot](https://medium.com/web3foundation/how-nominated-proof-of-stake-will-work-in-polkadot-377d70c6bd43) -
   Blog post by Web3 Foundation researcher Alfonso Cevallos covering NPoS in Polkadot.
 - [Validator setup](../maintain/maintain-guides-secure-validator.md)
-
-[epoch]: ../general/glossary.md#epoch
-[how to chill]: ../maintain/maintain-guides-how-to-chill.md

--- a/docs/learn/learn-statemint.md
+++ b/docs/learn/learn-statemint.md
@@ -54,7 +54,7 @@ account using the teleport functionality. For instructions on teleporting DOT, c
 Assuming you have the required DOT balance on your Statemint account, the following instructions
 should let you successfully create an asset on Statemint
 
-- Access Statemint through [Polkadot-JS UI][].
+- Access Statemint through [Polkadot-JS UI](https://polkadot.js.org/apps/#/explorer).
 - Navigate to Network > Assets.
 
 ![Navigate to Assets page](../assets/statemint/Statemint-asset-0.png)
@@ -84,5 +84,3 @@ Network > Assets page on Statemint.
 Checkout
 [this support article](https://support.polkadot.network/support/solutions/articles/65000181118-how-to-transfer-tether-usdt-on-statemine),
 for a step by step guide covering how to make a transfer on the Statemine and the risks associated.
-
-[polkadot-js ui]: https://polkadot.js.org/apps/#/explorer

--- a/docs/learn/learn-teleport.md
+++ b/docs/learn/learn-teleport.md
@@ -12,8 +12,9 @@ import RPC from "./../../components/RPC-Connection";
 One of the main properties that Polkadot and Kusama bring to the ecosystems is decentralized
 blockchain interoperability. This interoperability allows for asset teleportation: the process of
 moving assets, such as coins, tokens, or NFTs, between chains (parachains) to use them as you would
-any other asset native to that chain. Interoperability is possible through [XCM][] and [SPREE
-modules][], which together ensure that assets are not lost or duplicated across multiple chain.
+any other asset native to that chain. Interoperability is possible through [XCM](learn-xcm.md) and
+[SPREE modules](learn-spree.md), which together ensure that assets are not lost or duplicated across
+multiple chain.
 
 ## How Teleports work
 
@@ -30,25 +31,25 @@ the circulating supply, taking note of the total amount of assets that was taken
 
 ### Receive Teleported Assets
 
-The source then creates an [XCM][] instruction called `ReceiveTeleportedAssets` containing as
-parameters a) the receiving account and b) the amount of assets taken out from circulation. It then
-sends this instruction over to the destination, where it gets processed and new assets are **put
-back into** the circulating supply.
+The source then creates an [XCM](learn-xcm.md) instruction called `ReceiveTeleportedAssets`
+containing as parameters a) the receiving account and b) the amount of assets taken out from
+circulation. It then sends this instruction over to the destination, where it gets processed and new
+assets are **put back into** the circulating supply.
 
 ### Deposit Asset
 
 The destination deposits the assets to the receiving account. The actions of **taking out** from the
 circulating supply and **putting back** into the circulating supply show the great flexibility that
-an [XCM][] executor has in regulating the flow of an asset without changing its circulating supply.
-Assets are transferred to an inaccessible account in order to take them out from circulation.
-Likewise, for putting assets back into circulation, assets are released from a pre-filled and
-inaccessible treasury, or perform a mint of the assets. This process requires mutual trust between
-the source and destination. The destination must trust the source of having appropriately removed
-the sent assets from the circulating supply, and the source must trust the destination of having put
-the received assets back into circulation. The result of an asset teleportation should result in the
-same circulating supply of the asset, and failing to uphold this condition will result in a change
-in the asset's total issuance (in the case of fungible tokens) or a complete loss/duplication of an
-NFT.
+an [XCM](learn-xcm.md) executor has in regulating the flow of an asset without changing its
+circulating supply. Assets are transferred to an inaccessible account in order to take them out from
+circulation. Likewise, for putting assets back into circulation, assets are released from a
+pre-filled and inaccessible treasury, or perform a mint of the assets. This process requires mutual
+trust between the source and destination. The destination must trust the source of having
+appropriately removed the sent assets from the circulating supply, and the source must trust the
+destination of having put the received assets back into circulation. The result of an asset
+teleportation should result in the same circulating supply of the asset, and failing to uphold this
+condition will result in a change in the asset's total issuance (in the case of fungible tokens) or
+a complete loss/duplication of an NFT.
 
 ## Teleporting Tokens using the Polkadot-JS UI
 
@@ -59,7 +60,3 @@ NFT.
 
 If you do not see "Accounts > Teleport" in [Polkadot-JS UI], the source chain that you have selected
 does not support teleportation yet.
-
-[polkadot-js ui]: https://polkadot.js.org/apps/
-[xcm]: learn-xcm.md
-[spree modules]: learn-spree.md

--- a/docs/maintain/kusama/maintain-guides-how-to-nominate-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-how-to-nominate-kusama.md
@@ -21,12 +21,13 @@ appointing their stake to the validators who are the second type of participant.
 stake, they are able to elect the active set of validators and share in the rewards that are paid
 out.
 
-While the [validators][] are active participants in the network that engage in the block production
-and finality mechanisms, nominators take a slightly more passive role. Being a nominator does not
-require running a node of your own or worrying about online uptime. However, a good nominator
-performs due diligence on the validators that they elect. When looking for validators to nominate, a
-nominator should pay attention to their own reward percentage for nominating a specific validator -
-as well as the risk that they bear of being slashed if the validator gets slashed.
+While the [validators](maintain-guides-how-to-validate-kusama.md) are active participants in the
+network that engage in the block production and finality mechanisms, nominators take a slightly more
+passive role. Being a nominator does not require running a node of your own or worrying about online
+uptime. However, a good nominator performs due diligence on the validators that they elect. When
+looking for validators to nominate, a nominator should pay attention to their own reward percentage
+for nominating a specific validator - as well as the risk that they bear of being slashed if the
+validator gets slashed.
 
 :::note Explainer videos on staking
 
@@ -41,11 +42,11 @@ are available:
 ## Setting up Stash and Controller keys
 
 Nominators are recommended to set up two separate stash and controller accounts. Explanation and
-reasoning for generating distinct accounts for this purpose is elaborated in the [keys][] section of
-the Wiki.
+reasoning for generating distinct accounts for this purpose is elaborated in the
+[keys](../../learn/learn-cryptography.md) section of the Wiki.
 
 You can generate your stash and controller account via any of the recommended methods that are
-detailed on the [account generation][] page.
+detailed on the [account generation](../../learn/learn-account-generation.md) page.
 
 Starting with runtime version v2023 natively included in client version
 [0.8.23](https://github.com/paritytech/polkadot/releases/tag/v0.8.23), payouts can go to any custom
@@ -220,7 +221,3 @@ polkadot-js-api --seed "xxxx xxxxx xxxx xxxxx" tx.staking.nominate '["CmD9vaMYoi
 
 After a few seconds, you should see the hash of the transaction and if you would like to verify the
 nomination status, you can check that on the Polkadot-JS UI as well.
-
-[validators]: maintain-guides-how-to-validate-kusama.md
-[keys]: ../../learn/learn-cryptography.md
-[account generation]: ../../learn/learn-account-generation.md

--- a/docs/maintain/kusama/maintain-guides-society-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-society-kusama.md
@@ -7,7 +7,8 @@ keywords: [kappa sigma mu, society, kusama, member]
 slug: ../../maintain-guides-society-kusama
 ---
 
-Kappa Sigma Mu is a membership club using the Substrate [Society pallet][substrate pallet]. It is an
+Kappa Sigma Mu is a membership club using the Substrate
+[Society pallet](https://paritytech.github.io/substrate/master/pallet_society/index.html). It is an
 economic game to incentivize users to join a society that coordinates around whatever the rules are
 decided to be. The members of the society are incentivized to participate in the society via the
 rewards paid by the treasury. Currently, there is only one society on Kusama but it is possible to
@@ -18,7 +19,8 @@ have multiple societies in the future through a runtime upgrade.
 
 Before joining the society, let's take a brief look at the
 [Society UI](https://polkadot.js.org/apps/#/society) on Polkadot-JS apps and read through all the
-[rules][kappa rules] to become a member.
+[rules](https://kusama.subscan.io/extrinsic/0x948d3a4378914341dc7af9220a4c73acb2b3f72a70f14ee8089799da16d94c17)
+to become a member.
 
 ## UI Overview
 
@@ -43,13 +45,14 @@ Below are the various types of users at different stages.
 - `Head` - One winning candidate will be randomly chosen as head of the members, weighted by the
   number of approvals the winning candidates accumulated.
 - `Defender` - In every challenge period, one of the members will be randomly selected to defend
-  their membership in the society. The rules for defending the membership are documented [in the
-  rules][kappa rules].
+  their membership in the society. The rules for defending the membership are documented
+  [in the rules](https://kusama.subscan.io/extrinsic/0x948d3a4378914341dc7af9220a4c73acb2b3f72a70f14ee8089799da16d94c17).
 
 ## Procedure
 
-Remember to take a look at the [rules][kappa rules] first. And since those rules are not enforced
-entirely on-chain, it is recommended to join the
+Remember to take a look at the
+[rules](https://kusama.subscan.io/extrinsic/0x948d3a4378914341dc7af9220a4c73acb2b3f72a70f14ee8089799da16d94c17)
+first. And since those rules are not enforced entirely on-chain, it is recommended to join the
 [Kappa Sigma Mu Lounge](https://app.element.io/#/room/!BUmiAAnAYSRGarqwOt:matrix.parity.io) to ask
 any questions if anything is unclear.
 
@@ -133,7 +136,9 @@ time - see below.
 
 It would take the number of members of the society as the variable to determine how many blocks you
 have to wait in order to get the payout. The longest lockup time is close to 3 years. The formula is
-defined [in the society pallet][substrate pallet] if you would like to have a look.
+defined
+[in the society pallet](https://paritytech.github.io/substrate/master/pallet_society/index.html) if
+you would like to have a look.
 
 Example:
 
@@ -169,9 +174,10 @@ the same as the above mentioned lockup formula.
 
 Third, there will be a membership challenge every seven days on Kusama. So one of the members will
 be randomly selected as a defender. Then, other members can vote whether this defender should stay
-in the society or not. A simple majority wins the vote. You can take a look [here][kappa rules] and
-search for "Existing Members (Challenges)". Besides that, you can earn extra KSM by helping a user
-apply for the membership and requesting a tip. This is useful when a user does not have enough
+in the society or not. A simple majority wins the vote. You can take a look
+[here](https://kusama.subscan.io/extrinsic/0x948d3a4378914341dc7af9220a4c73acb2b3f72a70f14ee8089799da16d94c17)
+and search for "Existing Members (Challenges)". Besides that, you can earn extra KSM by helping a
+user apply for the membership and requesting a tip. This is useful when a user does not have enough
 balance to reserve a deposit. The tip will be given when a user successfully joins the society.
 
 :::info
@@ -196,7 +202,3 @@ hexadecimal string. In order to see the rules in human-readable format, you can 
 extrinsic's parameters go to Element 1 ("proposal") -> "value" -> "params" -> Element 2 ("rules")
 and copy the value corresponding to the key "value". You can use a hex-to-UTF8 converter to then
 display the text. Note that the text is formatted with Markdown.
-
-[substrate pallet]: https://paritytech.github.io/substrate/master/pallet_society/index.html
-[kappa rules]:
-  https://kusama.subscan.io/extrinsic/0x948d3a4378914341dc7af9220a4c73acb2b3f72a70f14ee8089799da16d94c17

--- a/docs/maintain/maintain-guides-how-to-chill.md
+++ b/docs/maintain/maintain-guides-how-to-chill.md
@@ -7,52 +7,92 @@ keywords: [chill, chilling, pause]
 slug: ../maintain-guides-how-to-chill
 ---
 
-Staking bonds can be in any of the three states: validating, nominating, or chilled (neither validating nor nominating).  When a staker wants to temporarily pause their active engagement in staking but does not want to unbond their funds, they can choose to "chill" their involvement and keep their funds bonded.
+Staking bonds can be in any of the three states: validating, nominating, or chilled (neither
+validating nor nominating). When a staker wants to temporarily pause their active engagement in
+staking but does not want to unbond their funds, they can choose to "chill" their involvement and
+keep their funds bonded.
 
 An account can step back from participating in active staking by clicking "Stop" under the Network >
 Staking > Account actions page in [PolkadotJS Apps](https://polkadot.js.org/apps) or by calling the
-`chill` extrinsic in the [staking pallet][chill extrinsic]. When an account chooses to chill, it
-becomes inactive in the next era. The call must be signed by the _controller_ account, not the
-_stash_.
+`chill` extrinsic in the
+[staking pallet](https://paritytech.github.io/substrate/master/pallet_staking/pallet/enum.Call.html#variant.chill).
+When an account chooses to chill, it becomes inactive in the next era. The call must be signed by
+the _controller_ account, not the _stash_.
 
 :::note Primer on stash and controller accounts
 
 If you need a refresher on the different responsibilities of the stash and controller account when
-staking, take a look at the [accounts][] section in the general staking guide.
+staking, take a look at the [accounts](../learn/learn-staking.md#accounts) section in the general
+staking guide.
 
 :::
 
 ![staking](../assets/NPoS/staking-keys_stash_controller.png)
+
 ## Consideration for Staking Election
 
-A bond that is actively participating in staking but chilled would continue to participate in staking for the rest of the current era.  If the bond was chilled in sessions 1 through 4 and continues to be chilled for the rest of the era, it would NOT be selected for election in the next era.  If a bond was chilled for the entire session 5, it would not be considered in the next election.  If the bond was chilled in session 6, its participation in the next era's election would depend on its state in session 5.
+A bond that is actively participating in staking but chilled would continue to participate in
+staking for the rest of the current era. If the bond was chilled in sessions 1 through 4 and
+continues to be chilled for the rest of the era, it would NOT be selected for election in the next
+era. If a bond was chilled for the entire session 5, it would not be considered in the next
+election. If the bond was chilled in session 6, its participation in the next era's election would
+depend on its state in session 5.
 
 ## Chilling as a Nominator
 
-When you chill after being a nominator, your nominations will be reset. This means that when you decide to start nominating again you will need to select validators to nominate once again. These can be the same validators if you prefer, or, a completely new set. Just be aware - your nominations will not persist across chills.
+When you chill after being a nominator, your nominations will be reset. This means that when you
+decide to start nominating again you will need to select validators to nominate once again. These
+can be the same validators if you prefer, or, a completely new set. Just be aware - your nominations
+will not persist across chills.
 
-Your nominator will remain bonded when it is chilled. When you are ready to nominate again, you will not need to go through the whole process of bonding again, rather, you will issue a new nominate call that specifies the new validators to nominate.
+Your nominator will remain bonded when it is chilled. When you are ready to nominate again, you will
+not need to go through the whole process of bonding again, rather, you will issue a new nominate
+call that specifies the new validators to nominate.
 
 ## Chilling as a Validator
 
-When you voluntarily chill after being a validator, your nominators will remain.  As long as your nominators make no action, you will still have the nominations when you choose to become an active validator once again.  You bond however would not be listed as a nominable validator thus any nominators issuing new or revisions to existing nominations would not be able to select your bond.
+When you voluntarily chill after being a validator, your nominators will remain. As long as your
+nominators make no action, you will still have the nominations when you choose to become an active
+validator once again. You bond however would not be listed as a nominable validator thus any
+nominators issuing new or revisions to existing nominations would not be able to select your bond.
 
-When you become an active validator, you will also need to reset your validator preferences (commission, etc.). These can be configured as the same values set previously or something different.
+When you become an active validator, you will also need to reset your validator preferences
+(commission, etc.). These can be configured as the same values set previously or something
+different.
 
 ## Involuntary Chills
 
-If a validator was unresponsive for an entire session, the validator bond would be chilled in a process known as _involuntary chilling._ When a validator has been involuntarily chilled, it may restrict the validator from being selected in the next election depending on the session in which it was chilled (see considerations above).  A chilled validator may re-declare the intent to validate at any time. However, it is recommended that the validator attempts to determine the source of the chill before doing so.
+If a validator was unresponsive for an entire session, the validator bond would be chilled in a
+process known as _involuntary chilling._ When a validator has been involuntarily chilled, it may
+restrict the validator from being selected in the next election depending on the session in which it
+was chilled (see considerations above). A chilled validator may re-declare the intent to validate at
+any time. However, it is recommended that the validator attempts to determine the source of the
+chill before doing so.
 
-Slashing may also result in an involuntary chill. However, in that scenario, the validator would also lose their nominations.  By this action, even if the validator re-declares its intent to validate before session 5, there wouldn't be sufficient nominations to re-elect the node into the active set.
+Slashing may also result in an involuntary chill. However, in that scenario, the validator would
+also lose their nominations. By this action, even if the validator re-declares its intent to
+validate before session 5, there wouldn't be sufficient nominations to re-elect the node into the
+active set.
 
-Nominators have the option to renominate a slashed validator using a display row in Polkadot-JS UI. This row is displayed in the "Account Actions" tab for the nominator under a heading that says "Renomination required". 
+Nominators have the option to renominate a slashed validator using a display row in Polkadot-JS UI.
+This row is displayed in the "Account Actions" tab for the nominator under a heading that says
+"Renomination required".
 
 ## Chill Other
 
-An unbounded and unlimited number of nominators and validators in Polkadot's NPoS is not possible due to constraints in the runtime. As a result, multiple checks are incorporated to keep the size of staking system manageable, like mandating minimum active bond requirements for both nominators and validators. When these requirements are modified through on-chain governance, they can be enforced only on the accounts that newly call `nominate` or `validate` after the update. The changes to the bonding parameters would not automatically chill the active accounts on-chain which do not meet the requirements.
+An unbounded and unlimited number of nominators and validators in Polkadot's NPoS is not possible
+due to constraints in the runtime. As a result, multiple checks are incorporated to keep the size of
+staking system manageable, like mandating minimum active bond requirements for both nominators and
+validators. When these requirements are modified through on-chain governance, they can be enforced
+only on the accounts that newly call `nominate` or `validate` after the update. The changes to the
+bonding parameters would not automatically chill the active accounts on-chain which do not meet the
+requirements.
 
-For instance, let us consider a scenario where the minimum staking requirement for nominators is changed from 80 DOTs to 120 DOTs. An account that was actively nominating with 80 DOTs before this update would still keep receiving staking rewards. To handle this corner case, the `chill_other` extrinsic was incorporated which also helps to keep things backwards compatible and safe. The `chill_other` extrinsic is permissionless and any third party user can target it on an account where the minimum active bond is not satisfied, and chill that account. The list of addresses of all the active validators and their nominators can be viewed by running [validator stats](https://github.com/w3f/validator-stats) script.
-
-[chill extrinsic]:
-  https://paritytech.github.io/substrate/master/pallet_staking/pallet/enum.Call.html#variant.chill
-[accounts]: ../learn/learn-staking.md#accounts
+For instance, let us consider a scenario where the minimum staking requirement for nominators is
+changed from 80 DOTs to 120 DOTs. An account that was actively nominating with 80 DOTs before this
+update would still keep receiving staking rewards. To handle this corner case, the `chill_other`
+extrinsic was incorporated which also helps to keep things backwards compatible and safe. The
+`chill_other` extrinsic is permissionless and any third party user can target it on an account where
+the minimum active bond is not satisfied, and chill that account. The list of addresses of all the
+active validators and their nominators can be viewed by running
+[validator stats](https://github.com/w3f/validator-stats) script.

--- a/docs/maintain/maintain-guides-how-to-nominate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-nominate-polkadot.md
@@ -35,12 +35,13 @@ Nominators are one type of participant in the staking subsystem of Polkadot. The
 stake to the validators, the second type of participant. By appointing their stake, they can elect
 the active set of validators and share in the rewards that are paid out.
 
-While the [validators][] are active participants in the network that engage in the block production
-and finality mechanisms, nominators take a slightly more passive role. Being a nominator does not
-require running a node of your own or worrying about online uptime. However, a good nominator
-performs due diligence on the validators that they elect. When looking for validators to nominate, a
-nominator should pay attention to their own reward percentage for nominating a specific validator -
-as well as the risk that they bear of being slashed if the validator gets slashed.
+While the [validators](maintain-guides-how-to-validate-polkadot.md) are active participants in the
+network that engage in the block production and finality mechanisms, nominators take a slightly more
+passive role. Being a nominator does not require running a node of your own or worrying about online
+uptime. However, a good nominator performs due diligence on the validators that they elect. When
+looking for validators to nominate, a nominator should pay attention to their own reward percentage
+for nominating a specific validator - as well as the risk that they bear of being slashed if the
+validator gets slashed.
 
 If you are a beginner, please watch the video below for detailed instructions.
 
@@ -49,11 +50,11 @@ If you are a beginner, please watch the video below for detailed instructions.
 ## Setting up Stash and Controller Accounts
 
 Nominators are recommended to set up separate stash and controller accounts. Explanation and the
-reasoning for generating distinct accounts for this purpose is elaborated in the [keys][] section of
-the Wiki.
+reasoning for generating distinct accounts for this purpose is elaborated in the
+[keys](../learn/learn-cryptography.md#keys) section of the Wiki.
 
 You can generate your stash and controller account via any of the recommended methods, which are
-detailed on the [account generation][] page.
+detailed on the [account generation](../learn/learn-account-generation.md) page.
 
 Starting with runtime version v23 natively included in the client version
 [0.8.23](https://github.com/paritytech/polkadot/releases/tag/v0.8.23), payouts can go to any custom
@@ -67,11 +68,16 @@ Nominating is the action of choosing validators. It does not simply involve bond
 Nominating is an active task, which implies that you regularly monitor that your stake is backing an
 active validator in all the eras and check if you are receiving your staking rewards. More
 importantly, ensure that the validators you chose always act in the best interests of the network
-protocol and have less chance of getting slashed. To nominate, you need a minimum of {{ polkadot: <RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :kusama }}, and to
-receive rewards, you need at least a balance greater than the minimum active bond. Depending on your
-validators, if your active validator is oversubscribed, you will earn rewards only if your stake is
-within that of the top {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }} nominators. If the validator misbehaves, It is worth noting that your
-stake is subject to slashing, irrespective of whether you are in the top {{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }} nominators or not.
+protocol and have less chance of getting slashed. To nominate, you need a minimum of
+{{ polkadot: <RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :polkadot }}{{ kusama: <RPC network="kusama" path="query.staking.minNominatorBond" defaultValue={100000000000} filter="humanReadable"/> :kusama }},
+and to receive rewards, you need at least a balance greater than the minimum active bond. Depending
+on your validators, if your active validator is oversubscribed, you will earn rewards only if your
+stake is within that of the top
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
+nominators. If the validator misbehaves, It is worth noting that your stake is subject to slashing,
+irrespective of whether you are in the top
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}{{ kusama: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
+nominators or not.
 
 As the minimum active bond is a dynamic value, it can make your nomination inactive when the
 threshold goes above your bonded balance. Hence, to be eligible to earn rewards while nominating,
@@ -87,19 +93,19 @@ the pool operator that maintains the list of validators nominated by the pool, a
 are trusting the pool operator to act in your best interests. However, it is advised to check the
 validators nominated by the pool from time to time and change the pool if necessary.
 
-|                                         Nominating                                          |                                                     Joining a Pool                                                      |
-| :-----------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------: |
-|                                 Minimum 100 DOT to nominate.                                 |                                              Minimum 1 DOT to be a member.                                              |
-| Rewards can be compounded automatically or sent to any account. | Rewards can be manually claimed to the pool member's account and be bonded in the pool again to compound them. |
-| If the active validator gets slashed, all active nominators are subjected to slashing, also those that do not receive rewards due to the oversubscription issue. | If the active validator gets slashed, all pool members are subjected to slashing. |
-|                                  Can bond and stake DOT indefinitely.                                  |                                     Can bond and stake DOT until the pool exists.                                     |
-|                                Unbonding period of 28 days. Can switch validators without unbonding.                                 |                                              Unbonding period of 28 days. Need to unbond before switching to a different pool.                                              |
-|                                      Maximum uncapped.                                      |                                                    Maximum uncapped.                                                    |
-|                               Should bond more than the [minimum active nomination](../learn/learn-nominator.md#minimum-active-nomination-to-receive-staking-rewards) in an era to be eligible to earn staking rewards, although it can depend on multiple other factors outlined in the linked document.                               |                                               A nomination pool earns rewards in an era if it satisfies all the conditions mentioned for the nominator (as the nomination pool is just a nominator from [the NPoS system](../learn/learn-phragmen.md) perspective).                                                |
-|                      Staked tokens can be used for participation in Governance.                    |        Staked tokens cannot be used for participation in Governance.                                                    |
-| [Rewards payout](../learn/learn-staking-advanced.md#claiming-rewards) can be triggered permissionlessly by anyone (typically done by the validator).   |                                       Rewards must be claimed by the pool member.                                       |
-|                            Bonded funds remain in your account.                             | Bonded funds are transferred to a pool account which is administered by the network protocol and is not accessible to anyone else. |
-|                              Nominator is responsible for managing the list of staked validators (up to 16).                              |                                            Nominations managed by the pool operator.                                            |
+|                                                                                                                                 Nominating                                                                                                                                  |                                                                                                    Joining a Pool                                                                                                     |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                                                                                                        Minimum 100 DOT to nominate.                                                                                                                         |                                                                                             Minimum 1 DOT to be a member.                                                                                             |
+|                                                                                                       Rewards can be compounded automatically or sent to any account.                                                                                                       |                                                    Rewards can be manually claimed to the pool member's account and be bonded in the pool again to compound them.                                                     |
+|                                                      If the active validator gets slashed, all active nominators are subjected to slashing, also those that do not receive rewards due to the oversubscription issue.                                                       |                                                                   If the active validator gets slashed, all pool members are subjected to slashing.                                                                   |
+|                                                                                                                    Can bond and stake DOT indefinitely.                                                                                                                     |                                                                                     Can bond and stake DOT until the pool exists.                                                                                     |
+|                                                                                                    Unbonding period of 28 days. Can switch validators without unbonding.                                                                                                    |                                                                   Unbonding period of 28 days. Need to unbond before switching to a different pool.                                                                   |
+|                                                                                                                              Maximum uncapped.                                                                                                                              |                                                                                                   Maximum uncapped.                                                                                                   |
+| Should bond more than the [minimum active nomination](../learn/learn-nominator.md#minimum-active-nomination-to-receive-staking-rewards) in an era to be eligible to earn staking rewards, although it can depend on multiple other factors outlined in the linked document. | A nomination pool earns rewards in an era if it satisfies all the conditions mentioned for the nominator (as the nomination pool is just a nominator from [the NPoS system](../learn/learn-phragmen.md) perspective). |
+|                                                                                                         Staked tokens can be used for participation in Governance.                                                                                                          |                                                                             Staked tokens cannot be used for participation in Governance.                                                                             |
+|                                                            [Rewards payout](../learn/learn-staking-advanced.md#claiming-rewards) can be triggered permissionlessly by anyone (typically done by the validator).                                                             |                                                                                      Rewards must be claimed by the pool member.                                                                                      |
+|                                                                                                                    Bonded funds remain in your account.                                                                                                                     |                                          Bonded funds are transferred to a pool account which is administered by the network protocol and is not accessible to anyone else.                                           |
+|                                                                                               Nominator is responsible for managing the list of staked validators (up to 16).                                                                                               |                                                                                       Nominations managed by the pool operator.                                                                                       |
 
 ## Using the Polkadot Staking Dashboard
 
@@ -226,7 +232,3 @@ polkadot-js-api --seed "xxxx xxxxx xxxx xxxxx" tx.staking.nominate '["CmD9vaMYoi
 
 After a few seconds, you should see the hash of the transaction, and if you would like to verify the
 nomination status, you can check that on the Polkadot-JS UI as well.
-
-[validators]: maintain-guides-how-to-validate-polkadot.md
-[keys]: ../learn/learn-cryptography.md#keys
-[account generation]: ../learn/learn-account-generation.md

--- a/docs/maintain/maintain-guides-how-to-use-polkadot-validator-setup.md
+++ b/docs/maintain/maintain-guides-how-to-use-polkadot-validator-setup.md
@@ -9,10 +9,11 @@ slug: ../maintain-guides-how-to-use-polkadot-validator-setup
 
 # Polkadot Validator Setup
 
-The following guide will walk you through using Web3 Foundation's [polkadot validator setup][] to
-offer a potential setup for your validator that aims to prevent some types of potential attacks at
-the TCP layer and layers below. This will work for Polkadot and Kusama out of the box, and, if
-you're using another Substrate-based chain, it should work with some tweaks.
+The following guide will walk you through using Web3 Foundation's
+[polkadot validator setup](https://github.com/w3f/polkadot-validator-setup) to offer a potential
+setup for your validator that aims to prevent some types of potential attacks at the TCP layer and
+layers below. This will work for Polkadot and Kusama out of the box, and, if you're using another
+Substrate-based chain, it should work with some tweaks.
 
 :::tip This setup should not be assumed to include the best security practices
 
@@ -34,8 +35,8 @@ There are two ways that the setup can be configured:
    tool for setting up the VPN, Firewall, and the validator node. It supports a few different cloud
    providers such as AWS, Microsoft Azure, GCP, and Packet.
 
-   :::note Please file an [issue][] if you would like to make a feature request or report a bug for
-   this setup
+   :::note Please file an [issue](https://github.com/w3f/polkadot-validator-setup/issues) if you
+   would like to make a feature request or report a bug for this setup
 
    :::
 
@@ -51,7 +52,8 @@ system.
 
 ### NodeJS
 
-We recommend using [nvm][] as a tool to manage different NodeJS versions across projects.
+We recommend using [nvm](https://github.com/nvm-sh/nvm) as a tool to manage different NodeJS
+versions across projects.
 
 ```
 sudo apt-get install curl
@@ -105,8 +107,8 @@ machines.
 
 ### Step Two: Generate the SSH keys
 
-We will use [SSH][], a remote shell tool, to access our validator. You will first use the
-`ssh-keygen` command to generate a key for your validator.
+We will use [SSH](https://en.wikipedia.org/wiki/Secure_Shell), a remote shell tool, to access our
+validator. You will first use the `ssh-keygen` command to generate a key for your validator.
 
 ```zsh
 $ ssh-keygen -m pem -f id_rsa_validator
@@ -176,15 +178,17 @@ use them:
 In the `additionalFlags` option, configure any of the additional flags you want to run for your
 validator. If you want to run with a specific name, this is where you would enter it.
 
-Under the `polkadotBinary.url` field you can provide the release that is hosted in the [W3F
-repository][w3f polkadot] or use an alternate one that you build and publish yourself.
+Under the `polkadotBinary.url` field you can provide the release that is hosted in the
+[W3F repository](https://github.com/w3f/polkadot/releases) or use an alternate one that you build
+and publish yourself.
 
-By enabling the `nodeExporter`, Ansible will install and configure the [node_exporter][], which will
-expose hardware-level metrics of your node in a format compatible with Prometheus.
+By enabling the `nodeExporter`, Ansible will install and configure the
+[node_exporter](https://github.com/prometheus/node_exporter), which will expose hardware-level
+metrics of your node in a format compatible with Prometheus.
 
 The field `machineType:` will configure the machine's hardware specifications, check
-[here][gcp machine types] for the configuration options for GCP. The other hosting providers should
-have similar pages in their documentation.
+[here](https://cloud.google.com/compute/docs/machine-types) for the configuration options for GCP.
+The other hosting providers should have similar pages in their documentation.
 
 Under `provider` the option are `gcp` (Google Cloud Provider), `aws` (AWS), `azure` (Microsoft
 Azure) and `packet` for Packet.
@@ -192,12 +196,14 @@ Azure) and `packet` for Packet.
 The field `count` is the number of instances you would like to create.
 
 The `location` and `zone` fields are for the location of the machine, for GCP check
-[here][gcp regions], other cloud providers will have similar documentation.
+[here](https://cloud.google.com/compute/docs/regions-zones/), other cloud providers will have
+similar documentation.
 
 The `telemetryUrl` field will send your node's information to a specific telemetry server. You could
 send all your nodes' data (e.g. IP address) to the public endpoint, but it is highly recommended
 that that you set up your own telemetry server to protect your validator’s data from being exposed
-to the public. If you want to do that, see [substrate telemetry source][].
+to the public. If you want to do that, see
+[substrate telemetry source](https://github.com/paritytech/substrate-telemetry).
 
 :::note
 
@@ -215,7 +221,8 @@ For different cloud providers, you need to set the corresponding credentials as 
 variables, for example, on GCP you only need to set `GOOGLE_APPLICATION_CREDENTIALS`. This variable
 is the path to the JSON file containing the credentials of the service account you wish to use; this
 service account needs to have write access to compute and network resources if you use GCP. For
-others, you can check that by referring to the [README][].
+others, you can check that by referring to the
+[README](https://github.com/w3f/polkadot-validator-setup#prerequisites).
 
 :::info Environment variables for Ansible
 
@@ -308,14 +315,3 @@ it.
 
 Congratulations! You have successfully deployed a secure validator. Free feel to open an issue if
 you have any suggestions.
-
-[polkadot validator setup]: https://github.com/w3f/polkadot-validator-setup
-[issue]: https://github.com/w3f/polkadot-validator-setup/issues
-[ssh]: https://en.wikipedia.org/wiki/Secure_Shell
-[nvm]: https://github.com/nvm-sh/nvm
-[w3f polkadot]: https://github.com/w3f/polkadot/releases
-[node_exporter]: https://github.com/prometheus/node_exporter
-[gcp machine types]: https://cloud.google.com/compute/docs/machine-types
-[gcp regions]: https://cloud.google.com/compute/docs/regions-zones/
-[substrate telemetry source]: https://github.com/paritytech/substrate-telemetry
-[readme]: https://github.com/w3f/polkadot-validator-setup#prerequisites

--- a/docs/maintain/maintain-guides-validator-community.md
+++ b/docs/maintain/maintain-guides-validator-community.md
@@ -9,10 +9,11 @@ slug: ../maintain-guides-validator-community
 
 ## Building a Community and Attracting Nominations
 
-After [setting up a validator][], nominations will only come in with extra work. The community of
-nominators will need to know about the validator to trust staking with them, and thus the validator
-must distinguish themselves to attract nominations. The following gives some general guidance on
-different approaches to building a community and attracting nominations.
+After [setting up a validator](maintain-guides-how-to-validate-Polkadot), nominations will only come
+in with extra work. The community of nominators will need to know about the validator to trust
+staking with them, and thus the validator must distinguish themselves to attract nominations. The
+following gives some general guidance on different approaches to building a community and attracting
+nominations.
 
 Being a high-quality validator entails effectively running nodes and building a brand, reputation,
 and community around validation services. The responsibilities of a quality validator additionally
@@ -38,11 +39,12 @@ channels.
 
 ### Setting Identity
 
-All validators should set an on-chain [identity][] and get a judgement on the identity so that
-nominators can find nodes when browsing through various dashboards and UIs. When someone interacts
-with the chain, it ensures that an address they may come across belongs to the validator, and
-actions of that identity throughout various parts of the ecosystem (staking, governance, block
-explorers, etc.) form a cohesive representation of their participation.
+All validators should set an on-chain [identity](../learn/learn-identity.md#setting-an-identity) and
+get a judgement on the identity so that nominators can find nodes when browsing through various
+dashboards and UIs. When someone interacts with the chain, it ensures that an address they may come
+across belongs to the validator, and actions of that identity throughout various parts of the
+ecosystem (staking, governance, block explorers, etc.) form a cohesive representation of their
+participation.
 
 :::note When running multiple validator nodes, the best way to scale an identity is to use multiple
 sub-identities from a single verified identity
@@ -258,7 +260,7 @@ Whether by voting on-chain, or by discussing off-chain, or proposing new things,
 participation in the direction of the chain is an excellent signal that a validator is there for the
 network’s good. There are many ways to participate in different governance aspects, such as voting
 for council members, weighing in on treasury proposals, voting on public referenda, proposing tips,
-and more. See the section on [governance][] for additional details.
+and more. See the section on [governance](maintain-guides-democracy) for additional details.
 
 #### Producing Educational Content
 
@@ -281,7 +283,3 @@ validation services. Some potential building categories are block explorers, dep
 monitoring, observability services, staking dashboards, wallets, command-line utilities, or porting
 implementations to other languages. Additionally, this may also be eligible to be funded via a
 [Web3 Foundation Grant](https://github.com/w3f/Grants-Program).
-
-[setting up a validator]: maintain-guides-how-to-validate-Polkadot
-[identity]: ../learn/learn-identity.md#setting-an-identity
-[governance]: maintain-guides-democracy

--- a/docs/maintain/maintain-index.md
+++ b/docs/maintain/maintain-index.md
@@ -33,8 +33,8 @@ guides to set up a node and run the network.
   nominate on the Polkadot network.
 - [Nomination Guide (Kusama)](kusama/maintain-guides-how-to-nominate-kusama.md) - Walkthrough on how
   to nominate on the Kusama canary network.
-- [How to stop being a Nominator](maintain-guides-how-to-nominate-polkadot.md) - Guide on how to stop
-  nominating.
+- [How to stop being a Nominator](maintain-guides-how-to-nominate-polkadot.md) - Guide on how to
+  stop nominating.
 
 ## Validator
 
@@ -61,9 +61,7 @@ guides to set up a node and run the network.
 
 - [How to participate in Governance](maintain-guides-democracy.md) - Walkthrough on how to
   participate in governance.
-- [How to join the Council][join the council] - Step by step guide for running for the Council.
-- [How to vote for a Councillor][vote for councillors] - Step by step guide for voting for your
-  favorite councillors.
-
-[join the council]: maintain-guides-how-to-join-council.md
-[vote for councillors]: maintain-guides-how-to-vote-councillor.md
+- [How to join the Council](maintain-guides-how-to-join-council.md) - Step by step guide for running
+  for the Council.
+- [How to vote for a Councillor](maintain-guides-how-to-vote-councillor.md) - Step by step guide for
+  voting for your favorite councillors.

--- a/docs/maintain/maintain-networks.md
+++ b/docs/maintain/maintain-networks.md
@@ -89,8 +89,9 @@ the CLI.
 
 ## Substrate Networks
 
-To connect to a Substrate public network, follow the [instructions][substrate install] for
-installing the Substrate executable first.
+To connect to a Substrate public network, follow the
+[instructions](https://docs.substrate.io/v3/getting-started/overview/) for installing the Substrate
+executable first.
 
 ### Flaming Fir
 
@@ -111,13 +112,10 @@ and you will connect and start syncing Flaming Fir.
 ## Telemetry Dashboard
 
 If you connect to the public networks, the default configuration for your node will connect it to
-the public [Telemetry][telemetry] service.
+the public [Telemetry](https://telemetry.polkadot.io/) service.
 
 You can verify that your node is connected by navigating to the correct network on the dashboard and
 finding the name of your node.
 
 There is a built-in search function on the nodes page. Simply start typing keystrokes in the main
 window to make it available.
-
-[substrate install]: https://docs.substrate.io/v3/getting-started/overview/
-[telemetry]: https://telemetry.polkadot.io/


### PR DESCRIPTION
### Issue

It was recently discovered that document links formatted in the following manner:

```
[Collator subsystem][]

[collator subsystem]: https://paritytech.github.io/polkadot/book/node/collators/index.html
```

can causes conflicts with prettier.  For example. prettier could split the tag `[Collator subsystem][]` between `Collator` and `subsystem` with a newline, which breaks the link.  This exact scenario is found many times below.  Even if it is not currently the case, it can happen with future PRs when the formatter runs.

This formatting is also not audited by the link auditing tool.

### Solution

To resolve this issue, this PR unifies all link formatting to use the traditional markdown syntax, such as `[link](url)`.

### Testing

I ran the url auditing tool to verify this change didn't introduce any broken links