### PR TITLE
Add automated Prettier repo scan to GitHub actions and run on all files

### DIFF
--- a/.github/workflows/prettier-all.yml
+++ b/.github/workflows/prettier-all.yml
@@ -1,0 +1,35 @@
+name: Run Prettier on entire repo
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Once a week
+  workflow_dispatch: # Or manually from GitHub UI
+
+jobs:
+  update_json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Update cache
+        run: |
+          git config --global user.email "polkadot-kusama-automation-bot@users.noreply.github.com"
+          git config --global user.name "Polkadot-Kusama Bot"
+          git branch prettier-update
+          git checkout prettier-update
+          yarn && yarn prettier:all
+      - name: Commit and push changes
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git commit -a -m 'applying prettier to entire repo'
+            git push --set-upstream origin prettier-update
+          else
+            echo No prettier changes detected, skipping update.
+          fi
+      - name: create pull request
+        run: gh pr create -B master -H prettier-update --title 'Automated prettier cleanup' --body 'Automated prettier cleanup over entire repo.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/build/build-tools-index.md
+++ b/docs/build/build-tools-index.md
@@ -153,8 +153,8 @@ WebAssembly related tools and projects.
   language.
 - [Go: Subscan API](https://github.com/itering/substrate-api-rpc) - Go API for Polkadot.
 - [C++ Polkadot API](https://github.com/usetech-llc/polkadot_api_cpp) - С++ API for Polkadot.
-- [.NET Toolchain for Polkadot/Substrate API](https://github.com/ajuna-network/Ajuna.SDK) - Toolchain
-  to generate Polkadot API & Service Layer for .NET (usable in Unity).
+- [.NET Toolchain for Polkadot/Substrate API](https://github.com/ajuna-network/Ajuna.SDK) -
+  Toolchain to generate Polkadot API & Service Layer for .NET (usable in Unity).
 - [.NET Polkadot API](https://github.com/usetech-llc/polkadot_api_dotnet) - Polkadot Substrate API
   for .NET.
 - [Python Polkadot API](https://github.com/polkascan/py-substrate-interface) - Polkadot library for

--- a/docs/general/kusama/kusama-community.md
+++ b/docs/general/kusama/kusama-community.md
@@ -21,7 +21,8 @@ anyone doing so is likely trying to scam you.**
   Information on hosting meetups, applying for funding, and materials for running it.
 - [Support Knowledgebase](https://support.polkadot.network/support/home) and
   [Polkadot Support Contact](https://support.polkadot.network).
-- [Polkadot's Latest Research](https://research.web3.foundation/en/latest/polkadot/overview.html) - also applies to Kusama.
+- [Polkadot's Latest Research](https://research.web3.foundation/en/latest/polkadot/overview.html) -
+  also applies to Kusama.
 
 ### Events
 

--- a/docs/general/research.md
+++ b/docs/general/research.md
@@ -16,7 +16,9 @@ Polkadot from a research or academic perspective.
 
 ## Research Papers
 
-- [Efficient Aggregatable BLS Signatures with Chaum-Pedersen Proofs](https://eprint.iacr.org/2022/1611) - describes our improvements regarding efficient verification for BLS signatures for both individual as well as aggregated signatures.
+- [Efficient Aggregatable BLS Signatures with Chaum-Pedersen Proofs](https://eprint.iacr.org/2022/1611) -
+  describes our improvements regarding efficient verification for BLS signatures for both individual
+  as well as aggregated signatures.
 - [Accountable Light Client Systems for PoS Blockchains](https://github.com/w3f/apk-proofs/blob/9f3ed95d4dba4a4ea4b0dca3a57f4b7495271346/Light%20Client.pdf) -
   [`Implemented`](https://github.com/w3f/apk-proofs) as an efficient method to aggregate BLS
   signatures and BLS public keys which in turn is used to build light client systems that are the

--- a/docs/learn/learn-accounts.md
+++ b/docs/learn/learn-accounts.md
@@ -90,7 +90,8 @@ To learn more about generating accounts on
 In {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} there are different types of
 balance depending on the account activity. Different balance types indicate whether your balance can
 be used for transfers, to pay fees, or must remain frozen and unused due to an on-chain requirement.
-Below we give an example of different balance types on Kusama (note that on Polkadot the situation will look the same).
+Below we give an example of different balance types on Kusama (note that on Polkadot the situation
+will look the same).
 
 ![account_balance_types](../assets/account-balance-types.png)
 

--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -48,8 +48,8 @@ equipment) is limited; this can directly increase operational costs as well. Sys
 number of validators tend to form pools to decrease the variance of their revenue and profit from
 economies of scale. These pools are often off-chain.
 
-A way to alleviate this is to implement pool formation on-chain and allow token holders to vote
-with their stake for validators to represent them.
+A way to alleviate this is to implement pool formation on-chain and allow token holders to vote with
+their stake for validators to represent them.
 
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses NPoS (Nominated Proof-of-Stake)
 as its mechanism for selecting the validator set. It is designed with the roles of **validators**

--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -67,7 +67,6 @@ also applied proportionally to members who may have been actively bonded.
 
 :::info Nomination Pool Stats
 
-```suggestion
 - There can be a maximum of
   {{ polkadot: <RPC network="polkadot" path="query.nominationPools.maxPoolMembers" defaultValue={16384} /> :polkadot }}
   {{ kusama: <RPC network="kusama" path="query.nominationPools.maxPoolMembers" defaultValue={65536} /> :kusama }}

--- a/docs/learn/learn-opengov.md
+++ b/docs/learn/learn-opengov.md
@@ -40,12 +40,12 @@ referenda can be voted on at a time and the voting period can last multiple week
 the system favoring careful consideration of very few proposals, as opposed to broad consideration
 of many. With that being said, OpenGov (also referred to as Governance v2) is here!
 
-OpenGov changes how the practical means of day-to-day decisions are made, making the
-repercussions of referenda better scoped and agile in order to dramatically increase the number of
-collective decisions the system is able to make.
+OpenGov changes how the practical means of day-to-day decisions are made, making the repercussions
+of referenda better scoped and agile in order to dramatically increase the number of collective
+decisions the system is able to make.
 
-**OpenGov is launched on Kusama. Once it is rigorously tested on
-Kusama, a proposal will be made for it to be deployed on Polkadot.**
+**OpenGov is launched on Kusama. Once it is rigorously tested on Kusama, a proposal will be made for
+it to be deployed on Polkadot.**
 
 The following content will begin by walking through many of the core principles of governance on the
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} network. It is important to
@@ -303,8 +303,8 @@ three tasks of governance:
 
 In Governance v2, an alternate strategy was required to replace the Council in its previous duties
 as a body delegated by voters to compensate for the fact that many choose to not take part in
-day-to-day of governance. OpenGov builds on the **Vote Delegation** feature from v1 where a voter can
-choose to delegate their voting power to another voter in the system. It does so by improving a
+day-to-day of governance. OpenGov builds on the **Vote Delegation** feature from v1 where a voter
+can choose to delegate their voting power to another voter in the system. It does so by improving a
 feature known as **Multirole Delegation**, where voters can specify a different delegate for every
 class of referendum in the system. So for example, a voter could delegate one entity for managing a
 less potent referenda class, choose a different delegate for a different class with more powerful

--- a/docs/learn/learn-parachains-faq.md
+++ b/docs/learn/learn-parachains-faq.md
@@ -34,13 +34,15 @@ Substrate-based.
 
 ### Is 100 a hard limit on the number of Parachains that can be supported?
 
-No.{{ polkadot: Polkadot :polkadot }} {{ kusama: Kusama :kusama }} network went through a significant
-number of optimizations, and there are [several updates planned](https://polkadot.network/blog/polkadot-roadmap-roundup/) 
-in the near future. The exact number of parachains that the Relay Chain can support without any 
-degradation in performance is yet to be discovered. Also, with the 
-[blockspace over blockchains](https://www.rob.tech/polkadot-blockspace-over-blockchains/) paradigm which brings
-parathreads into the picture, there is no hard limit number on the number of blockchains that can be supported 
-by {{ polkadot: Polkadot :polkadot }} {{ kusama: Kusama :kusama }}.
+No.{{ polkadot: Polkadot :polkadot }} {{ kusama: Kusama :kusama }} network went through a
+significant number of optimizations, and there are
+[several updates planned](https://polkadot.network/blog/polkadot-roadmap-roundup/) in the near
+future. The exact number of parachains that the Relay Chain can support without any degradation in
+performance is yet to be discovered. Also, with the
+[blockspace over blockchains](https://www.rob.tech/polkadot-blockspace-over-blockchains/) paradigm
+which brings parathreads into the picture, there is no hard limit number on the number of
+blockchains that can be supported by {{ polkadot: Polkadot :polkadot }}
+{{ kusama: Kusama :kusama }}.
 
 ### What happens to parachains when the number of validators drops below a certain threshold?
 
@@ -72,8 +74,9 @@ within [Cumulus](https://github.com/paritytech/cumulus).
 ### Parachain Development Kits (PDKs)
 
 Parachain Development Kits are a set of tools that enable developers to create their own
-applications as parachains. For more information, see the
-PDK content](../build/build-parachains.md#parachain-development-kit-pdk) and [Parachain Development page](../build/build-parachains.md).
+applications as parachains. For more information, see the PDK
+content](../build/build-parachains.md#parachain-development-kit-pdk) and
+[Parachain Development page](../build/build-parachains.md).
 
 ## Security
 
@@ -105,10 +108,10 @@ validators.
 
 ### How will parachain slots be distributed?
 
-Parachain slots are acquirable through auction. For more information on the auction process, please 
-see the [parachain slot auctions](learn-auction.md) article. Additionally, some parachain
-slots will be set aside to run [parathreads](learn-parathreads.md) &mdash; chains that bid on a per-block
-basis to be included in the Relay Chain. (Parathreads are not implemented yet.)
+Parachain slots are acquirable through auction. For more information on the auction process, please
+see the [parachain slot auctions](learn-auction.md) article. Additionally, some parachain slots will
+be set aside to run [parathreads](learn-parathreads.md) &mdash; chains that bid on a per-block basis
+to be included in the Relay Chain. (Parathreads are not implemented yet.)
 
 ### Why doesn't everyone bid for the max length?
 

--- a/docs/learn/learn-polkadotjs.md
+++ b/docs/learn/learn-polkadotjs.md
@@ -107,10 +107,10 @@ To populate the Apps UI, the web app queries the Polkadot-JS API. The API then q
 information that the UI will display on the screen. You can choose which node to connect to by
 changing it in the upper-left-hand corner of the screen.
 
-Let's see how we can query on-chain data with Polkadot-JS UI on the Polkadot network with an example.
-To find out the current value for existential deposit, navigate to Developer > Chain state >
-Constants and query the balances pallet for existential deposit as shown in the snapshot below. You
-need to click on the plus button to execute the query. The value displayed is in
+Let's see how we can query on-chain data with Polkadot-JS UI on the Polkadot network with an
+example. To find out the current value for existential deposit, navigate to Developer > Chain
+state > Constants and query the balances pallet for existential deposit as shown in the snapshot
+below. You need to click on the plus button to execute the query. The value displayed is in
 [plancks](learn-DOT#polkadot)
 
 ![query chain state](../assets/chain-state-constant.png)

--- a/docs/maintain/maintain-guides-best-practices-to-avoid-slashes.md
+++ b/docs/maintain/maintain-guides-best-practices-to-avoid-slashes.md
@@ -9,56 +9,101 @@ slug: ../maintain-guides-avoid-slashing
 
 ## Best practices to prevent slashing
 
-Slashing is implemented as a deterrent for validators to misbehave. Slashes are applied to a validator’s total stake (own + nominated) and can range from as little as 0.01% or rise to 100%.  In all instances, slashes are accompanied by a loss of nominators.  
+Slashing is implemented as a deterrent for validators to misbehave. Slashes are applied to a
+validator’s total stake (own + nominated) and can range from as little as 0.01% or rise to 100%. In
+all instances, slashes are accompanied by a loss of nominators.
 
 A slash may occur under four circumstances:
 
-1.  Unresponsiveness – Slashing starts when 10% of the active validators set are offline and increases in a linear manner until 44% of the validator set is offline; at this point, the slash is held at 7% 
-2.  Equivocation – A slash of 0.01% is applied with as little as a single evocation.   The slashed amount increases to 100% incrementally as more validators also equivocate.
-3.  Malicious action – This may result from a validator trying to represent the contents of a block falsely.  Slashing penalties of 100% may apply.
-4.  Application related (bug or otherwise) – The amount is unknown and may manifest as scenarios 1, 2, and 3 above.
+1.  Unresponsiveness – Slashing starts when 10% of the active validators set are offline and
+    increases in a linear manner until 44% of the validator set is offline; at this point, the slash
+    is held at 7%
+2.  Equivocation – A slash of 0.01% is applied with as little as a single evocation. The slashed
+    amount increases to 100% incrementally as more validators also equivocate.
+3.  Malicious action – This may result from a validator trying to represent the contents of a block
+    falsely. Slashing penalties of 100% may apply.
+4.  Application related (bug or otherwise) – The amount is unknown and may manifest as scenarios 1,
+    2, and 3 above.
 
-This article provides some best practices to prevent slashing based on lessons learned from previous slashes.  It provides comments and guidance for all circumstances except for malicious action by the node operator.
+This article provides some best practices to prevent slashing based on lessons learned from previous
+slashes. It provides comments and guidance for all circumstances except for malicious action by the
+node operator.
 
 ## Unresponsiveness
-An offline event occurs when a validator does not produce a BLOCK or IMONLINE message within an EPOCH.  Isolated offline events do not result in a slash; however, the validator would not earn any era points while offline.
-A slash for unresponsiveness occurs when 10% or more of the active validators are offline at the same time. Check the  Wiki section on [slashing due to unresponsiveness](../learn/learn-staking-advanced.md#unresponsiveness) to learn more about its specifics.
 
-The following are recommendations to validators to avoid slashing under liveliness for servers that have historically functioned:
-1.  Utilize systems to host your validator instance.  Systemd should be configured to auto reboot the service with a minimum 60-second delay.  This configuration should aid with re-establishing the instance under isolated failures with the binary.  
-2.  A validator instance can demonstrate un-lively behaviour if it cannot sync new blocks.  This may result from insufficient disk space or a corrupt database.
-3.  Monitoring should be implemented that allows node operators to monitor connectivity network connectivity to the peer-to-peer port of the validator instance.  Monitoring should also be implemented to ensure that there is <50 Block ‘drift’ between the target and best blocks.  If either event produces a failure, the node operator should be notified.
-The following are recommendations to validators to avoid liveliness for new servers / migrated servers:
+An offline event occurs when a validator does not produce a BLOCK or IMONLINE message within an
+EPOCH. Isolated offline events do not result in a slash; however, the validator would not earn any
+era points while offline. A slash for unresponsiveness occurs when 10% or more of the active
+validators are offline at the same time. Check the Wiki section on
+[slashing due to unresponsiveness](../learn/learn-staking-advanced.md#unresponsiveness) to learn
+more about its specifics.
+
+The following are recommendations to validators to avoid slashing under liveliness for servers that
+have historically functioned:
+
+1.  Utilize systems to host your validator instance. Systemd should be configured to auto reboot the
+    service with a minimum 60-second delay. This configuration should aid with re-establishing the
+    instance under isolated failures with the binary.
+2.  A validator instance can demonstrate un-lively behaviour if it cannot sync new blocks. This may
+    result from insufficient disk space or a corrupt database.
+3.  Monitoring should be implemented that allows node operators to monitor connectivity network
+    connectivity to the peer-to-peer port of the validator instance. Monitoring should also be
+    implemented to ensure that there is <50 Block ‘drift’ between the target and best blocks. If
+    either event produces a failure, the node operator should be notified. The following are
+    recommendations to validators to avoid liveliness for new servers / migrated servers:
 4.  Ensure that the `--validator` flag is used when starting the validator instance
 5.  If switching keys, ensure that the correct session keys are applied
-6.  If migrating using a two-server approach, ensure that you don’t switch off the original server too soon.
-7.  Ensure that the database on the new server is fully synchronized
-It is highly recommended to avoid hosting on providers that other validators may also utilize.  If the provider fails, there is a probability that one or more other validators would also fail due to liveliness building to a slash.  
-There is a precedent that a slash may be forgiven if a single validator faces an offline event when a larger operator also faces multiple offline events, resulting in a slash.
+6.  If migrating using a two-server approach, ensure that you don’t switch off the original server
+    too soon.
+7.  Ensure that the database on the new server is fully synchronized It is highly recommended to
+    avoid hosting on providers that other validators may also utilize. If the provider fails, there
+    is a probability that one or more other validators would also fail due to liveliness building to
+    a slash.  
+    There is a precedent that a slash may be forgiven if a single validator faces an offline event
+    when a larger operator also faces multiple offline events, resulting in a slash.
 
-## Equivocation 
-Equivocation events can occur when a validator produces two or more of the same block; under this condition, it is referred to as a BABE equivocation.  Equivocation may also happen when a validator signs two or more of the same consensus vote; under this condition, it is referred to as a GRANDPA Equivocation.
-Equivocations usually occur when duplicate signing keys reside on the validator host. If keys are never duplicated, the probability of an equivocation slash decreases to near 0.
-Check the  Wiki section on [Equivocation](../learn/learn-staking-advanced.md#equivocation) to learn more about its specifics. 
+## Equivocation
+
+Equivocation events can occur when a validator produces two or more of the same block; under this
+condition, it is referred to as a BABE equivocation. Equivocation may also happen when a validator
+signs two or more of the same consensus vote; under this condition, it is referred to as a GRANDPA
+Equivocation. Equivocations usually occur when duplicate signing keys reside on the validator host.
+If keys are never duplicated, the probability of an equivocation slash decreases to near 0. Check
+the Wiki section on [Equivocation](../learn/learn-staking-advanced.md#equivocation) to learn more
+about its specifics.
 
 The following are scenarios that build towards slashes under equivocation:
-1.  Cloning a server, i.e., copying all contents when migrating to new hardware.  This action should be avoided.  If an image is desired, it should be taken before keys are generated.
-2.  High Availability (HA) Systems – Equivocation can occur if there are any concurrent operations, either when a failed server restarts or if false positive event results in both servers being online simultaneously.  HA systems are to be treated with extreme caution and are not advised.
+
+1.  Cloning a server, i.e., copying all contents when migrating to new hardware. This action should
+    be avoided. If an image is desired, it should be taken before keys are generated.
+2.  High Availability (HA) Systems – Equivocation can occur if there are any concurrent operations,
+    either when a failed server restarts or if false positive event results in both servers being
+    online simultaneously. HA systems are to be treated with extreme caution and are not advised.
 3.  The keystore folder is copied when attempting to copy a database from one instance to another.  
-It is important to note that equivocation slashes occur with a single incident.  This can happen if duplicated keystores are used for only a few seconds.  A slash can result in losing nominators, and funds, removal from the Thousand Validator Programme, and reputational damage.  An offline event results in losing some funds but the retention of nominators and a fault under the Thousand Validator Programme.  
+    It is important to note that equivocation slashes occur with a single incident. This can happen
+    if duplicated keystores are used for only a few seconds. A slash can result in losing
+    nominators, and funds, removal from the Thousand Validator Programme, and reputational damage.
+    An offline event results in losing some funds but the retention of nominators and a fault under
+    the Thousand Validator Programme.
 
 ## Application Related
-In the past, there have been releases with bugs that lead to slashes; these issues are not as prevalent in current releases.  The following are advised to node operators to ensure that they obtain pristine binaries or source code and to ensure the security of their node:
+
+In the past, there have been releases with bugs that lead to slashes; these issues are not as
+prevalent in current releases. The following are advised to node operators to ensure that they
+obtain pristine binaries or source code and to ensure the security of their node:
+
 1.  Always download either source files or binaries from the official Parity repository
 2.  Verify the hash of downloaded files.
 3.  Use the W3F secure validator setup or adhere to its principles
-4.  Ensure essential security items are checked, use a firewall, manage user access, use SSH certificates
-5. Avoid using your server as a general-purpose system.  Hosting a validator on your workstation or one that hosts other services increases the risk of maleficence.
+4.  Ensure essential security items are checked, use a firewall, manage user access, use SSH
+    certificates
+5.  Avoid using your server as a general-purpose system. Hosting a validator on your workstation or
+    one that hosts other services increases the risk of maleficence.
 
 ## Examples
-|Network|Era|Event Type|Details|Action Taken|
-|-------|---|----------|-------|------------|
-|Polkadot|774|Small Equivocation|[The validator](https://matrix.to/#/!NZrbtteFeqYKCUGQtr:matrix.parity.io/$165562246360408hKCfC:matrix.org?via=matrix.parity.io&via=corepaper.org&via=matrix.org) migrated servers and cloned the keystore folder.  The on-chain event can be viewed [here](https://polkadot.subscan.io/extrinsic/11190109-0?event=11190109-5)|The validator did not submit a request for the slash to be canceled.|
-|Kusama|3329|Small Equivocation|The validator operated a test machine with cloned keys; the test machine was online at the same time as the primary, which resulted in a slash.  Details can be found [here](https://kusama.polkassembly.io/post/1343)|The validator requested a cancellation of the slash, but the council declined.|
-|Kusama|3995|Small Equivocation|The validator noticed several errors, after which the client crashed, and a slash was applied.  The validator recorded all events and opened GitHub issues to allow for technical opinions to be shared.  Details can be found [here](https://kusama.polkassembly.io/post/1733).|The validator requested to cancel the slash.  The council approved the request as they believed the error was not operator related.| 
 
+| Network  | Era  | Event Type         | Details                                                                                                                                                                                                                                                                                                                      | Action Taken                                                                                                                       |
+| -------- | ---- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Polkadot | 774  | Small Equivocation | [The validator](https://matrix.to/#/!NZrbtteFeqYKCUGQtr:matrix.parity.io/$165562246360408hKCfC:matrix.org?via=matrix.parity.io&via=corepaper.org&via=matrix.org) migrated servers and cloned the keystore folder. The on-chain event can be viewed [here](https://polkadot.subscan.io/extrinsic/11190109-0?event=11190109-5) | The validator did not submit a request for the slash to be canceled.                                                               |
+| Kusama   | 3329 | Small Equivocation | The validator operated a test machine with cloned keys; the test machine was online at the same time as the primary, which resulted in a slash. Details can be found [here](https://kusama.polkassembly.io/post/1343)                                                                                                        | The validator requested a cancellation of the slash, but the council declined.                                                     |
+| Kusama   | 3995 | Small Equivocation | The validator noticed several errors, after which the client crashed, and a slash was applied. The validator recorded all events and opened GitHub issues to allow for technical opinions to be shared. Details can be found [here](https://kusama.polkassembly.io/post/1733).                                               | The validator requested to cancel the slash. The council approved the request as they believed the error was not operator related. |

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -569,8 +569,8 @@ associates your validator node with your Controller account on Polkadot.
 
 #### Option 1: PolkadotJS-APPS
 
-You can generate your [Session keys](../learn/learn-cryptography.md) in the client via the apps
-RPC. If you are doing this, make sure that you have the PolkadotJS-Apps explorer attached to your
+You can generate your [Session keys](../learn/learn-cryptography.md) in the client via the apps RPC.
+If you are doing this, make sure that you have the PolkadotJS-Apps explorer attached to your
 validator node. You can configure the apps dashboard to connect to the endpoint of your validator in
 the Settings tab. If you are connected to a default endpoint hosted by Parity of Web3 Foundation,
 you will not be able to use this method since making RPC requests to this node would effect the

--- a/docs/maintain/maintain-guides-secure-validator.md
+++ b/docs/maintain/maintain-guides-secure-validator.md
@@ -37,10 +37,10 @@ forgiving than the equivocation or parachain validity slashing.
 
 ## Key Management
 
-See the [Polkadot Keys guide](../learn/learn-cryptography.md) for more information on keys. The keys that
-are of primary concern for validator infrastructure are the Session keys. These keys sign messages
-related to consensus and parachains. Although Session keys are _not_ account keys and therefore
-cannot transfer funds, an attacker could use them to commit slashable behavior.
+See the [Polkadot Keys guide](../learn/learn-cryptography.md) for more information on keys. The keys
+that are of primary concern for validator infrastructure are the Session keys. These keys sign
+messages related to consensus and parachains. Although Session keys are _not_ account keys and
+therefore cannot transfer funds, an attacker could use them to commit slashable behavior.
 
 Session keys are generated inside the node via RPC call. See the
 [How to Validate guide](maintain-guides-how-to-validate-polkadot.md#set-session-keys) for

--- a/docs/maintain/maintain-guides-validator-payout.md
+++ b/docs/maintain/maintain-guides-validator-payout.md
@@ -35,10 +35,11 @@ Era points create a probabilistic component for staking rewards.
 
 If the _mean_ of staking rewards is the average rewards per era, then the _variance_ is the
 variability from the average staking rewards. The exact DOT value of each era point is not known in
-advance since it depends on the total number of points earned by all validators in a given era. This 
-is designed this way so that the total payout per era depends on Polkadot's 
-[inflation model](../learn/learn-staking-advanced.md#inflation), and not on the number of payable actions 
-(f.e., authoring a new block) executed. For more information, check [this stackexchange post](https://substrate.stackexchange.com/questions/5353/how-are-rewards-in-dot-calculated-from-the-era-points-earned-by-validators-in-po).
+advance since it depends on the total number of points earned by all validators in a given era. This
+is designed this way so that the total payout per era depends on Polkadot's
+[inflation model](../learn/learn-staking-advanced.md#inflation), and not on the number of payable
+actions (f.e., authoring a new block) executed. For more information, check
+[this stackexchange post](https://substrate.stackexchange.com/questions/5353/how-are-rewards-in-dot-calculated-from-the-era-points-earned-by-validators-in-po).
 
 With parachains now on Polkadot, a large percentage of era points will come from parachain
 validation, as a subset of validators are selected to para-validate for all parachains each epoch,

--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -8,6 +8,7 @@ slug: ../maintain-sync
 ---
 
 import Tabs from "@theme/Tabs";
+
 import TabItem from "@theme/TabItem";
 
 If you're building dapps or products on a Substrate-based chain like Polkadot, Kusama or a custom
@@ -28,11 +29,11 @@ pending changes on top of it, and emits the events that are the result of these 
 state of the chain at block 1 is used in the same way to build the state of the chain at block 2,
 and so on. Once two thirds of the validators agree on a specific block being valid, it is finalized.
 
-An **archive node** keeps all the past blocks and their states. An archive node makes it convenient to query the past
-state of the chain at any point in time. Finding out what an account's balance at a certain block
-was, or which extrinsics resulted in a certain state change are fast operations when using an
-archive node. However, an archive node takes up a lot of disk space - around Kusama's 12 millionth
-block this was around 660 GB.
+An **archive node** keeps all the past blocks and their states. An archive node makes it convenient
+to query the past state of the chain at any point in time. Finding out what an account's balance at
+a certain block was, or which extrinsics resulted in a certain state change are fast operations when
+using an archive node. However, an archive node takes up a lot of disk space - around Kusama's 12
+millionth block this was around 660 GB.
 
 :::tip
 
@@ -45,15 +46,16 @@ Archive nodes are used by utilities that need past information - like block expl
 scanners, discussion platforms like [Polkassembly](https://polkassembly.io), and others. They need
 to be able to look at past on-chain data.
 
-A **full node** prunes historical states: all finalized blocks' states older than a configurable number
-except the genesis block's state. This is 256 blocks from the last finalized one, by default. A node that is
-pruned this way requires much less space than an archive node.
+A **full node** prunes historical states: all finalized blocks' states older than a configurable
+number except the genesis block's state. This is 256 blocks from the last finalized one, by default.
+A node that is pruned this way requires much less space than an archive node.
 
-A full node may eventually be able to rebuild every block's state with no additional information, and
-become an archive node, but at the time of writing, this is not implemented. If you need to query
-historical blocks' states past what you pruned, you need to purge your database and resync your node
-starting in archive mode. Alternatively you can use a backup or snapshot of a trusted source to
-avoid needing to sync from genesis with the network, and only need the states of blocks past that snapshot.
+A full node may eventually be able to rebuild every block's state with no additional information,
+and become an archive node, but at the time of writing, this is not implemented. If you need to
+query historical blocks' states past what you pruned, you need to purge your database and resync
+your node starting in archive mode. Alternatively you can use a backup or snapshot of a trusted
+source to avoid needing to sync from genesis with the network, and only need the states of blocks
+past that snapshot.
 
 Full nodes allow you to read the current state of the chain and to submit and validate extrinsics
 directly on the network without relying on a centralized infrastructure provider.
@@ -99,15 +101,12 @@ example:
 
 :::
 
-<Tabs
-  groupId="operating-systems"
-  values={[
-    {label: 'macOS', value: 'mac'},
-    {label: 'Windows', value: 'win'},
-    {label: 'Linux (standalone)', value: 'linux-standalone'},
-    {label: 'Linux (package)', value: 'linux-package'},
-  ]}
+<Tabs groupId="operating-systems" values={[ {label: 'macOS', value: 'mac'}, {label: 'Windows',
+value: 'win'}, {label: 'Linux (standalone)', value: 'linux-standalone'}, {label: 'Linux (package)',
+value: 'linux-package'}, ]}
+
 >
+
 <TabItem value="mac">
 
 - Install Homebrew within the terminal by running:
@@ -202,18 +201,17 @@ example:
 
 You can also install Polkadot from one of our package repositories.
 
-Installation from the Debian or rpm repositories will create a `systemd`
-service that can be used to run a Polkadot node. The service is disabled by default,
-and can be started by running `systemctl start polkadot` on demand (use
-`systemctl enable polkadot` to make it auto-start after reboot). By default, it
-will run as the `polkadot` user.  Command-line flags passed to the binary can
-be customized by editing `/etc/default/polkadot`. This file will not be
-overwritten on updating polkadot.
-  
+Installation from the Debian or rpm repositories will create a `systemd` service that can be used to
+run a Polkadot node. The service is disabled by default, and can be started by running
+`systemctl start polkadot` on demand (use `systemctl enable polkadot` to make it auto-start after
+reboot). By default, it will run as the `polkadot` user. Command-line flags passed to the binary can
+be customized by editing `/etc/default/polkadot`. This file will not be overwritten on updating
+polkadot.
+
 ### Debian-based (Debian, Ubuntu)
 
-Currently supports Debian 10 (Buster) and Ubuntu 20.04 (Focal), and
-derivatives. Run the following commands as the `root` user.
+Currently supports Debian 10 (Buster) and Ubuntu 20.04 (Focal), and derivatives. Run the following
+commands as the `root` user.
 
 ```bash
 # Import the security@parity.io GPG key
@@ -229,8 +227,9 @@ apt install parity-keyring
 apt install polkadot
 
 ```
-If you don't want polkadot package to be automatically updated when you update packages on your server,
-you can issue the following command:
+
+If you don't want polkadot package to be automatically updated when you update packages on your
+server, you can issue the following command:
 
 ```bash
 sudo apt-mark hold polkadot
@@ -250,7 +249,7 @@ dnf config-manager --set-enabled polkadot
 # should have the following fingerprint: 9D4B2B6EB8F97156D19669A9FF0812D491B96798)
 dnf install polkadot
 ```
-  
+
 :::info
 
 If you choose to use a custom folder for the polkadot home by passing `--base-path '/custom-path'`,
@@ -259,19 +258,22 @@ you will need to issue following command:
 ```bash
 sudo mkdir /etc/systemd/system/polkadot.service.d
 ```
+
 And create a new file inside this folder:
-  
+
 ```bash
 sudo -e /etc/systemd/system/polkadot.service.d/custom.conf
 ```
+
 With the following content:
 
 ```
 [Service]
 ReadWritePaths=/custom-path
 ```
+
 And finally issue a reload to have your modifications applied by systemd:
-  
+
 ```bash
 systemctl daemon-reload
 ```

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "docusaurus": "docusaurus",
     "prepare": "husky install",
     "update:auctions": "node ./components/utilities/updateAuctions.js",
-    "audit:links": "python ./scripts/auditLinks.py"
+    "audit:links": "python ./scripts/auditLinks.py",
+    "prettier:all": "npx prettier --write ."
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
Addresses part of https://github.com/w3f/polkadot-wiki/issues/4095.

This PR adds a new GitHub workflow that will run prettier on the entire repo on a regular schedule.  Although we added a pre-commit hook, it is still easy to introduce un-formatted content through the GitHub file editor or committing inline suggestions.  

Sometimes when creating a new PR, prettier format content you personally have not edited (possibly from the sources listed above) will appear in the comparison diff. The automation routine should help maintain the formatting without letting too much time pass between cleanups.  This will help reduce this occurrence. 

I set the interval to weekly to begin so I can monitor that it is working correctly but we can likely reduce this to once a month if it because tedious with small changes appearing too frequently.