### PR TITLE
Handle stale branches in automation pipeline

### DIFF
--- a/.github/workflows/audit-links.yml
+++ b/.github/workflows/audit-links.yml
@@ -15,11 +15,23 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      
-      - name: Pull repo
+
+      - name: Set credentials
         run: |
           git config --global user.email "polkadot-kusama-automation-bot@users.noreply.github.com"
           git config --global user.name "Polkadot-Kusama Bot"
+
+      - name: Check for existing branch
+        run: |
+          if [[ git ls-remote --heads https://github.com/w3f/polkadot-wiki.git audit-links | wc -l === 2]]; then
+            echo deleting existing branch
+            git branch -d audit-links
+          else
+            echo no existing branch found
+          fi
+      
+      - name: Create new branch
+        run: |
           git branch audit-links
           git checkout audit-links
       

--- a/.github/workflows/prettier-all.yml
+++ b/.github/workflows/prettier-all.yml
@@ -14,14 +14,24 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: project setup
+      - name: Set credentials
         run: |
           git config --global user.email "polkadot-kusama-automation-bot@users.noreply.github.com"
           git config --global user.name "Polkadot-Kusama Bot"
+      - name: Check for existing branch
+        run: |
+          if [[ git ls-remote --heads https://github.com/w3f/polkadot-wiki.git prettier-update | wc -l === 2]]; then
+            echo deleting existing branch
+            git branch -d prettier-update
+          else
+            echo no existing branch found
+          fi
+      - name: Project setup
+        run: |
           git branch prettier-update
           git checkout prettier-update
           yarn && yarn prettier:all
-      - name: commit any changes from prettier execution and make new PR
+      - name: Commit any changes from prettier execution and make new PR
         run: |
           if [[ `git status --porcelain` ]]; then
             git commit -a -m 'applying prettier to entire repo'

--- a/.github/workflows/update-auction-schedules.yml
+++ b/.github/workflows/update-auction-schedules.yml
@@ -14,10 +14,20 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Update cache
+      - name: Set credentials
         run: |
           git config --global user.email "polkadot-kusama-automation-bot@users.noreply.github.com"
           git config --global user.name "Polkadot-Kusama Bot"
+      - name: Check for existing branch
+        run: |
+          if [[ git ls-remote --heads https://github.com/w3f/polkadot-wiki.git auction-schedule-update | wc -l === 2]]; then
+            echo deleting existing branch
+            git branch -d auction-schedule-update
+          else
+            echo no existing branch found
+          fi
+      - name: Update cache
+        run: |
           git branch auction-schedule-update
           git checkout auction-schedule-update
           yarn && yarn update:auctions


### PR DESCRIPTION
I noticed sometimes when an automation PR isn't merged and the branch remains live and gets stale, it can cause future automation PR's to that same branch name to fail.  I added a step to check if the branch exists prior to making any changes.  If it exists we will replace the branch with the new data.