### PR TITLE
Restore Kusama auction status

### DIFF
--- a/components/Auction-Schedule.jsx
+++ b/components/Auction-Schedule.jsx
@@ -108,6 +108,10 @@ function GetCurrentOrNextAuction(chain, auctions, currentBlock) {
 	let index = 0;
 	let status = "";
 	for (let i = 0; i < auctions.length; i++) {
+		// Temporary patch until Kusama auctions are restored
+		if (chain === "Kusama") {
+			return [61, "No Kusama auctions are currently scheduled or in-progress."]
+		}
 		if (currentBlock === null) {
 			status = "Current block is still loading...";
 			return [index, status];

--- a/components/utilities/updateAuctions.js
+++ b/components/utilities/updateAuctions.js
@@ -33,10 +33,6 @@ LoadAPI(PolkadotParameters).then(() => {
   // Update Polkadot cache
   console.log(`Updating ${PolkadotParameters.chain} cache.`);
   Update(PolkadotParameters).then(() => {
-    console.log(`Updating auctions cache complete.`);
-    // Disabling Kusama updating for now due to https://github.com/paritytech/substrate/pull/11649
-    // Kusama auctions from #63 on have not been dispatched
-    /*
     // Load Kusama API
     LoadAPI(KusamaParameters).then(() => {
       // Update Kusama cache
@@ -45,7 +41,6 @@ LoadAPI(PolkadotParameters).then(() => {
         console.log(`Updating auctions cache complete.`);
       })
     });
-    */
   });
 });
 
@@ -97,12 +92,12 @@ async function Update(params) {
           // Once both async processes have completed terminate the script
           if (err) {
             console.log(err);
-            if(params.chain === "Polkadot") {
+            if(params.chain === "Kusama") {
               process.exit(1);
             }
           } else {
             console.log(`Updating of ${params.chain} cache complete.`);
-            if(params.chain === "Polkadot") {
+            if(params.chain === "Kusama") {
               process.exit(0);
             }
           }


### PR DESCRIPTION
Since new Kusama auctions are not currently on-going the status that displays which auction is in-progress or upcoming was throwing an error.  I added a new condition that handles the current state and still allows browsing of previous auctions.  This can be removed when Kusama auctions resume.

From:
![image](https://user-images.githubusercontent.com/13341935/209713196-42e82927-0f20-4f8b-83f5-467a56861007.png)


To:
![image](https://user-images.githubusercontent.com/13341935/209713144-86ffb990-1e4e-42a8-9359-f13e29724cdd.png)
