### PR TITLE
Update Crowdloan documentation

### DIFF
--- a/docs/learn/learn-crowdloans.md
+++ b/docs/learn/learn-crowdloans.md
@@ -34,8 +34,9 @@ please see the [Rococo content](../build/build-parachains.md##testing-a-parachai
 Anyone who has registered a parachain can create a new crowdloan campaign for a slot by depositing a
 specified number of tokens. A campaign is configured as a range of slots (i.e. the duration of the
 [parachain](learn-parachains.md) will bid for), a cap, and a duration. The duration can last over
-several auctions, meaning that the team will not need to restart the campaign just because they do
-not secure a slot on their first attempt.
+several auctions as long as the range of slots matches those of the auction (i.e. the first lease period 
+of the crowdloan is the same or bigger than that of the auction). This means that a team will not need to 
+restart the campaign just because they do not secure a slot on their first attempt.
 
 :::info Crowdloan Submission Deposit Required
 


### PR DESCRIPTION
After several discussions with teams, it's not yet clear that a crowdloan can bid on subsequent auctions if and only if the first Lease Period of the crowdloan is the same or bigger than the first Lease Period of the auction.