### PR TITLE
Wrong RPC path

### DIFF
--- a/docs/maintain/maintain-guides-validator-payout.md
+++ b/docs/maintain/maintain-guides-validator-payout.md
@@ -196,8 +196,8 @@ validator, then you will lose 1 DOT in each case.
 :::caution
 
 If a validator is oversubscribed in an era, staking rewards are distributed only to the the top
-{{ polkadot: <RPC network="polkadot" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={0}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={0}/> :kusama }}
 nominators and the rest of the nominators do not receive any rewards. This is not the case for
 slashing! Every active nominator of the validator committing slashable offence will be slashed.
 

--- a/docs/maintain/maintain-guides-validator-payout.md
+++ b/docs/maintain/maintain-guides-validator-payout.md
@@ -196,8 +196,8 @@ validator, then you will lose 1 DOT in each case.
 :::caution
 
 If a validator is oversubscribed in an era, staking rewards are distributed only to the the top
-{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={0}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={0}/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={256}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.staking.maxNominatorRewardedPerValidator" defaultValue={512}/> :kusama }}
 nominators and the rest of the nominators do not receive any rewards. This is not the case for
 slashing! Every active nominator of the validator committing slashable offence will be slashed.
 


### PR DESCRIPTION
I think the path should be "consts.staking.maxNominatorRewardedPerValidator" not query. Kusama is currently 512 but because of the wrong path the wiki shows the wrong default of 256. Would default "0" not be better so errors show up quicker?