### PR TITLE
Wallets page cleanup

### DIFF
--- a/docs/build/build-wallets.md
+++ b/docs/build/build-wallets.md
@@ -22,19 +22,6 @@ Exchanges), another party controls your private keys.
 
 :::
 
-### Supported Wallets
-
-[Polkadot support](https://support.polkadot.network/) can provide assistance with issues related to
-Polkadot-JS UI, the Polkadot-JS extension, or Parity Signer. For other wallet software, you should
-contact the developers of that wallet.
-
-| Wallet Name                                                         | Development State | Team Name | Description                                                                                                                                                     |
-| ------------------------------------------------------------------- | ----------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Parity Signer](https://www.parity.io/signer/)                      | Live              | Parity    | iOS and Android app used with [Companion](https://parity.link/signer-companion) or [Polkadot-JS Extension](https://github.com/polkadot-js/extension)            |
-| [Polkadot-JS Desktop](https://github.com/polkadot-js/apps/releases) | Live              | Parity    | Win, Mac, Linux                                                                                                                                                 |
-| [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts)           | Live              | Parity    | Browser based wallet used with [Polkadot-JS Extension](https://github.com/polkadot-js/extension)                                                                |
-| [Ledger](https://github.com/Zondax/ledger-polkadot)                 | Live              | Zondax    | Hardware wallet app used with [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) (and [Polkadot-JS Extension](https://github.com/polkadot-js/extension)) |
-
 ### Treasury Funded Wallets
 
 These are wallets which have been supported by either the Polkadot or Kusama Treasury via Treasury


### PR DESCRIPTION
remove duplicate content and prioritize showing treasury funded wallets ahead in the page