### PR TITLE
Add new definitions to glossary & replace Gov2 with OpenGov

### DIFF
--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -487,10 +487,9 @@ perform arbitrary, cross-chain communication under shared security.
 
 ## Polkadot Alliance
 
-Seven of Polkadot’s leading projects have joined forces to establish standards and ethics for
-open-source development in [referendum #94](https://polkadot.polkassembly.io/referendum/94). The
-Polkadot Alliance was founded by Acala, Astar, Interlay, Kilt, Moonbeam, Phala, and Subscan, seven
-of the top projects occupying Polkadot’s parachain slots. The on-chain collective aims to support
+The
+Polkadot Alliance is an [on-chain collective](#collectives) founded by Acala, Astar, Interlay, Kilt, Moonbeam, Phala, and Subscan, to establish standards and ethics for
+open-source development in [referendum #94](https://polkadot.polkassembly.io/referendum/94). It aims to support
 development standards and expose bad actors within the ecosystems of Polkadot.
 
 ## Host

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -136,7 +136,7 @@ transition proofs for the validators.
 The Polkadot Collectives parachain was added in
 [Referendum 81](https://polkadot.polkassembly.io/referendum/81) and exists only on Polkadot (i.e.,
 there is no Kusama equivalent). The Collectives chain hosts on-chain collectives that serve the
-Polkadot network, such as the [Fellowship](#fellowship) and [Polkadot Alliance]().
+Polkadot network, such as the [Fellowship](#fellowship) and [Polkadot Alliance](#polkadot-alliance).
 
 ## Commission
 
@@ -415,8 +415,8 @@ online, even if they haven't published a block this epoch. This is sometimes ref
 
 ## OpenGov
 
-Previously known as Governance v2 (Gov2) during early development, [OpenGov](../learn/learn-opengov) serves as the current
-governance protocol for Kusama and will eventually be deployed on Polkadot. 
+Previously known as Governance v2 (Gov2) during early development, [OpenGov](../learn/learn-opengov)
+serves as the current governance protocol for Kusama and will eventually be deployed on Polkadot.
 
 ## Origin
 
@@ -480,10 +480,10 @@ perform arbitrary, cross-chain communication under shared security.
 
 ## Polkadot Alliance
 
-The
-Polkadot Alliance is an [on-chain collective](#collectives) founded by Acala, Astar, Interlay, Kilt, Moonbeam, Phala, and Subscan, to establish standards and ethics for
-open-source development in [referendum #94](https://polkadot.polkassembly.io/referendum/94). It aims to support
-development standards and expose bad actors within the ecosystems of Polkadot.
+The Polkadot Alliance is an [on-chain collective](#collectives) founded by Acala, Astar, Interlay,
+Kilt, Moonbeam, Phala, and Subscan, to establish standards and ethics for open-source development in
+[referendum #94](https://polkadot.polkassembly.io/referendum/94). It aims to support development
+standards and expose bad actors within the ecosystems of Polkadot.
 
 ## Host
 
@@ -694,9 +694,9 @@ The process of replacing sensitive data with non-sensitive data.
 ## Tracks
 
 Each [Origin](#origin) is associated with a single referendum class and each class is associated
-with a [Track](../maintain/maintain-guides-opengov#origins-and-tracks). The Track outlines the lifecycle for the proposal and is independent from other
-class's tracks. Having independent tracks allows the network to tailor the dynamics of referenda
-based upon their implied privilege level.
+with a [Track](../maintain/maintain-guides-opengov#origins-and-tracks). The Track outlines the
+lifecycle for the proposal and is independent from other class's tracks. Having independent tracks
+allows the network to tailor the dynamics of referenda based upon their implied privilege level.
 
 ## Tranche
 

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -131,6 +131,13 @@ and upward messages.
 A node that maintains a parachain by collecting parachain transactions and producing state
 transition proofs for the validators.
 
+## Collectives
+
+The Polkadot Collectives parachain was added in
+[Referendum 81](https://polkadot.polkassembly.io/referendum/81) and exists only on Polkadot (i.e.,
+there is no Kusama equivalent). The Collectives chain hosts on-chain collectives that serve the
+Polkadot network, such as the [Fellowship](#fellowship) and [Polkadot Alliance]().
+
 ## Commission
 
 Validators and nominators get paid from block production on the network, where validators can set a
@@ -215,6 +222,15 @@ including the parameters required for that function to be executed. These state 
 from the outside world, i.e. they are not part of the system itself. Extrinsics can take two forms,
 "[inherents](#inherent)" and "[transactions](#transaction)". For more technical details see the
 [polkadot spec](https://spec.polkadot.network/#_extrinsics)
+
+## Fellowship
+
+A mostly self-governing expert body with a primary goal of representing humans who embody and
+contain the technical knowledge base of the Kusama and/or Polkadot networks and protocols. This is
+accomplished by associating a rank with members to categorize the degree to which the system expects
+their opinion to be well-informed, of a sound technical basis and in line with the interests of
+Polkadot and Kusama. Members can vote on any given Fellowship proposal and the aggregate opinion of
+the members (weighted by their rank) constitutes the Fellowship's considered opinion.
 
 ## Finality
 
@@ -401,6 +417,18 @@ This is a message that is broadcast by a validator to verify to the network that
 online, even if they haven't published a block this epoch. This is sometimes referred to as
 "ImOnline".
 
+## OpenGov
+
+Previously known as governance v2 during early development, OpenGov serves as the currently
+governance protocol for Kusama and eventually Polkadot. The primary goal of this mechanism is to
+ensure that the majority of the stake can always command the network and is built to evolve
+gracefully overtime at the ultimate behest of its assembled stakeholders. OpenGov is designed to
+make the repercussions of referenda better scoped and agile in order to dramatically increase the
+number of collective decisions the system is able to make. Anyone is able to start a referendum at
+anytime and they can do so as many times as they wish. OpenGov includes a Fellowship that replaces
+the Technical Committee from the original governance model, to help aid in technical decision making
+in a democratic manner.
+
 ## Origin
 
 The initiator of an extrinsic. A simple origin would be the account that is sending a token to
@@ -460,6 +488,14 @@ Store.
 
 A heterogeneous, multi-chain network allowing various blockchains of different characteristics to
 perform arbitrary, cross-chain communication under shared security.
+
+## Polkadot Alliance
+
+Seven of Polkadot’s leading projects have joined forces to establish standards and ethics for
+open-source development in [referendum #94](https://polkadot.polkassembly.io/referendum/94). The
+Polkadot Alliance was founded by Acala, Astar, Interlay, Kilt, Moonbeam, Phala, and Subscan, seven
+of the top projects occupying Polkadot’s parachain slots. The on-chain collective aims to support
+development standards and expose bad actors within the ecosystems of Polkadot.
 
 ## Host
 
@@ -667,6 +703,13 @@ Networks are often executed on a testnet before they are deployed to a [mainnet]
 
 The process of replacing sensitive data with non-sensitive data.
 
+## Tracks
+
+Each [Origin](#origin) is associated with a single referendum class and each class is associated
+with a Track. The Track outlines the lifecycle for the proposal and is independent from other
+class's tracks. Having independent tracks allows the network to tailor the dynamics of referenda
+based upon their implied privilege level.
+
 ## Tranche
 
 Validators use a subjective, tick-based system to determine when the approval process should start.
@@ -753,3 +796,9 @@ execution. Checkout this section of the Substrate docs covering
 ## Witness
 
 Cryptographic proof statements of data validity.
+
+## Whitelist Pallet
+
+Allows one [Origin ](#origin) to escalate the privilege level of another Origin for a certain
+operation. In terms of OpenGov, it allows the [Fellowship](#fellowship) to authorise a new origin
+(which we will call Whitelisted-Root) to be executed with Root-level privileges.

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -226,11 +226,7 @@ from the outside world, i.e. they are not part of the system itself. Extrinsics 
 ## Fellowship
 
 A mostly self-governing expert body with a primary goal of representing humans who embody and
-contain the technical knowledge base of the Kusama and/or Polkadot networks and protocols. This is
-accomplished by associating a rank with members to categorize the degree to which the system expects
-their opinion to be well-informed, of a sound technical basis and in line with the interests of
-Polkadot and Kusama. Members can vote on any given Fellowship proposal and the aggregate opinion of
-the members (weighted by their rank) constitutes the Fellowship's considered opinion.
+contain the technical knowledge base of the Kusama and/or Polkadot networks and protocols.
 
 ## Finality
 

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -415,15 +415,8 @@ online, even if they haven't published a block this epoch. This is sometimes ref
 
 ## OpenGov
 
-Previously known as governance v2 during early development, OpenGov serves as the currently
-governance protocol for Kusama and eventually Polkadot. The primary goal of this mechanism is to
-ensure that the majority of the stake can always command the network and is built to evolve
-gracefully overtime at the ultimate behest of its assembled stakeholders. OpenGov is designed to
-make the repercussions of referenda better scoped and agile in order to dramatically increase the
-number of collective decisions the system is able to make. Anyone is able to start a referendum at
-anytime and they can do so as many times as they wish. OpenGov includes a Fellowship that replaces
-the Technical Committee from the original governance model, to help aid in technical decision making
-in a democratic manner.
+Previously known as Governance v2 (Gov2) during early development, [OpenGov](../learn/learn-opengov) serves as the current
+governance protocol for Kusama and will eventually be deployed on Polkadot. 
 
 ## Origin
 

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -694,7 +694,7 @@ The process of replacing sensitive data with non-sensitive data.
 ## Tracks
 
 Each [Origin](#origin) is associated with a single referendum class and each class is associated
-with a Track. The Track outlines the lifecycle for the proposal and is independent from other
+with a [Track](../maintain/maintain-guides-opengov#origins-and-tracks). The Track outlines the lifecycle for the proposal and is independent from other
 class's tracks. Having independent tracks allows the network to tailor the dynamics of referenda
 based upon their implied privilege level.
 

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -16,11 +16,11 @@ mechanism that allows it to evolve gracefully overtime at the ultimate behest of
 stakeholders. The stated goal is to ensure that the majority of the stake can always command the
 network.
 
-:::info Gov2 is live on Kusama Network
+:::info OpenGov is live on Kusama Network
 
 Learn about the upcoming changes to the governance on
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} in this
-[Wiki doc on Gov2](learn-opengov.md).
+[Wiki doc on OpenGov](learn-opengov.md).
 
 :::
 

--- a/docs/learn/learn-opengov.md
+++ b/docs/learn/learn-opengov.md
@@ -4,7 +4,7 @@ title: OpenGov
 sidebar_label: OpenGov
 description: Learn about Polkadot’s next generation of decentralised governance.
 keywords: [governance, referenda, proposal, voting, endorse]
-slug: ../learn-gov2
+slug: ../learn-opengov
 ---
 
 import RPC from "./../../components/RPC-Connection";
@@ -38,7 +38,8 @@ systems and protocols must evolve as they mature to improve upon their shortcomi
 modern advancements. For example, in Governance v1 all referenda carry the same weight as only one
 referenda can be voted on at a time and the voting period can last multiple weeks. This results in
 the system favoring careful consideration of very few proposals, as opposed to broad consideration
-of many. With that being said, OpenGov (also referred to as Governance v2) is here!
+of many. With that being said, OpenGov (previously referred to as Governance v2 while in
+development) is here!
 
 OpenGov changes how the practical means of day-to-day decisions are made, making the repercussions
 of referenda better scoped and agile in order to dramatically increase the number of collective
@@ -52,9 +53,9 @@ The following content will begin by walking through many of the core principles 
 understand the roots of governance v1 to better understand the direction of the second iteration.
 These deltas and distinctions will be highlighted throughout the various sub-topics.
 
-This being said, it is important to remember that governance is a constantly evolving protocol at
-this stage in its lifecycle. As updates for Governance v2 are making their way to the networks,
-plans for Governance v2.5 are already in development.
+This being said, it is also important to remember that governance is a constantly evolving protocol
+at this stage in its lifecycle. As updates for OpenGov are making their way to the networks, plans
+for future updates are already in development.
 
 ## Premise
 
@@ -74,7 +75,7 @@ conviction , make the decision.
 
 To better understand how the council is formed, please read [this section](#council).
 
-There are several changes here with Governance v2. The way the new governance model reflects its
+There are several changes here with OpenGov. The way the new governance model reflects its
 decentralised character is by:
 
 1. Migrating all responsibilities of Council to token holders via democracy votes
@@ -211,16 +212,16 @@ emergency referendum occurring at the same time as a regular referendum (either 
 council-proposed) is the only time that multiple referenda will be able to be voted on
 simultaneously.
 
-Governance v2 shares the same
+OpenGov shares the same
 {{ polkadot: <RPC network="polkadot" path="consts.democracy.votingPeriod" defaultValue={403200} filter="blocksToDays" /> :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.democracy.votingPeriod" defaultValue={100800} filter="blocksToDays" /> :kusama }}
 day eligibility period when the proposal can get approved. If not approved by then end of this
 period, the proposal is automatically rejected.
 
-#### Voting on a referendum (governance v2)
+#### Voting on a referendum (OpenGov)
 
-In Governance v2, a proposal is approved if it meets the requirements for **approval** and
-**support**, removing the adaptive quorum biasing system.
+In OpenGov, a proposal is approved if it meets the requirements for **approval** and **support**,
+removing the adaptive quorum biasing system.
 
 **Approval** is defined as the share of approval vote-weight (after adjustment for conviction)
 against the total vote-weight (for both approval and rejection).
@@ -280,8 +281,7 @@ impacted by the locking period of the tokens.
 
 #### Adaptive Quorum Biasing
 
-Adaptive quorum biasing is longer used in Governance v2 and is replaced by the Approval/Support
-system.
+Adaptive quorum biasing is longer used in OpenGov and is replaced by the Approval/Support system.
 
 ## Council
 
@@ -301,13 +301,13 @@ three tasks of governance:
 2. Cancelling dangerous or malicious referenda
 3. Electing the Technical Committee
 
-In Governance v2, an alternate strategy was required to replace the Council in its previous duties
-as a body delegated by voters to compensate for the fact that many choose to not take part in
-day-to-day of governance. OpenGov builds on the **Vote Delegation** feature from v1 where a voter
-can choose to delegate their voting power to another voter in the system. It does so by improving a
-feature known as **Multirole Delegation**, where voters can specify a different delegate for every
-class of referendum in the system. So for example, a voter could delegate one entity for managing a
-less potent referenda class, choose a different delegate for a different class with more powerful
+In OpenGov, an alternate strategy was required to replace the Council in its previous duties as a
+body delegated by voters to compensate for the fact that many choose to not take part in day-to-day
+of governance. OpenGov builds on the **Vote Delegation** feature from v1 where a voter can choose to
+delegate their voting power to another voter in the system. It does so by improving a feature known
+as **Multirole Delegation**, where voters can specify a different delegate for every class of
+referendum in the system. So for example, a voter could delegate one entity for managing a less
+potent referenda class, choose a different delegate for a different class with more powerful
 consequences and still retain full voting power over any remaining classes.
 
 ### Canceling Referenda
@@ -323,10 +323,10 @@ the runtime that the proposal would institute.
 If the cancellation is controversial enough that the council cannot get a two-thirds majority, then
 it will be left to the stakeholders _en masse_ to determine the fate of the proposal.
 
-In Governance v2, there is a special operation called **Cancelation** for intervening with a
-proposal that is already being voted on. The operation will immediately reject an ongoing referendum
-regardless of its status. There is also a provision to ensure the deposit of the proposer is
-slashed, if the proposal is malicious or spam.
+In OpenGov, there is a special operation called **Cancelation** for intervening with a proposal that
+is already being voted on. The operation will immediately reject an ongoing referendum regardless of
+its status. There is also a provision to ensure the deposit of the proposer is slashed, if the
+proposal is malicious or spam.
 
 Cancelation itself is a governance operation which must be voted upon by the network in order to be
 executed. Cancelation comes with its own Origin and Track which has a low lead-time and
@@ -353,11 +353,11 @@ Fast-tracked referenda are the only type of referenda that can be active alongsi
 referendum. Thus, with fast-tracked referenda it is possible to have two active referendums at the
 same time. Voting on one does not prevent a user from voting on the other.
 
-In Governance v2, a new successor committee was introduced, known as the "Polkadot Fellowship", to
-replace the Technical Committee. It will serve both the Polkadot and Kusama networks. See additional
-details below.
+In OpenGov, a new successor committee was introduced, known as the "Polkadot Fellowship", to replace
+the Technical Committee. It will serve both the Polkadot and Kusama networks. See additional details
+below.
 
-## Polkadot Fellowship
+## Fellowship
 
 The Fellowship is a mostly self-governing expert body with a primary goal of representing humans who
 embody and contain the technical knowledge base of the Kusama and/or Polkadot networks and


### PR DESCRIPTION
This PR addresses the initial scope of #4258 adding the following definitions to the glossary doc:

- [x] OpenGov
- [x] Fellowship
- [x] Collectives
- [x] Whitelist Pallet
- [x] Polkadot Alliance
- [x] Tracks

and replaces the original `Gov2` phrasing with `OpenGov` in several locations.