### PR TITLE
Update smallest unit of ETH to use correct name

### DIFF
--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -17,7 +17,7 @@ Bitcoin or Ether is the native token of the Ethereum blockchain.
 The smallest unit for the account balance on Substrate based blockchains (Polkadot, Kusama, etc.) is
 Planck (a reference to [Planck Length](https://en.wikipedia.org/wiki/Planck_length), the smallest
 possible distance in the physical Universe). You can compare DOT's Planck to BTC's Satoshi or ETH's
-Gwei. Polkadot's native token DOT equals to 10<sup>10</sup> Planck and Kusama's native token KSM
+Wei. Polkadot's native token DOT equals to 10<sup>10</sup> Planck and Kusama's native token KSM
 equals to 10<sup>12</sup> Planck.
 
 ### Polkadot


### PR DESCRIPTION
ETH's smallest unit of measurement is Wei, not Gwei. 
1 wei == 1
1 gwei == 1e9
1 ether == 1e18

We should compare 1 Planck to 1 Wei, not 1 Gwei.