### PR TITLE
Add new component for displaying current fellowship members and ranks from on-chain data

### DIFF
--- a/components/Fellowship.jsx
+++ b/components/Fellowship.jsx
@@ -13,8 +13,8 @@ function Fellowship({ network, defaultValue }) {
     else { return (<div />) }
     // Set default value to render on component
     setReturnValue(
-      <div style={{ color: "#e6007a" }}>
-        {defaultValue}
+      <div style={{ color: "#e6007a", textAlign: "center" }}>
+        <b>{defaultValue}</b>
       </div>
     );
     // Calculate a more accurate approximation using on-chain data
@@ -65,7 +65,7 @@ async function GetFellows(network, wsUrl, setReturnValue) {
     const hash = member[0].toHuman();
     const rank = JSON.parse(member[1]).rank;
     tableData.push(
-      <tr key={ hash.toString() }>
+      <tr key={hash.toString()}>
         <td style={{ width: "100%", border: "none" }}>
           <a href={`${explorerUrl + hash}`}>
             {`${hash}`}
@@ -78,8 +78,9 @@ async function GetFellows(network, wsUrl, setReturnValue) {
 
   // Render Table
   setReturnValue(
-    <div>
-      Current { chain } Fellows:
+    <div style={{ textAlign: "center" }}>
+      <b>Current {chain} Fellows ({tableData.length}):</b>
+      <br /><br />
       <div style={{ margin: "auto", maxWidth: "650px", border: "1px solid #dadde1" }}>
         <table style={{ margin: 0 }}>
           {header}

--- a/components/Fellowship.jsx
+++ b/components/Fellowship.jsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from "react";
+import React from "react";
+import { ApiPromise, WsProvider } from "@polkadot/api";
+
+function Fellowship({ network, defaultValue }) {
+  const [returnValue, setReturnValue] = useState('');
+
+  useEffect(async () => {
+    // Set defaults based on network
+    let wsUrl = undefined;
+    if (network === "polkadot") { wsUrl = "wss://rpc.polkadot.io" }
+    else if (network === "kusama") { wsUrl = "wss://kusama-rpc.polkadot.io/" }
+    else { return (<div />) }
+    // Set default value to render on component
+    setReturnValue(
+      <div style={{ color: "#e6007a" }}>
+        {defaultValue}
+      </div>
+    );
+    // Calculate a more accurate approximation using on-chain data
+    await GetFellows(network, wsUrl, setReturnValue);
+  }, []);
+
+  return (returnValue);
+}
+
+async function GetFellows(network, wsUrl, setReturnValue) {
+  const wsProvider = new WsProvider(wsUrl);
+  const api = await ApiPromise.create({ provider: wsProvider })
+
+  let chain = "";
+  let explorerUrl = "";
+  if (network === "polkadot") {
+    chain = "Polkadot"
+    explorerUrl = "https://polkadot.subscan.io/account/";
+  } else if (network === "kusama") {
+    chain = "Kusama"
+    explorerUrl = "https://kusama.subscan.io/account/";
+  } else {
+    setReturnValue(<div></div>);
+    return;
+  }
+
+  // Get current fellows
+  const collectiveData = await api.query.fellowshipCollective.members.entries();
+
+  // Sort by rank
+  collectiveData.sort(function (a, b) {
+    return JSON.parse(b[1]).rank - JSON.parse(a[1]).rank;
+  })
+
+  const header = (
+    <thead>
+      <tr>
+        <th style={{ width: "100%" }}>Account</th>
+        <th style={{ width: "100%" }}>Rank</th>
+      </tr>
+    </thead>
+  )
+
+  let tableData = [];
+
+  // Decode and style accounts and ranks
+  collectiveData.forEach((member) => {
+    const hash = member[0].toHuman();
+    const rank = JSON.parse(member[1]).rank;
+    tableData.push(
+      <tr key={ hash.toString() }>
+        <td style={{ width: "100%", border: "none" }}>
+          <a href={`${explorerUrl + hash}`}>
+            {`${hash}`}
+          </a>
+        </td>
+        <td style={{ width: "100%", border: "none" }}>{`${rank}`}</td>
+      </tr>
+    )
+  });
+
+  // Render Table
+  setReturnValue(
+    <div>
+      Current { chain } Fellows:
+      <div style={{ margin: "auto", maxWidth: "650px", border: "1px solid #dadde1" }}>
+        <table style={{ margin: 0 }}>
+          {header}
+        </table>
+        <table style={{ width: "100%", overflow: "auto", height: "300px" }}>
+          <tbody style={{ width: "100%", textAlign: "center" }}>
+            {tableData}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Fellowship;

--- a/components/Fellowship.jsx
+++ b/components/Fellowship.jsx
@@ -84,7 +84,7 @@ async function GetFellows(network, wsUrl, setReturnValue) {
         <table style={{ margin: 0 }}>
           {header}
         </table>
-        <table style={{ width: "100%", overflow: "auto", height: "300px" }}>
+        <table style={{ margin: 0, width: "100%", overflow: "auto", height: "300px" }}>
           <tbody style={{ width: "100%", textAlign: "center" }}>
             {tableData}
           </tbody>

--- a/docs/learn/learn-opengov.md
+++ b/docs/learn/learn-opengov.md
@@ -11,6 +11,8 @@ import RPC from "./../../components/RPC-Connection";
 
 import VLTable from "./../../components/Voluntary-Locking";
 
+import Fellowship from "./../../components/Fellowship";
+
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses a sophisticated governance
 mechanism that allows it to evolve gracefully overtime at the ultimate behest of its assembled
 stakeholders. The stated goal is to ensure that the majority of the stake can always command the
@@ -370,11 +372,12 @@ work well with even tens of thousands of members) and with far lower barrier to 
 of administrative process flow and expectations of expertise). Becoming a candidate member in the
 Fellowship is as easy as placing a small deposit.
 
-Members of the Fellowship can vote on any given Fellowship proposal and the aggregate opinion of the
-members (weighted by their rank) constitutes the Fellowship's considered opinion.
-
 The mechanism by which the Fellowship votes is the same as what is used for Polkadot and Kusama
-stakeholder voting for a proposed referendum.
+stakeholder voting for a proposed referendum. Members of the Fellowship can vote on any given
+Fellowship proposal and the aggregate opinion of the members (weighted by their rank) constitutes
+the Fellowship's considered opinion.
+
+{{ kusama: <Fellowship network="kusama" defaultValue="Loading Kusama Fellows..."/> :kusama }}
 
 ### Ranking System
 


### PR DESCRIPTION
Account addresses are sorted by rank and link to [subscan.io/account](https://kusama.subscan.io/account/) for the provided account.  The table is currently only rendered for Kusama docs but it will also work for Polkadot when OpenGov is activated by simply swapping the `network` parameter value on the `<Fellowship />` component, such as `network="polkadot"`.

![image](https://user-images.githubusercontent.com/13341935/212425386-c6e636d5-2093-408a-99c4-d2e8d293c2e4.png)