### PR TITLE
Update `BlockHashCount` in Transaction Mortality section

### DIFF
--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -203,8 +203,8 @@ valid. If the extrinsic is not included in a block within this validity window, 
 from the transaction queue.
 
 The chain only stores a limited number of prior block hashes as reference. You can query this
-parameter, called `BlockHashCount`, from the chain state or metadata. This parameter is set to 2400
-blocks (about four hours) at genesis. If the validity period is larger than the number of blocks
+parameter, called `BlockHashCount`, from the chain state or metadata. This parameter is set to 4096
+blocks (about seven hours) at genesis. If the validity period is larger than the number of blocks
 stored on-chain, then the transaction will only be valid as long as there is a block to check it
 against, i.e. the minimum value of validity period and block hash count.
 

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -203,7 +203,7 @@ valid. If the extrinsic is not included in a block within this validity window, 
 from the transaction queue.
 
 The chain only stores a limited number of prior block hashes as reference. You can query this
-parameter, called `BlockHashCount`, from the chain state or metadata. This parameter is set to 4096
+parameter, called `BlockHashCount`, from the chain state or metadata. This parameter is set to {{ polkadot: <RPC network="polkadot" path="consts.system.blockHashCount" defaultValue={4096}/> :polkadot }}
 blocks (about seven hours) at genesis. If the validity period is larger than the number of blocks
 stored on-chain, then the transaction will only be valid as long as there is a block to check it
 against, i.e. the minimum value of validity period and block hash count.


### PR DESCRIPTION
### Description
In the [Transaction Mortality](https://wiki.polkadot.network/docs/build-protocol-info#transaction-mortality) section of the wiki it is mentioned that `BlockHashCount` is set to `2400` blocks. 

However at [line 81](https://github.com/paritytech/polkadot/blob/master/runtime/common/src/lib.rs#L81) of the Polkadot repo it looks like it was increased to `4096`. The change happened in this [PR](https://github.com/paritytech/polkadot/pull/6037) from `2400` to `4096`.

Also changed the hours from `four` to `seven` by doing the following calculations (based on this [Polkadot Parameters](https://wiki.polkadot.network/docs/maintain-polkadot-parameters)) :
- 4096 * 6 (seconds) = 24.576
- 24.576 / 60 / 60 = 6.82 so approx 7h