### PR TITLE
Create new RPC tests for all active paths

### DIFF
--- a/docs/learn/learn-account-multisig.md
+++ b/docs/learn/learn-account-multisig.md
@@ -98,11 +98,11 @@ Deposit = depositBase + threshold * depositFactor
 Where `depositBase` and `depositFactor` are chain constants (in
 {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} units) set in the runtime code. Currently,
 the deposit base equals
-{{ polkadot: <RPC network="polkadot" path="query.multisig.depositBase" defaultValue={200880000000} filter="humanReadable"/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.multisig.depositBase" defaultValue={669599996400} filter="humanReadable"/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="consts.multisig.depositBase" defaultValue={200880000000} filter="humanReadable"/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.multisig.depositBase" defaultValue={669599996400} filter="humanReadable"/> :kusama }}
 and the deposit factor equals
-{{ polkadot: <RPC network="polkadot" path="query.multisig.depositFactor" defaultValue={320000000} filter="humanReadable"/>. :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.multisig.depositFactor" defaultValue={1066665600} filter="humanReadable"/>. :kusama }}
+{{ polkadot: <RPC network="polkadot" path="consts.multisig.depositFactor" defaultValue={320000000} filter="humanReadable"/>. :polkadot }}
+{{ kusama: <RPC network="kusama" path="consts.multisig.depositFactor" defaultValue={1066665600} filter="humanReadable"/>. :kusama }}
 
 ### Example using Multisig Accounts
 

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -18,8 +18,8 @@ check this
 [extensive article list](https://support.polkadot.network/support/solutions/articles/65000182104) to
 help you get started. You can now stake on
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} natively with just
-{{ polkadot: <RPC network="polkadot" path="query.nomiationPools.minJoinBond" filter="humanReadable" defaultValue={10000000000}/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.nomiationPools.minJoinBond" filter="humanReadable" defaultValue={1666666650}/> :kusama }}
+{{ polkadot: <RPC network="polkadot" path="query.nominationPools.minJoinBond" filter="humanReadable" defaultValue={10000000000}/> :polkadot }}
+{{ kusama: <RPC network="kusama" path="query.nominationPools.minJoinBond" filter="humanReadable" defaultValue={1666666650}/> :kusama }}
 and earn staking rewards. For additional information, check out
 [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/).
 

--- a/tests/rpc.test.js
+++ b/tests/rpc.test.js
@@ -31,6 +31,7 @@ test("Human readable filter with float value", async () => {
 
 // Test all active RPC paths in individual tests
 const paths = [
+	// Add new RPC paths here for testing coverage
 	{ path: 'consts.system.blockHashCount', network: 'kusama' },
 	{ path: 'consts.balances.existentialDeposit', network: 'kusama' },
 	{ path: 'query.staking.validatorCount', network: 'kusama' },

--- a/tests/rpc.test.js
+++ b/tests/rpc.test.js
@@ -53,6 +53,7 @@ const paths = [
 	{ path: 'consts.democracy.voteLockingPeriod', network: 'kusama' },
 	{ path: 'consts.treasury.spendPeriod', network: 'kusama' },
 	{ path: 'consts.electionProviderMultiPhase.maxElectingVoters', network: 'kusama' },
+	{ path: 'query.staking.chillThreshold', network: 'kusama' },
 	{ path: 'consts.assets.assetDeposit', network: 'statemint' },
 ]
 

--- a/tests/rpc.test.js
+++ b/tests/rpc.test.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, act, screen, waitFor } from "@testing-library/react";
+import { render, act, screen, waitFor, fail } from "@testing-library/react";
+import { ApiPromise, WsProvider } from "@polkadot/api";
 import "@testing-library/jest-dom";
 import RPC from "../components/RPC-Connection";
 
@@ -9,7 +10,7 @@ test("Retrieves and applies a 'const' RPC value", async () => {
 });
 
 test("Retrieves and applies a 'query' RPC value", async () => {
-	render(<RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={0} filter="humanReadable"/>);
+	render(<RPC network="polkadot" path="query.staking.minNominatorBond" defaultValue={0} filter="humanReadable" />);
 	await waitFor(() => expect(screen.getByText("100 DOT")).toBeInTheDocument(), { timeout: 5000 });
 });
 
@@ -28,102 +29,65 @@ test("Human readable filter with float value", async () => {
 	await waitFor(() => expect(screen.getByText("20.258 DOT")).toBeInTheDocument(), { timeout: 5000 });
 });
 
-/*
-// Set max test duration before failing (2 min)
-jest.setTimeout(120000);
+// Test all active RPC paths in individual tests
+const paths = [
+	'consts.system.blockHashCount',
+	'consts.balances.existentialDeposit',
+	'query.staking.validatorCount',
+	'consts.staking.maxNominatorRewardedPerValidator',
+	'consts.identity.basicDeposit',
+	'query.staking.currentEra',
+	'consts.phragmenElection.votingBondBase',
+	'query.staking.minNominatorBond',
+	'consts.staking.maxNominations',
+	'consts.democracy.votingPeriod',
+	'consts.crowdloan.minContribution',
+	'query.nominationPools.minJoinBond',
+	'consts.auctions.endingPeriod',
+	'consts.democracy.enactmentPeriod',
+	'consts.electionProviderMultiPhase.signedMaxSubmissions',
+	'query.multisig.depositBase',
+	'consts.proxy.maxProxies',
+	'query.nomiationPools.minJoinBond',
+	'consts.democracy.voteLockingPeriod',
+	'consts.assets.assetDeposit',
+	'consts.treasury.spendPeriod',
+	'consts.electionProviderMultiPhase.maxElectingVoters'
+]
 
-// This test takes about a minute to execute synchronously
-test("All leveraged RPC paths are valid", async () => {
-	const paths = [
-		// Polkadot & Kusama
-		{ networks: ["polkadot", "kusama"], path: "query.staking.validatorCount" },
-		{ networks: ["polkadot", "kusama"], path: "consts.staking.maxNominatorRewardedPerValidator" },
-		{ networks: ["polkadot", "kusama"], path: "consts.identity.basicDeposit" },
-		{ networks: ["polkadot", "kusama"], path: "consts.identity.subAccountDeposit" },
-		{ networks: ["polkadot", "kusama"], path: "consts.balances.existentialDeposit" },
-		{ networks: ["polkadot", "kusama"], path: "consts.identity.basicDeposit" },
-		{ networks: ["polkadot", "kusama"], path: "consts.crowdloan.minContribution" },
-		{ networks: ["polkadot", "kusama"], path: "consts.staking.maxNominations" },
-		{ networks: ["polkadot", "kusama"], path: "consts.democracy.voteLockingPeriod" },
-		{ networks: ["polkadot", "kusama"], path: "consts.identity.fieldDeposit" },
-		{ networks: ["polkadot", "kusama"], path: "consts.electionProviderMultiPhase.maxElectingVoters" },
-		{ networks: ["polkadot", "kusama"], path: "query.staking.maxNominatorsCount" },
-		{ networks: ["polkadot", "kusama"], path: "consts.proxy.proxyDepositBase" },
-		{ networks: ["polkadot", "kusama"], path: "consts.proxy.proxyDepositFactor" },
-		{ networks: ["polkadot", "kusama"], path: "query.staking.minNominatorBond" },
-		{ networks: ["polkadot", "kusama"], path: "query.staking.maxNominatorsCount" },
-		{ networks: ["polkadot", "kusama"], path: "consts.treasury.spendPeriod" },
-		{ networks: ["polkadot", "kusama"], path: "consts.treasury.proposalBondMinimum" },
-		{ networks: ["polkadot", "kusama"], path: "consts.treasury.proposalBondMaximum" },
-		{ networks: ["polkadot", "kusama"], path: "consts.tips.tipReportDepositBase" },
-		{ networks: ["polkadot", "kusama"], path: "consts.tips.tipFindersFee" },
-		// Statemine & Statemint
-		{ networks: ["statemine", "statemint"], path: "consts.assets.assetDeposit" },
-		{ networks: ["statemine", "statemint"], path: "consts.assets.metadataDepositBase" },
-	]
+for (let i = 0; i < paths.length; i++) {
+	test(`RPC Path Test: ${paths[i]}`, async () => {
+		let chainValue = undefined;
+		
+		try {
+			const wsUrl = "wss://kusama-rpc.polkadot.io/";
+			const wsProvider = new WsProvider(wsUrl);
+			let api = await ApiPromise.create({ provider: wsProvider });
 
-	let attemptedConnections = 0;
-	let successfulResponses = 0;
+			// Build API call
+			const pathParameters = paths[i].split(".");
+			pathParameters.forEach(param => {
+				api = api[param];
+			});
 
-	for (let i = 0; i < paths.length; i++) {
-		const testObject = paths[i];
-		for (let j = 0; j < testObject.networks.length; j++) {
-			attemptedConnections += 1;
-			let chainValue = undefined;
-			try {
-				const network = testObject.networks[j];
-				const path = testObject.path;
-				let wsUrl = undefined;
-
-				switch (network) {
-					case "polkadot":
-						wsUrl = "wss://rpc.polkadot.io";
-						break;
-					case "kusama":
-						wsUrl = "wss://kusama-rpc.polkadot.io/";
-						break;
-					case "statemine":
-						wsUrl = "wss://statemine-rpc.polkadot.io/";
-						break;
-					case "statemint":
-						wsUrl = "wss://statemint-rpc.polkadot.io/";
-						break;
-					default:
-						fail("Unknown socket url provided, no connection made.");
-
-				}
-
-				const wsProvider = new WsProvider(wsUrl);
-				let api = await ApiPromise.create({ provider: wsProvider });
-
-				// Build API call
-				const pathParameters = path.split(".");
-				pathParameters.forEach(param => {
-					api = api[param];
-				});
-
-				// Process constants and queries based on parameters prefix
-				switch (pathParameters[0]) {
-					case "consts":
-						chainValue = api.toString();
-						break;
-					case "query":
-						chainValue = await api();
-						chainValue = chainValue.toString();
-						break;
-					default:
-						fail(`Unknown path prefix (${pathParameters[0]}) in ${path}`);
-				}
-			} catch (error) {
-				console.log(error);
+			// Process constants and queries based on parameters prefix
+			switch (pathParameters[0]) {
+				case "consts":
+					chainValue = api.toString();
+					break;
+				case "query":
+					chainValue = await api();
+					chainValue = chainValue.toString();
+					break;
+				default:
+					fail(`Unknown path prefix (${pathParameters[0]}) in ${paths[i]}`);
 			}
-
-			// TODO - check chain value before marking successful response
-			if(chainValue !== undefined) { successfulResponses += 1; }
+		} catch (error) {
+			console.log(error);
 		}
-	}
 
-	// All RPC paths should return valid responses
-	expect(attemptedConnections === successfulResponses).toEqual(true);
-});
-*/
+		if (chainValue === undefined) {
+			fail(`Undefined value returned from ${paths[i]}`);
+		}
+	});
+}

--- a/tests/rpc.test.js
+++ b/tests/rpc.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, act, screen, waitFor, fail } from "@testing-library/react";
+import { render, screen, waitFor, fail } from "@testing-library/react";
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import "@testing-library/jest-dom";
 import RPC from "../components/RPC-Connection";
@@ -31,41 +31,58 @@ test("Human readable filter with float value", async () => {
 
 // Test all active RPC paths in individual tests
 const paths = [
-	'consts.system.blockHashCount',
-	'consts.balances.existentialDeposit',
-	'query.staking.validatorCount',
-	'consts.staking.maxNominatorRewardedPerValidator',
-	'consts.identity.basicDeposit',
-	'query.staking.currentEra',
-	'consts.phragmenElection.votingBondBase',
-	'query.staking.minNominatorBond',
-	'consts.staking.maxNominations',
-	'consts.democracy.votingPeriod',
-	'consts.crowdloan.minContribution',
-	'query.nominationPools.minJoinBond',
-	'consts.auctions.endingPeriod',
-	'consts.democracy.enactmentPeriod',
-	'consts.electionProviderMultiPhase.signedMaxSubmissions',
-	'query.multisig.depositBase',
-	'consts.proxy.maxProxies',
-	'query.nomiationPools.minJoinBond',
-	'consts.democracy.voteLockingPeriod',
-	'consts.assets.assetDeposit',
-	'consts.treasury.spendPeriod',
-	'consts.electionProviderMultiPhase.maxElectingVoters'
+	{ path: 'consts.system.blockHashCount', network: 'kusama' },
+	{ path: 'consts.balances.existentialDeposit', network: 'kusama' },
+	{ path: 'query.staking.validatorCount', network: 'kusama' },
+	{ path: 'consts.staking.maxNominatorRewardedPerValidator', network: 'kusama' },
+	{ path: 'consts.identity.basicDeposit', network: 'kusama' },
+	{ path: 'query.staking.currentEra', network: 'kusama' },
+	{ path: 'consts.phragmenElection.votingBondBase', network: 'kusama' },
+	{ path: 'query.staking.minNominatorBond', network: 'kusama' },
+	{ path: 'consts.staking.maxNominations', network: 'kusama' },
+	{ path: 'consts.democracy.votingPeriod', network: 'kusama' },
+	{ path: 'consts.crowdloan.minContribution', network: 'kusama' },
+	{ path: 'query.nominationPools.minJoinBond', network: 'kusama' },
+	{ path: 'consts.auctions.endingPeriod', network: 'kusama' },
+	{ path: 'consts.democracy.enactmentPeriod', network: 'kusama' },
+	{ path: 'consts.electionProviderMultiPhase.signedMaxSubmissions', network: 'kusama' },
+	{ path: 'consts.multisig.depositBase', network: 'kusama' },
+	{ path: 'consts.proxy.maxProxies', network: 'kusama' },
+	{ path: 'query.nominationPools.minJoinBond', network: 'kusama' },
+	{ path: 'consts.democracy.voteLockingPeriod', network: 'kusama' },
+	{ path: 'consts.treasury.spendPeriod', network: 'kusama' },
+	{ path: 'consts.electionProviderMultiPhase.maxElectingVoters', network: 'kusama' },
+	{ path: 'consts.assets.assetDeposit', network: 'statemint' },
 ]
 
 for (let i = 0; i < paths.length; i++) {
-	test(`RPC Path Test: ${paths[i]}`, async () => {
+	test(`RPC Path Test: ${paths[i].path}`, async () => {
 		let chainValue = undefined;
-		
+
 		try {
-			const wsUrl = "wss://kusama-rpc.polkadot.io/";
+			let wsUrl = undefined;
+			switch (paths[i].network) {
+				case "polkadot":
+					wsUrl = "wss://rpc.polkadot.io";
+					break;
+				case "kusama":
+					wsUrl = "wss://kusama-rpc.polkadot.io/";
+					break;
+				case "statemine":
+					wsUrl = "wss://statemine-rpc.polkadot.io/";
+					break;
+				case "statemint":
+					wsUrl = "wss://statemint-rpc.polkadot.io/";
+					break;
+				default:
+					fail("Unknown network provided, no connection made.");
+			}
+
 			const wsProvider = new WsProvider(wsUrl);
 			let api = await ApiPromise.create({ provider: wsProvider });
 
 			// Build API call
-			const pathParameters = paths[i].split(".");
+			const pathParameters = paths[i].path.split(".");
 			pathParameters.forEach(param => {
 				api = api[param];
 			});
@@ -80,14 +97,16 @@ for (let i = 0; i < paths.length; i++) {
 					chainValue = chainValue.toString();
 					break;
 				default:
-					fail(`Unknown path prefix (${pathParameters[0]}) in ${paths[i]}`);
+					fail(`Unknown path prefix (${pathParameters[0]}) in ${paths[i].path}`);
 			}
 		} catch (error) {
 			console.log(error);
 		}
 
+		console.log(`${paths[i].path} on-chain value: ${chainValue}`);
+
 		if (chainValue === undefined) {
-			fail(`Undefined value returned from ${paths[i]}`);
+			fail(`Undefined value returned from ${paths[i].path}`);
 		}
 	});
 }


### PR DESCRIPTION
### Description
Addresses #4322 

Initial run results:
```
✅ Retrieves and applies a 'const' RPC value (1170 ms)
✅ Retrieves and applies a 'query' RPC value (1063 ms)
✅ RPC falls back to default (15 ms)
✅ Human readable filter with integer value (9 ms)
✅ Human readable filter with float value (8 ms)
✅ RPC Path Test: consts.system.blockHashCount (2226 ms)
✅ RPC Path Test: consts.balances.existentialDeposit (1133 ms)
✅ RPC Path Test: query.staking.validatorCount (1332 ms)
✅ RPC Path Test: consts.staking.maxNominatorRewardedPerValidator (1127 ms)
✅ RPC Path Test: consts.identity.basicDeposit (1139 ms)
✅ RPC Path Test: query.staking.currentEra (1215 ms)
✅ RPC Path Test: consts.phragmenElection.votingBondBase (1125 ms)
✅ RPC Path Test: query.staking.minNominatorBond (1118 ms)
✅ RPC Path Test: consts.staking.maxNominations (1057 ms)
✅ RPC Path Test: consts.democracy.votingPeriod (1018 ms)
✅ RPC Path Test: consts.crowdloan.minContribution (1128 ms)
✅ RPC Path Test: query.nominationPools.minJoinBond (1195 ms)
✅ RPC Path Test: consts.auctions.endingPeriod (1149 ms)
✅ RPC Path Test: consts.democracy.enactmentPeriod (1126 ms)
✅ RPC Path Test: consts.electionProviderMultiPhase.signedMaxSubmissions (1173 ms)
❌ RPC Path Test: query.multisig.depositBase (1077 ms)
✅ RPC Path Test: consts.proxy.maxProxies (1131 ms)
❌ RPC Path Test: query.nomiationPools.minJoinBond (1107 ms)
✅ RPC Path Test: consts.democracy.voteLockingPeriod (1051 ms)
❌ RPC Path Test: consts.assets.assetDeposit (1022 ms)
✅ RPC Path Test: consts.treasury.spendPeriod (1099 ms)
✅ RPC Path Test: consts.electionProviderMultiPhase.maxElectingVoters (1033 ms)
```

I addressed the failing tests, so running the suite now yields:
```
Test Suites: 1 passed, 1 total
Tests:       27 passed, 27 total
Snapshots:   0 total
Time:        30.67 s, estimated 35 s
Ran all test suites.
Done in 31.65s.
```