### PR TITLE
Add new GitHub action for deploying docs to prod every 24 hrs

### DIFF
--- a/.github/workflows/update-prod.yml
+++ b/.github/workflows/update-prod.yml
@@ -1,0 +1,27 @@
+name: Update Polkadot & Kusama Prod
+on:
+  schedule:
+    - cron: '0 0 * * *' # At the end of every day (00:00)
+  workflow_dispatch: # Or manually from GitHub UI
+
+jobs:
+  update_prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set credentials
+        run: |
+          git config --global user.email "polkadot-kusama-automation-bot@users.noreply.github.com"
+          git config --global user.name "Polkadot-Kusama Bot"
+      - name: Rebase and deploy
+        run: |
+          git checkout --track origin/prod
+          git rebase master
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This job pulls the repo and runs the following three commands:

```
git checkout --track origin/prod
git rebase master
git push
```
This will rebase the `prod` branch w/ `master` and then trigger [deploy-polkadot-prod.yml](https://github.com/w3f/polkadot-wiki/blob/master/.github/workflows/deploy-polkadot-prod.yml) and [deploy-kusama-prod.yml](https://github.com/w3f/polkadot-wiki/blob/master/.github/workflows/deploy-kusama-prod.yml) after pushing, resulting in the updating of both the Polkadot and Kusama docs in production.