### PR TITLE
Make sure upstream master is available on prod deployment branch

### DIFF
--- a/.github/workflows/deploy-kusama-prod.yml
+++ b/.github/workflows/deploy-kusama-prod.yml
@@ -25,7 +25,7 @@ jobs:
           git config --global user.name "Polkadot Wiki CI"
           echo "machine github.com login w3fdeploy password ${{ secrets.ACCESS_KEY }}" > ~/.netrc
 
-          git branch
+          git checkout --track origin/prod
           git rebase master
           git push
           yarn && yarn kusama:build && GIT_USER=w3fdeploy PUBLISHING=true PROJECT_NAME=kusama-guide-hosting yarn run kusama:publish-gh-pages

--- a/.github/workflows/deploy-kusama-prod.yml
+++ b/.github/workflows/deploy-kusama-prod.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: prod
 
       - name: Publish
         run: |

--- a/.github/workflows/deploy-polkadot-prod.yml
+++ b/.github/workflows/deploy-polkadot-prod.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: prod
 
       - name: Publish
         run: |
@@ -25,7 +24,7 @@ jobs:
           git config --global user.name "Polkadot Wiki CI"
           echo "machine github.com login w3fdeploy password ${{ secrets.ACCESS_KEY }}" > ~/.netrc
 
-          git branch
+          git checkout --track origin/prod
           git rebase master
           git push
           yarn && yarn polkadot:build && GIT_USER=w3fdeploy PUBLISHING=true yarn run polkadot:publish-gh-pages


### PR DESCRIPTION
Related to https://github.com/w3f/polkadot-wiki/pull/4355, CI was failing with error `fatal: invalid upstream 'master'`