### PR TITLE
Staging Deployment - Manual run

### DIFF
--- a/.github/workflows/deploy-kusama-staging.yml
+++ b/.github/workflows/deploy-kusama-staging.yml
@@ -1,9 +1,6 @@
 name: Kusama Staging
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-polkadot-staging.yml
+++ b/.github/workflows/deploy-polkadot-staging.yml
@@ -1,9 +1,6 @@
 name: Polkadot Staging
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The original intent for Wiki staging is to ensure that the docusaurus features like redirects are verified by actually deploying to github pages and sharing the Wiki page previews to people who need to become more familiar with markdown syntax on PRs that are not yet merged to the master.

Currently. the Wiki staging build runs each time a change is pushed to the master branch. As the changes to the Wiki pages are verified locally by both PR authors and reviewers. the CI job for staging deployment is redundant (waste of resources).

I propose modifying the CI job trigger to just manual dispatch on whichever branch we would like to see on the staging website.