### PR TITLE
chore(build-oracle): adds Acurast

### DIFF
--- a/docs/build/build-oracle.md
+++ b/docs/build/build-oracle.md
@@ -33,7 +33,7 @@ your preferences. A Chainlink
 [Feed Pallet](https://github.com/smartcontractkit/chainlink-polkadot/blob/master/pallet-chainlink-feed/README.md)
 was recently released to allow smart contract applications across
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} to access price reference data, made
-available as a Substrate oracle pallet.
+available as a Substrate oracle pallet. [Acurast](https://acurast.com/) is another solution that enables developers to define their off-chain data and computation requirements and receive the outputs to the [Acurast Pallet](https://docs.acurast.com/integrations/substrate) and EVM or WASM environments.
 
 When using an oracle in your application you should be aware of the benefits and risks that are
 baked into its specific model. As the {{ polkadot: Polkadot :polkadot }}


### PR DESCRIPTION
Adds Acurast as a reference for oracles for the Polkadot/Kusama ecosystem through its Substrate Pallet integration.