### PR TITLE
Nano X not supported for development releases

### DIFF
--- a/docs/general/ledger.md
+++ b/docs/general/ledger.md
@@ -218,7 +218,7 @@ audit, you can install the developer release from the shell using the latest ver
 See [**this video tutorial**](https://youtu.be/4SyVQrlXZ_Q) to learn how to install the developer
 release of your ledger app.
 
-Unfortunately the developer release can't be installed on the Nano X, only on the Nano S and S plus.
+Currently, the developer release can be installed only on the Nano S and S plus devices and can't be installed on the Nano X.
 
 :::
 

--- a/docs/general/ledger.md
+++ b/docs/general/ledger.md
@@ -218,6 +218,8 @@ audit, you can install the developer release from the shell using the latest ver
 See [**this video tutorial**](https://youtu.be/4SyVQrlXZ_Q) to learn how to install the developer
 release of your ledger app.
 
+Unfortunately the developer release can't be installed on the Nano X, only on the Nano S and S plus.
+
 :::
 
 To install the developer version make sure you have the latest `pip` version and follow the steps


### PR DESCRIPTION
I tried to install on my nano X but this doesn't work and according to multiple discussion (see https://github.com/LedgerHQ/blue-loader-python/issues/58) is also not supported, only on the nano S (plus) and on a special developer nano x release