### PR TITLE
Fix future pdk url in build-parachains.md

### DIFF
--- a/docs/build/build-parachains.md
+++ b/docs/build/build-parachains.md
@@ -271,7 +271,7 @@ connected to {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}. Thi
 - An embedded full client of the Relay Chain
 - Block authorship compatibility
 
-Are you interested in building a PDK? See the [future PDKs](##future-pdks) section for details.
+Are you interested in building a PDK? See the [future PDKs](#future-pdks) section for details.
 
 ### How to set up your parachain
 


### PR DESCRIPTION
Fix broken link for future pdk redirection
Previously : https://wiki.polkadot.network/docs/build-pdk##future-pdks
Fix :             https://wiki.polkadot.network/docs/build-pdk#future-pdks

![image](https://user-images.githubusercontent.com/8139783/216987125-b3e180df-0820-46f3-93e8-c939046dc304.png)


