### PR TITLE
Search results counter should update when no results are found

### DIFF
--- a/components/Metadata.jsx
+++ b/components/Metadata.jsx
@@ -480,7 +480,6 @@ function Search() {
               matchCount += 1;
             } else { item.style.background = "transparent"; }
           }
-          document.getElementById("searchCount").innerText = matchCount;
           div.style.maxHeight = "100%";
           button.innerText = "-";
         } else {
@@ -488,6 +487,7 @@ function Search() {
           div.style.maxHeight = "0px";
           button.innerText = "+";
         }
+        document.getElementById("searchCount").innerText = matchCount;
       });
       ToggleLoading("searchResults", false);
     }


### PR DESCRIPTION
Previously the counter would not update if the initial query returned results and the user extended the query to the point that no results were found.

For example searching:

`cc` = 815 results

`ccc` = 815 results but should be 0 as it was still showing the previous count

This is now resolved.