### PR TITLE
Fix link to tech stack

### DIFF
--- a/docs/build/build-hackathon.md
+++ b/docs/build/build-hackathon.md
@@ -16,8 +16,7 @@ the {{ polkadot: [Polkadot newsletter](https://info.polkadot.network/subscribe).
 ## Host a Hackathon
 
 As one of our objectives in the Web3 Foundation is promoting the
-[Web3 technology stack](https://github.com/w3f/General-Grants-Program/blob/master/grants/polkadot_stack.md)
-, we would like to support any individual or team who wants to organize a hackathon that gets more
+[Web3 technology stack](https://wiki.polkadot.network/docs/build-open-source), we would like to support any individual or team who wants to organize a hackathon that gets more
 developers to understand {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} and
 Substrate in your city or online.
 


### PR DESCRIPTION
Not sure the link makes sense or should be relative, as it's the previous page in the sidebar. Anyway, the old URL is archived and points back to this wiki.