### PR TITLE
Remove the misconception of 100 parachian limit

### DIFF
--- a/docs/learn/learn-auction.md
+++ b/docs/learn/learn-auction.md
@@ -13,13 +13,12 @@ import AuctionSchedule from "./../../components/Auction-Schedule";
 
 For a [parachain](learn-parachains.md) to be added to
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} it must inhabit one of the available
-parachain slots. A parachain slot is a scarce resource on
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} as only a limited number are
-available. As parachains ramp up, there may only be a few slots unlocked every few months. The goal
-is to eventually have 100 parachain slots available on {{ polkadot: Polkadot :polkadot }}
-{{ kusama: Kusama :kusama }} (these will be split between parachains and the
-[parathread pool](learn-parathreads.md)). If a parachain wants to have guaranteed block inclusion at
-every Relay Chain block, it must acquire a parachain slot.
+parachain slots. The number of parachain slots is are not unbounded on
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, as only a limited number are
+available. A limited number of slots are unlocked every few months through on-chain governance. 
+If a parachain wants to have guaranteed block inclusion at every Relay Chain block, it must acquire a 
+parachain slot. The development of [on-demand parachains](https://forum.polkadot.network/t/on-demand-parachains/2208)
+(previously referred to as parathreads) is in progress. 
 
 The parachain slots will be leased according to an unpermissioned
 [candle auction](https://en.wikipedia.org/wiki/Candle_auction), with several alterations related to


### PR DESCRIPTION
This doc on the Wiki is cited as a reference stating that the number of parachains that can be supported is limited to 100.


"The current upper number of Parachains is just an educated guess, something to strive for. Depending on how the system performs in real life, the number could maybe be higher. However, with the introduction of parathreads this number will clearly be higher. This upper number is the number of concurrently advancing parachains/parathreads on the relay chain. As the idea behind parathreads is that certain chains don’t need a fixed block time of 6s and are having varying depending on activity on the parathread, the relay chain can run much more parathreads.

There are also ideas around scaling Polkadot. It isn’t the idea (and I think it never wasn’t) to stop at 100 Parachains. However, at some point we will reach a limit and need to either create “relay chain shards” or maybe create secondary parachains. All of these ideas are theoretical so far, but we are already thinking of what comes after the (first) 100."

Excerpt from the discussion in this thread -
https://forum.polkadot.network/t/polkadot-the-centralized-decentralized-ecosystem-a-cartel/1412