### PR TITLE
Updated application form

### DIFF
--- a/docs/general/thousand-validators.md
+++ b/docs/general/thousand-validators.md
@@ -137,7 +137,7 @@ In order to apply to the Polkadot programme, set up your node to adhere to the r
 and fill in the [application form](https://forms.gle/xqYLoceTwg1qvc9i6). You will hear back from the team shortly. :polkadot }}
 
 {{ kusama: In order to apply to the Kusama programme, set up your node to adhere to the requirements below
-and fill in the [application form](https://forms.gle/xqYLoceTwg1qvc9i6).  The process of review and addition is a manual one; you'll be invited to the 1KV Kusama channel and added to the leader board, if accepted. :kusama }}
+and fill in the {{ kusama: [application form](https://forms.gle/xqYLoceTwg1qvc9i6) :kusama }}{{ polkadot: [application form](https://docs.google.com/forms/d/e/1FAIpQLSdS-alI-J2wgIRCQVjQC7ZbFiTnf36hYBdmO-1ARMjKbC7H9w/viewform?ref=polkadot-network) :polkadot }}.  The process of review and addition is a manual one; you'll be invited to the 1KV Kusama channel and added to the leader board, if accepted. :kusama }}
 
 #### Requirements
 

--- a/docs/general/thousand-validators.md
+++ b/docs/general/thousand-validators.md
@@ -133,11 +133,11 @@ information on how to [secure a validator](../maintain/maintain-guides-secure-va
 {{ polkadot: **Entrance to the Polkadot programme requires a rank of 25 or higher in the Kusama programme.**
 Attaining a rank of 25 usually takes around two months. The leaderboard is available
 [here](https://thousand-validators.kusama.network/#/leaderboard).
-In order to apply to the Polkadot programme, set up your node to adhere to the requirements below
-and fill in the [application form](https://forms.gle/xqYLoceTwg1qvc9i6). You will hear back from the team shortly. :polkadot }}
+In order to apply to the Polkadot programme, set up your Polkadot node to adhere to the [requirements](#requirements) below
+and fill in the [application form](https://docs.google.com/forms/d/e/1FAIpQLSdS-alI-J2wgIRCQVjQC7ZbFiTnf36hYBdmO-1ARMjKbC7H9w/viewform?ref=polkadot-network). You will hear back from the team shortly. :polkadot }}
 
 {{ kusama: In order to apply to the Kusama programme, set up your node to adhere to the requirements below
-and fill in the {{ kusama: [application form](https://forms.gle/xqYLoceTwg1qvc9i6) :kusama }}{{ polkadot: [application form](https://docs.google.com/forms/d/e/1FAIpQLSdS-alI-J2wgIRCQVjQC7ZbFiTnf36hYBdmO-1ARMjKbC7H9w/viewform?ref=polkadot-network) :polkadot }}.  The process of review and addition is a manual one; you'll be invited to the 1KV Kusama channel and added to the leader board, if accepted. :kusama }}
+and fill in the [application form](https://forms.gle/xqYLoceTwg1qvc9i6). The process of review and addition is a manual one; you'll be invited to the 1KV Kusama channel and added to the leader board, if accepted. :kusama }}
 
 #### Requirements
 


### PR DESCRIPTION
This proposed change updates the application form link to direct users to the Polkadot form instead of the Kusama application form.  If this is confusing we could note both application forms regardless of the network.