### PR TITLE
XCM Doc Restructure: Covering pallet-xcm

### DIFF
--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -10,8 +10,8 @@ slug: ../learn-xcm-pallet
 The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/master/xcm/pallet-xcm))
 provides a developer-friendly interface for most of the common XCM messages.
 
-This pallet provides some default implementations for some traits required by `XcmConfig`, as well
-as an instance of the XCM Executor provided as a trait within the pallet's own configuration.
+This pallet provides some default implementations for traits required by `XcmConfig`, as well the
+`ExecuteXcm` trait over the pallet's own configuration.  
 `pallet-xcm` provides a default interface in the form of a pallet, that can manage and deal with
 XCM-related storage and higher-level dispatchable functions.
 
@@ -21,7 +21,7 @@ local or external chains. `pallet-xcm`'s functionality is separated into three c
 :::note
 
 Remember, all XCM messages are effectively XCVM programs that contain a set of instructions. It is
-the job of the XCM exector to handle these programs, and their subsequent instructions as needed.
+the job of the XCM executor is to handle and execute these programs.
 
 :::
 

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -11,7 +11,8 @@ The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/maste
 provides a developer-friendly interface for most of the common XCM messages.
 
 This pallet provides default implementations for many traits required by `XcmConfig`, which is
-highly useful for configuration.
+highly useful for configuration. `pallet-xcm` provides a default interface, in the form of a pallet,
+that can manage and deal with XCM-related storage and dispatchable functions.
 
 It defines a set of extrinsics that can be utilized to build XCVM programs, either to target the
 local or external chains. Pallet-xcm's functionality is separated into three categories:
@@ -19,3 +20,42 @@ local or external chains. Pallet-xcm's functionality is separated into three cat
 1. Primitive, dispatchable functions to locally execute an XCM message.
 2. High-level, dispatchable functions for asset transfers.
 3. Version negotiation-specific dispatchable functions.
+
+## Primitive Extrinsics
+
+There are two primary primitive extrinsics. These extrinsics handle sending and executing XCVM
+programs as dispatchable functions within the pallet.
+
+1. `execute` - This call is a direct access to the XCM executor. It checks the origin, message, and
+   ensures no barrier/filter will block the execution of the XCM message. Once it's deemed valid,
+   the message will then be _locally_ executed, therein returning the outcome as an event. This
+   operation is executed on behalf of whichever account has signed the extrinsic.
+2. `send` - This call specifies where a message should be sent externally to a particular
+   destination, i.e another parachain. It checks the origin, destination, and the message, and is
+   then sent to the `XcmRouter`.
+
+## Asset Transfer Extrinsics
+
+There are several extrinsics that handle asset transfer logic. They define a redetermined set of
+instructions in which to send and execute XCM messages. There are two variants of these functions,
+prefixed with `limited_`. These dispatchables have the same functionality, but with the option of
+specifying a weight to pay for the XCM fee.
+
+Otherwise, the fee is taken as needed from the asset being transferred.
+
+1. `reserve_transfer_assets` - Transfer some assets from the local chain to the sovereign account of
+   a destination chain and forward a notification XCM.
+2. `teleport_assets` - Teleport some assets from the local chain to some destination chain.
+
+## Version Negotiation Extrinsics
+
+These extrinisics require root, as they are only used when bypassing XCM version negotiation.
+
+1. `force_xcm_version` - Modifies the `SupportedVersion` storage to change a particular
+   destination's stated XCM version.
+2. `force_default_xcm_version` - Modifies the `SafeXcmVersion` storage, which stores the default
+   version to use when the destination's version is unknown.
+3. `force_subscribe_version_notify` - Sends an XCM message with a `SubscribeVersion` instruction to
+   a destination.
+4. `force_unsubscribe_version_notify` - Sends an XCM message with a `UnsubscribeVersion` instruction
+   to a destination.

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -92,8 +92,8 @@ While both extrinsics deal with transferring assets, they exhibit fundamentally 
 :::info
 
 A sovereign account refers to an account within a particular consensus system. Even though accounts
-may be different in terms of factors such as address, XCM agnostic nature enables for communication
-between these sovereign accounts that are in different consensus systems.
+may be different in terms of factors such as an address format, XCM agnostic nature enables
+communication between these sovereign accounts that are in other consensus systems.
 
 :::
 
@@ -119,7 +119,7 @@ applicable, fees are withdrawn from the assets from the specified `MultiLocation
 payment to execute any subsequent instructions within the XCM.
 
 Fees are generally dependent on several factors within the `XcmConfig`. For example, the barrier may
-negate any fees be paid at all.
+negate any fees to be paid at all.
 
 Before any XCM is sent, and if the destination chain’s barrier requires it, a `BuyExecution`
 instruction is used to buy the necessary weight for the XCM. XCM fee calculation is handled by the

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -10,11 +10,12 @@ slug: ../learn-xcm-pallet
 The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/master/xcm/pallet-xcm))
 provides a set of pre-defined, commonly used XCVM programs in the form of a set of extrinsics.
 
-This pallet provides some default implementations for traits required by `XcmConfig`, as well the
-`ExecuteXcm` trait over the pallet's own configuration. Where the XCM format defines a set of
-instructions used to construct XCVM programs, `pallet-xcm` defines a set of extrinsics that can be
-utilized to build XCVM programs, either to target the local or external chains. `pallet-xcm`'s
-functionality is separated into three categories:
+This pallet provides some default implementations for traits required by `XcmConfig`. The XCM
+executor is also included as an associated type within the pallet's configuration.
+
+Where the XCM format defines a set of instructions used to construct XCVM programs, `pallet-xcm`
+defines a set of extrinsics that can be utilized to build XCVM programs, either to target the local
+or external chains. `pallet-xcm`'s functionality is separated into three categories:
 
 :::note
 
@@ -108,6 +109,18 @@ They change any relevant storage aspects that enforce anything to do with XCM ve
 
 ## Fees in the XCM Pallet
 
-Message fees are only paid if the interior location is **not** equal to the interpreting consensus
-system (known as `Here` in the context of an XCM Multilocation). Otherwise, the chain bears the
-fees. If applicable, fees are withdrawn from the assets from the specified `MultiLocation`.
+Message fees are only paid if the interior location does not equal the interpreting consensus system
+(known as Here in the context of an XCM `Multilocation`). Otherwise, the chain bears the fees. If
+applicable, fees are withdrawn from the assets from the specified `MultiLocation` and used as
+payment to execute any subsequent instructions within the XCM.
+
+Fees are generally dependent on several factors within the `XcmConfig`. For example, the barrier may
+negate any fees be paid at all.
+
+Before any XCM is sent, and if the destination chain’s barrier requires it, a `BuyExecution`
+instruction is used to buy the necessary weight for the XCM. XCM fee calculation is handled by the
+Trader, which iteratively calculates the total fee based on the number of instructions.
+
+The Trader used to calculate the weight (time for computation in consensus) to include in the
+message. Fee calculation in XCM is highly configurable and, for this reason, subjective to whichever
+configuration is in place.

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -94,7 +94,6 @@ They change any relevant storage aspects that enforce anything to do with XCM ve
 
 ## Fees in the XCM Pallet
 
-Fees for messages are only paid if given interior location is **not** equal to the interpreting
-consensus system (known as `Here` in the context of an XCM Multilocation). Otherwise, the chain
-bears the fees. Fees are withdrawn from the assets from the specified `MultiLocation`, if
-applicable.
+Message fees are only paid if the interior location is **not** equal to the interpreting consensus
+system (known as `Here` in the context of an XCM Multilocation). Otherwise, the chain bears the
+fees. If applicable, fees are withdrawn from the assets from the specified `MultiLocation`.

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -11,11 +11,19 @@ The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/maste
 provides a developer-friendly interface for most of the common XCM messages.
 
 This pallet provides some default implementations for some traits required by `XcmConfig`, as well
-as an instance of the XCM Executor. `pallet-xcm` provides a default interface in the form of a
-pallet, that can manage and deal with XCM-related storage and dispatchable functions.
+as an instance of the XCM Executor provided as a trait within the pallet's own configuration.
+`pallet-xcm` provides a default interface in the form of a pallet, that can manage and deal with
+XCM-related storage and dispatchable functions.
 
 It defines a set of extrinsics that can be utilized to build XCVM programs, either to target the
 local or external chains. `pallet-xcm`'s functionality is separated into three categories:
+
+:::note
+
+Remember, all XCM messages are effectively XCVM programs that contain a set of instructions. It is
+the job of the XCM exector to handle these programs, and their subsequent instructions as needed.
+
+:::
 
 1. Primitive, dispatchable functions to locally execute an XCM message.
 2. High-level, dispatchable functions for asset transfers.
@@ -29,7 +37,8 @@ programs as dispatchable functions within the pallet.
 1. `execute` - This call is direct access to the XCM executor. It checks the origin and message and
    ensures that no barrier/filter will block the execution of the XCM message. Once it is deemed
    valid, the message will then be _locally_ executed, therein returning the outcome as an event.
-   This operation is executed on behalf of whichever account has signed the extrinsic.
+   This operation is executed on behalf of whichever account has signed the extrinsic. It's possible
+   for only a partial execution to occur.
 2. `send` - This call specifies where a message should be sent externally to a particular
    destination, i.e., another parachain. It checks the origin, destination, and message and is then
    sent to the `XcmRouter`.

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -53,7 +53,7 @@ be sent, and which XCM transport protocol to use. For example, Kusama, the canar
 `ChildParachainRouter` which only allows for Downward Message Passing from the relay to parachains
 to occur.
 
-You can read more about [XCM transport methods here](./learn-xcm-transport.md).
+You can read more about [XCM transport protocols here](./learn-xcm-transport.md).
 
 :::
 

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -8,7 +8,8 @@ slug: ../learn-xcm-pallet
 ---
 
 The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/master/xcm/pallet-xcm))
-provides a set of pre-defined, commonly used XCVM programs in the form of a set of extrinsics.
+provides a set of pre-defined, commonly used XCVM programs in the form of a set of extrinsics using
+[FRAME](https://docs.substrate.io/reference/frame-pallets/).
 
 This pallet provides some default implementations for traits required by `XcmConfig`. The XCM
 executor is also included as an associated type within the pallet's configuration.

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -41,8 +41,7 @@ programs as dispatchable functions within the pallet.
    for only a partial execution to occur.
 2. `send` - This call specifies where a message should be sent externally to a particular
    destination, i.e., another parachain. It checks the origin, destination, and message and is then
-   sent to the `XcmRouter`. Fees are withdrawn from the assets from the specified `MultiLocation`,
-   if applicable.
+   sent to the `XcmRouter`.
 
 :::info
 
@@ -67,6 +66,18 @@ Otherwise, the fee is taken as needed from the asset being transferred.
    a destination chain and forward a notification XCM.
 2. `teleport_assets` - Teleport some assets from the local chain to some destination chain.
 
+### Transfer Reserve vs Teleport
+
+While both extrinsics deal with transferring assets, they exhibit fundamentally different behavior.
+
+- **Teleporting** an asset implies a two-step process: the asset is burned/destroyed in the origin
+  chain and re-minted to whatever account is specified at the destination. Teleporting should only
+  occur if there is an inherent and bilateral trust between the two chains, as the tokens destroyed
+  _could not_ necessarily be guaranteed to have the same properties when minted at the destination.
+- **Transferring** or **reserving** an asset implies the movement of funds from one authority to
+  another, in this case, from the Origin of the sender's chain and into the sovereign account (who
+  will ultimately benefit from the assets) on the destination chain.
+
 ## Version Negotiation Extrinsics
 
 The following extrinsics require root, as they are only used when bypassing XCM version negotiation.
@@ -80,3 +91,10 @@ They change any relevant storage aspects that enforce anything to do with XCM ve
    a destination.
 4. `force_unsubscribe_version_notify` - Sends an XCM message with a `UnsubscribeVersion` instruction
    to a destination.
+
+## Fees in the XCM Pallet
+
+Fees for messages are only paid if given interior location is **not** equal to the interpreting
+consensus system (known as `Here` in the context of an XCM Multilocation). Otherwise, the chain
+bears the fees. Fees are withdrawn from the assets from the specified `MultiLocation`, if
+applicable.

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -13,7 +13,7 @@ provides a developer-friendly interface for most of the common XCM messages.
 This pallet provides some default implementations for some traits required by `XcmConfig`, as well
 as an instance of the XCM Executor provided as a trait within the pallet's own configuration.
 `pallet-xcm` provides a default interface in the form of a pallet, that can manage and deal with
-XCM-related storage and dispatchable functions.
+XCM-related storage and higher-level dispatchable functions.
 
 It defines a set of extrinsics that can be utilized to build XCVM programs, either to target the
 local or external chains. `pallet-xcm`'s functionality is separated into three categories:
@@ -41,7 +41,19 @@ programs as dispatchable functions within the pallet.
    for only a partial execution to occur.
 2. `send` - This call specifies where a message should be sent externally to a particular
    destination, i.e., another parachain. It checks the origin, destination, and message and is then
-   sent to the `XcmRouter`.
+   sent to the `XcmRouter`. Fees are withdrawn from the assets from the specified `MultiLocation`,
+   if applicable.
+
+:::info
+
+The XCM pallet needs the `XcmRouter` to send messages. It is used to dictate where messages are
+allowed to be sent, and which XCM transport protocol to use. For example, Kusama, the canary
+network, uses the `ChildParachainRoute` which only allows for Downward Message Passing from the
+relay to parachains to occur.
+
+You can read more about [XCM transport methods here.](./learn-xcm-transport.md)
+
+:::
 
 ## Asset Transfer Extrinsics
 

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -8,7 +8,7 @@ slug: ../learn-xcm-pallet
 ---
 
 The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/master/xcm/pallet-xcm))
-provides a developer-friendly interface for most of the common XCM messages.
+provides a developer-friendly interface for most of the common XCMs.
 
 This pallet provides some default implementations for traits required by `XcmConfig`, as well the
 `ExecuteXcm` trait over the pallet's own configuration.  
@@ -20,12 +20,12 @@ local or external chains. `pallet-xcm`'s functionality is separated into three c
 
 :::note
 
-Remember, all XCM messages are effectively XCVM programs that contain a set of instructions. It is
-the job of the XCM executor is to handle and execute these programs.
+Remember, all XCMs are effectively XCVM programs that contain a set of instructions. It is the job
+of the XCM executor is to handle and execute these programs.
 
 :::
 
-1. Primitive, dispatchable functions to locally execute an XCM message.
+1. Primitive, dispatchable functions to locally execute an XCM.
 2. High-level, dispatchable functions for asset transfers.
 3. Version negotiation-specific dispatchable functions.
 
@@ -35,20 +35,20 @@ There are two primary primitive extrinsics. These extrinsics handle sending and 
 programs as dispatchable functions within the pallet.
 
 1. `execute` - This call is direct access to the XCM executor. It checks the origin and message and
-   ensures that no barrier/filter will block the execution of the XCM message. Once it is deemed
-   valid, the message will then be _locally_ executed, therein returning the outcome as an event.
-   This operation is executed on behalf of whichever account has signed the extrinsic. It's possible
-   for only a partial execution to occur.
+   ensures that no barrier/filter will block the execution of the XCM. Once it is deemed valid, the
+   message will then be _locally_ executed, therein returning the outcome as an event. This
+   operation is executed on behalf of whichever account has signed the extrinsic. It's possible for
+   only a partial execution to occur.
 2. `send` - This call specifies where a message should be sent externally to a particular
    destination, i.e., another parachain. It checks the origin, destination, and message and is then
    sent to the `XcmRouter`.
 
 :::info
 
-The XCM pallet needs the `XcmRouter` to send messages. It is used to dictate where messages are
-allowed to be sent, and which XCM transport protocol to use. For example, Kusama, the canary
-network, uses the `ChildParachainRoute` which only allows for Downward Message Passing from the
-relay to parachains to occur.
+The XCM pallet needs the `XcmRouter` to send XCMs. It is used to dictate where XCMs are allowed to
+be sent, and which XCM transport protocol to use. For example, Kusama, the canary network, uses the
+`ChildParachainRoute` which only allows for Downward Message Passing from the relay to parachains to
+occur.
 
 You can read more about [XCM transport methods here.](./learn-xcm-transport.md)
 
@@ -57,8 +57,8 @@ You can read more about [XCM transport methods here.](./learn-xcm-transport.md)
 ## Asset Transfer Extrinsics
 
 Several extrinsics within the pallet handle asset transfer logic. They define a predetermined set of
-instructions for sending and executing XCM messages. Two variants of these functions are prefixed
-with `limited_`. They have the same functionality but can specify a weight to pay for the XCM fee.
+instructions for sending and executing XCMs. Two variants of these functions are prefixed with
+`limited_`. They have the same functionality but can specify a weight to pay for the XCM fee.
 
 Otherwise, the fee is taken as needed from the asset being transferred.
 
@@ -87,10 +87,10 @@ They change any relevant storage aspects that enforce anything to do with XCM ve
    destination's stated XCM version.
 2. `force_default_xcm_version` - Modifies the `SafeXcmVersion` storage, which stores the default
    version when the destination's version is unknown.
-3. `force_subscribe_version_notify` - Sends an XCM message with a `SubscribeVersion` instruction to
-   a destination.
-4. `force_unsubscribe_version_notify` - Sends an XCM message with a `UnsubscribeVersion` instruction
-   to a destination.
+3. `force_subscribe_version_notify` - Sends an XCM with a `SubscribeVersion` instruction to a
+   destination.
+4. `force_unsubscribe_version_notify` - Sends an XCM with a `UnsubscribeVersion` instruction to a
+   destination.
 
 ## Fees in the XCM Pallet
 

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -10,12 +10,12 @@ slug: ../learn-xcm-pallet
 The XCM pallet ([`pallet-xcm`](https://github.com/paritytech/polkadot/tree/master/xcm/pallet-xcm))
 provides a developer-friendly interface for most of the common XCM messages.
 
-This pallet provides default implementations for many traits required by `XcmConfig`, which is
-highly useful for configuration. `pallet-xcm` provides a default interface, in the form of a pallet,
-that can manage and deal with XCM-related storage and dispatchable functions.
+This pallet provides some default implementations for some traits required by `XcmConfig`, as well
+as an instance of the XCM Executor. `pallet-xcm` provides a default interface in the form of a
+pallet, that can manage and deal with XCM-related storage and dispatchable functions.
 
 It defines a set of extrinsics that can be utilized to build XCVM programs, either to target the
-local or external chains. Pallet-xcm's functionality is separated into three categories:
+local or external chains. `pallet-xcm`'s functionality is separated into three categories:
 
 1. Primitive, dispatchable functions to locally execute an XCM message.
 2. High-level, dispatchable functions for asset transfers.
@@ -26,20 +26,19 @@ local or external chains. Pallet-xcm's functionality is separated into three cat
 There are two primary primitive extrinsics. These extrinsics handle sending and executing XCVM
 programs as dispatchable functions within the pallet.
 
-1. `execute` - This call is a direct access to the XCM executor. It checks the origin, message, and
-   ensures no barrier/filter will block the execution of the XCM message. Once it's deemed valid,
-   the message will then be _locally_ executed, therein returning the outcome as an event. This
-   operation is executed on behalf of whichever account has signed the extrinsic.
+1. `execute` - This call is direct access to the XCM executor. It checks the origin and message and
+   ensures that no barrier/filter will block the execution of the XCM message. Once it is deemed
+   valid, the message will then be _locally_ executed, therein returning the outcome as an event.
+   This operation is executed on behalf of whichever account has signed the extrinsic.
 2. `send` - This call specifies where a message should be sent externally to a particular
-   destination, i.e another parachain. It checks the origin, destination, and the message, and is
-   then sent to the `XcmRouter`.
+   destination, i.e., another parachain. It checks the origin, destination, and message and is then
+   sent to the `XcmRouter`.
 
 ## Asset Transfer Extrinsics
 
-There are several extrinsics that handle asset transfer logic. They define a redetermined set of
-instructions in which to send and execute XCM messages. There are two variants of these functions,
-prefixed with `limited_`. These dispatchables have the same functionality, but with the option of
-specifying a weight to pay for the XCM fee.
+Several extrinsics within the pallet handle asset transfer logic. They define a predetermined set of
+instructions for sending and executing XCM messages. Two variants of these functions are prefixed
+with `limited_`. They have the same functionality but can specify a weight to pay for the XCM fee.
 
 Otherwise, the fee is taken as needed from the asset being transferred.
 
@@ -49,12 +48,13 @@ Otherwise, the fee is taken as needed from the asset being transferred.
 
 ## Version Negotiation Extrinsics
 
-These extrinisics require root, as they are only used when bypassing XCM version negotiation.
+The following extrinsics require root, as they are only used when bypassing XCM version negotiation.
+They change any relevant storage aspects that enforce anything to do with XCM version negotiations.
 
 1. `force_xcm_version` - Modifies the `SupportedVersion` storage to change a particular
    destination's stated XCM version.
 2. `force_default_xcm_version` - Modifies the `SafeXcmVersion` storage, which stores the default
-   version to use when the destination's version is unknown.
+   version when the destination's version is unknown.
 3. `force_subscribe_version_notify` - Sends an XCM message with a `SubscribeVersion` instruction to
    a destination.
 4. `force_unsubscribe_version_notify` - Sends an XCM message with a `UnsubscribeVersion` instruction

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -34,15 +34,16 @@ handle and execute these programs.
 There are two primary primitive extrinsics. These extrinsics handle sending and executing XCVM
 programs as dispatchable functions within the pallet.
 
-1. `execute` - This call contains direct access to the XCM executor. It is tje job of the executor
+1. `execute` - This call contains direct access to the XCM executor. It is the job of the executor
    to check the message and ensure that no barrier/filter will block the execution of the XCM. Once
    it is deemed valid, the message will then be _locally_ executed, therein returning the outcome as
    an event. This operation is executed on behalf of whichever account has signed the extrinsic.
    It's possible for only a partial execution to occur.
-2. `send` - This call specifies where a message should be sent externally to a particular
-   destination, i.e. a parachain, smart contract, or any system which is governed by consensus. As
-   before with `execute`, the Executor checks the origin, destination, and message and is then sent
-   to the `XcmRouter`.
+2. `send` - This call specifies where a message should be sent
+   ([via a transport method](./learn-xcm-transport.md)) externally to a particular destination, i.e.
+   a parachain, smart contract, or any system which is governed by consensus. In contrast to
+   `execute`, the executor is not called locally, as the execution will occur on the destination
+   chain.
 
 :::info
 
@@ -72,18 +73,21 @@ Otherwise, the fee is taken as needed from the asset being transferred.
 
 While both extrinsics deal with transferring assets, they exhibit fundamentally different behavior.
 
-- **Teleporting** an asset implies a two-step process: the asset is burned/destroyed in the origin
-  chain and re-minted to whatever account is specified at the destination. Teleporting should only
-  occur if there is an inherent and bilateral trust between the two chains, as the tokens destroyed
-  _could not_ necessarily be guaranteed to have the same properties when minted at the destination,
-  as well as that there has to be **trust** that the a particular chain burned, or re-minted the
-  assets.
+- **Teleporting** an asset implies a two-step process: the assets are taken out of circulating
+  supply (typically by burning/destroying) in the origin chain and re-minted to whatever account is
+  specified at the destination. Teleporting should only occur if there is an inherent and bilateral
+  trust between the two chains, as the tokens destroyed _could not_ necessarily be guaranteed to
+  have the same properties when minted at the destination, as well as that there has to be **trust**
+  that the a particular chain burned, or re-minted the assets.
 - **Transferring** or **reserving** an asset implies that **equivalent** assets (i.e, native
   currency, like `DOT` or `KSM`) are withdrawn from _sovereign account_ of the origin chain and
   deposited into the sovereign account on the destination chain. Unlike teleporting an asset, it is
   not destroyed and re-minted, rather a trusted, 3rd entity is used (i.e., Statemint on Polkadot) to
-  **reserve** the assets, wherein the sovereign account on the destination chain obtains ownership
-  of these assets.
+  **reserve** the assets, wherein the sovereign account of the destination chain on the reserve
+  chain obtains ownership of these assets.
+
+  It's worth noting that this means that some other mechanism is needed to ensure that the balance
+  on the destination does not exceed the reserve amount being held in this 3rd party.
 
 :::info
 
@@ -100,8 +104,8 @@ They change any relevant storage aspects that enforce anything to do with XCM ve
 
 1. `force_xcm_version` - Modifies the `SupportedVersion` storage to change a particular
    destination's stated XCM version.
-2. `force_default_xcm_version` - Modifies the `SafeXcmVersion` storage, which stores the default
-   version when the destination's version is unknown.
+2. `force_default_xcm_version` - Modifies the `SafeXcmVersion` storage, which stores the default XCM
+   version to use when the destination's version is unknown.
 3. `force_subscribe_version_notify` - Sends an XCM with a `SubscribeVersion` instruction to a
    destination.
 4. `force_unsubscribe_version_notify` - Sends an XCM with a `UnsubscribeVersion` instruction to a

--- a/docs/learn/learn-xcm-pallet.md
+++ b/docs/learn/learn-xcm-pallet.md
@@ -88,7 +88,7 @@ While both extrinsics deal with transferring assets, they exhibit fundamentally 
   chain obtains ownership of these assets.
 
   It's worth noting that this means that some other mechanism is needed to ensure that the balance
-  on the destination does not exceed the reserve amount being held in this 3rd party.
+  on the destination does not exceed the amount being held in reserve chain.
 
 :::info
 


### PR DESCRIPTION
As part of issue https://github.com/w3f/polkadot-wiki/issues/4541, this PR covers and documents `pallet-xcm`:

## TODO
- [x] What `pallet-xcm` does
- [x] How `pallet-xcm` handles fees
- [x] What extrinsics are important to note in `pallet-xcm` (and what they do)
- [x] How `pallet-xcm` defines interfaces for `XcmConfig`
- [x] Transfer Reserve vs Teleport difference