### PR TITLE
Wiki reorg: Archive Section Sidebar

### DIFF
--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -94,7 +94,6 @@ module.exports = {
               label: "Components",
               items: [
                 "learn/learn-consensus",
-                "learn/learn-governance",
                 "learn/learn-opengov",
                 "learn/learn-polkadot-host",
                 "learn/learn-runtime-upgrades",
@@ -184,6 +183,13 @@ module.exports = {
         },
         "learn/learn-launch",
         "learn/learn-video-tutorials",
+        {
+          type: "category",
+          label: "Archive",
+          items: [
+            "learn/learn-governance",
+          ],
+        },
       ],
     },
     {

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -77,7 +77,6 @@ module.exports = {
               items: [
                 "learn/learn-assets",
                 "learn/learn-DOT",
-                "learn/learn-redenomination",
                 "learn/learn-teleport",
               ],
             },
@@ -188,6 +187,7 @@ module.exports = {
           label: "Archive",
           items: [
             "learn/learn-governance",
+            "learn/learn-redenomination",
           ],
         },
       ],

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -180,13 +180,13 @@ module.exports = {
             'learn/learn-comparisons-avalanche'
           ],
         },
-        "learn/learn-launch",
         "learn/learn-video-tutorials",
         {
           type: "category",
           label: "Archive",
           items: [
             "learn/learn-governance",
+            "learn/learn-launch",
             "learn/learn-redenomination",
           ],
         },


### PR DESCRIPTION
Polkadot and Kusama evolve rapidly. A lot of things that today are great tomorrow will be deprecated. One good example is the Governance system. There are currently 2 pages Governance and OpenGov, in the wiki that are confusing. A new reader does not know where to go. I propose to create an "Archive" section in the sidebar and put in there important pages (such as the one about Governance) that are deprecated but indeed important for future references and users that want to know more about how things evolved. In this way, we can keep those pages without confusing the reader.

See [this issue](https://github.com/w3f/polkadot-wiki/issues/4376) and [this google doc](https://docs.google.com/document/d/1Fl8ReBIzcaQEOyF6s03d7MEcgk8aTVEt7xjmzAk_k5I/edit) for more information about the Wiki reorg.