### PR TITLE
Add binary merkle tree to tech stack

### DIFF
--- a/docs/build/build-open-source.md
+++ b/docs/build/build-open-source.md
@@ -28,6 +28,7 @@ apologize if we missed your project!
   - [Signatures](#signatures)
   - [Consensus](#consensus)
   - [Networking](#networking)
+  - [Primitives](#primitives)
 - [Contributing](#contributing)
 
 ## About
@@ -216,6 +217,11 @@ In the below sections you can find a list of different layers of the Polkadot St
 | DHT crawler         | [Go](https://github.com/atredispartners/dht-crawler-polkadot) 🔴, [Kotlin](https://github.com/emeraldpay/polkabot) 🔴|                                  |
 | RPC Tor-like access | [WhiteNoise](https://github.com/Evanesco-Labs/WhiteNoise.rs) 🔴|                                  |
 
+### Primitives
+
+| Components          | Existing projects                                                                                                     | Potentially interesting projects |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Storage             | [Merkle Tree DB]([https://github.com/atredispartners/dht-crawler-polkadot](https://github.com/frisitano/merkle-tree-db)) 🟢 |                                  |
 ## Contributing
 
 Pull requests, issues, or other contributions from the community are encouraged! You can not only


### PR DESCRIPTION
- this change concerns the [Binary merkle tree grant](https://github.com/w3f/Grants-Program/blob/master/applications/binary_merkle_tree.md)
- they successfully delivered [their first milestone](https://github.com/w3f/Grant-Milestone-Delivery/pull/786) which I [accepted](https://github.com/w3f/Grant-Milestone-Delivery/blob/master/evaluations/merkle-tree_1_takahser.md)
- it didn't really fit into any existing section and component, so I added a new one
- feedback welcome, as usual :)