### PR TITLE
Fix for current auction status in auction tool

### DIFF
--- a/components/Auction-Schedule.jsx
+++ b/components/Auction-Schedule.jsx
@@ -124,7 +124,8 @@ function GetCurrentOrNextAuction(chain, auctions, currentBlock) {
 			return [index, status];
 		}
 	}
-	return [auctions.length - 1, status = `There are currently no pending or ongoing auctions.  Auction #${auctions.length} was the last active auction.`];
+	status = `There are currently no pending or ongoing auctions.  Auction #${auctions.length} was the last active auction.`
+	return [auctions.length - 1, status];
 }
 
 // Update JSX

--- a/components/Auction-Schedule.jsx
+++ b/components/Auction-Schedule.jsx
@@ -122,11 +122,9 @@ function GetCurrentOrNextAuction(chain, auctions, currentBlock) {
 			}
 			index = i;
 			return [index, status];
-		} else {
-			status = `There are currently no pending or ongoing auctions.`;
-			return [index, status];
 		}
 	}
+	return [auctions.length - 1, status = `There are currently no pending or ongoing auctions.  Auction #${auctions.length} was the last active auction.`];
 }
 
 // Update JSX


### PR DESCRIPTION
### Description
It was previously discovered in #4593 that if no current or pending auctions were available the auction tool would hang on "Loading Auctions...".  #4593 corrects the issue in some scenarios but introduces additional edge cases that will result in "There are currently no pending or ongoing auctions" being displayed when there are indeed pending or active auctions.  For example, the Kusama variant currently displays this message in production but there is currently an active and future auctions in the cache.

Moving the statement from the previous fix to out of the for-loop and setting the index to the last auction in the cache when no auctions are active or pending should correct failing edge cases.

**Before** fix (current state) w/ active and pending:

![image](https://user-images.githubusercontent.com/13341935/229297145-fa72a016-2567-41d6-99ba-f9ed360c78d5.png)

**After** fix w/ no active but pending:

![image](https://user-images.githubusercontent.com/13341935/229296939-421d3d9d-1d95-46c6-a359-8f82b6035313.png)

**After** fix w/ no active and no pending:

![image](https://user-images.githubusercontent.com/13341935/229296980-6c21c03f-d921-4269-8e46-9e6bd7beeadf.png)

**After** fix w/ active and pending:

![image](https://user-images.githubusercontent.com/13341935/229297083-29ed194b-09e8-44d6-b974-652c58f31b84.png)

### FYI
@DrW3RK @filippoweb3 @CrackTheCode016 Hey guys! 👋 I happen to notice the auction status was incorrect when checking the tool recently and had a few minutes to look into it.  This PR builds off Bader's fix to handle all the various states.  Hope all is well!
