### PR TITLE
Wiki Reorg: Move SPREE to Architecture

### DIFF
--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -121,7 +121,6 @@ module.exports = {
             "learn/learn-cryptography",
             'learn/learn-phragmen',
             'learn/learn-randomness',
-            'learn/learn-spree',
             'learn/learn-wasm',
             {
               type: "category",
@@ -170,6 +169,7 @@ module.exports = {
                 'learn/learn-xcm-instructions',
               ],
             },
+            'learn/learn-spree',
           ],
         },
         {


### PR DESCRIPTION
See [this issue](https://github.com/w3f/polkadot-wiki/issues/4376) and [this google doc](https://docs.google.com/document/d/1Fl8ReBIzcaQEOyF6s03d7MEcgk8aTVEt7xjmzAk_k5I/edit) for more information about the Wiki reorg.