### PR TITLE
Add setup bootnode page, split the rpc node setup from the wss page and add dbsize reference

### DIFF
--- a/docs/maintain/maintain-bootnode.md
+++ b/docs/maintain/maintain-bootnode.md
@@ -7,7 +7,8 @@ keywords: [bootnode, web socket, remote, connection, secure websocket]
 slug: ../maintain-bootnode
 ---
 
-:::tip When you first start a node it has to find a way to find other nodes in the network. For that
+:::tip 
+When you first start a node it has to find a way to find other nodes in the network. For that
 purpose you need "bootnodes". After the first bootnode is found it can use the connections of that
 node to continue expanding its network and be able to play its role in the network, like participate
 as a validator. 
@@ -73,7 +74,8 @@ If we have above node running with dns name `dot-bootnode.stakeworld.io`, proxie
 certificate and node-id `12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg` then the following
 commands should give you a: "syncing 1 peers".
 
-:::tip You can add `-lsub-libp2p=trace` on the end to get libp2p trace logging for debugging
+:::tip 
+You can add `-lsub-libp2p=trace` on the end to get libp2p trace logging for debugging
 purposes. 
 :::
 

--- a/docs/maintain/maintain-bootnode.md
+++ b/docs/maintain/maintain-bootnode.md
@@ -1,0 +1,94 @@
+---
+id: maintain-bootnode
+title: Set up a Boot Node
+sidebar_label: Set up a Boot Node
+description: Steps on setting up a boot node.
+keywords: [bootnode, web socket, remote, connection, secure websocket]
+slug: ../maintain-bootnode
+---
+
+:::tip When you first start a node it has to find a way to find other nodes in the network. For that
+purpose you need "bootnodes". After the first bootnode is found it can use the connections of that
+node to continue expanding its network and be able to play its role in the network, like participate
+as a validator. :::
+
+## Accessing the bootnode
+
+The consensus is that bootnodes have to be accessible in three ways:
+
+- **p2p**: the p2p port, which can be set by `--listen-addr /ip4/0.0.0.0/tcp/<port>`. This port is
+  not automatically set on a non validator node (for example an archive rpc node).
+- **p2p/ws**: the websocket version, which can be set by `--listen-addr /ip4/0.0.0.0/tcp/<port>/ws`.
+- **p2p/wss**: the _secure_ websocket version. A ssl secured connection to the p2p/ws port which
+  will have to be achieved by a proxy since the node itself has no way to include certificates. It
+  is needed for light clients. See [here](/docs/maintain-wss) for info about setting this up.
+
+## Your network key
+
+When you startup a node it creates its node-key in the `chains/<chain>/network/secret_ed25519` file.
+You can also create a node-key by `polkadot key generate-node-key` and use that node-key in the
+startup command line.
+
+It is essential you backup the node-key, especially if it gets included in the polkadot binary
+because it gets hardcoded in the binary and needs to be recompiled to change.
+
+## Running the bootnode
+
+Say we are running a polkadot node with
+`polkadot --chain polkadot --name dot-bootnode --listen-addr /ip4/0.0.0.0/tcp/30310 --listen-addr /ip4/0.0.0.0/tcp/30311/ws`
+then we would have the p2p on port 30310 and p2p/ws on port 30311. For the p2p/wss port we need to
+setup a proxy, a dns name and a corresponding certificate. These concepts and example setups are
+described [here](https://wiki.polkadot.network/docs/maintain-wss#secure-the-ws-port). The following
+example is for the popular nginx server and enables p2p/wss on port 30312 by proxying the p2p/ws
+port 30311:
+
+_/etc/nginx/sites-enabled/dot-bootnode_
+
+```
+server {
+       listen       30312 ssl http2 default_server;
+       server_name  dot-bootnode.stakeworld.io;
+       root         /var/www/html;
+
+       ssl_certificate "<your_cert";
+       ssl_certificate_key "<your_key>";
+
+       location / {
+         proxy_buffers 16 4k;
+         proxy_buffer_size 2k;
+         proxy_pass http://localhost:30311;
+         proxy_http_version 1.1;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection "Upgrade";
+         proxy_set_header Host $host;
+   }
+
+}
+```
+
+## Testing the bootnode connection
+
+If we have above node running with dns name `dot-bootnode.stakeworld.io`, proxied with a valid
+certificate and node-id `12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg` then the following
+commands should give you a: "syncing 1 peers".
+
+:::tip You can add `-lsub-libp2p=trace` on the end to get libp2p trace logging for debugging
+purposes. :::
+
+**p2p**:
+
+```bash
+polkadot --chain polkadot --base-path /tmp/node --name "Bootnode testnode" --reserved-only --reserved-nodes "/dns/dot-bootnode.stakeworld.io/tcp/30310/p2p/12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg" --no-hardware-benchmarks
+```
+
+**p2p/ws**:
+
+```bash
+polkadot --chain polkadot --base-path /tmp/node --name "Bootnode testnode" --reserved-only --reserved-nodes "/dns/dot-bootnode.stakeworld.io/tcp/30311/ws/p2p/12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg" --no-hardware-benchmarks
+```
+
+**p2p/wss**:
+
+```bash
+polkadot --chain polkadot --base-path /tmp/node --name "Bootnode testnode" --reserved-only --reserved-nodes "/dns/dot-bootnode.stakeworld.io/tcp/30312/wss/p2p/12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg" --no-hardware-benchmarks
+```

--- a/docs/maintain/maintain-bootnode.md
+++ b/docs/maintain/maintain-bootnode.md
@@ -7,11 +7,13 @@ keywords: [bootnode, web socket, remote, connection, secure websocket]
 slug: ../maintain-bootnode
 ---
 
-:::tip 
+:::note
+
 When you first start a node it has to find a way to find other nodes in the network. For that
 purpose you need "bootnodes". After the first bootnode is found it can use the connections of that
 node to continue expanding its network and be able to play its role in the network, like participate
-as a validator. 
+as a validator.
+
 :::
 
 ## Accessing the bootnode
@@ -74,9 +76,10 @@ If we have above node running with dns name `dot-bootnode.stakeworld.io`, proxie
 certificate and node-id `12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg` then the following
 commands should give you a: "syncing 1 peers".
 
-:::tip 
-You can add `-lsub-libp2p=trace` on the end to get libp2p trace logging for debugging
-purposes. 
+:::tip
+
+You can add `-lsub-libp2p=trace` on the end to get libp2p trace logging for debugging purposes.
+
 :::
 
 **p2p**:

--- a/docs/maintain/maintain-bootnode.md
+++ b/docs/maintain/maintain-bootnode.md
@@ -9,39 +9,38 @@ slug: ../maintain-bootnode
 
 :::note
 
-When you first start a node it has to find a way to find other nodes in the network. For that
-purpose you need "bootnodes". After the first bootnode is found it can use the connections of that
-node to continue expanding its network and be able to play its role in the network, like participate
-as a validator.
+When you first start a node, it has to find a way to find other nodes in the network. For that
+purpose, you need "bootnodes". After the first bootnode is found, it can use that node’s connections
+to continue expanding and play its role in the network, like participating as a validator.
 
 :::
 
-## Accessing the bootnode
+## Accessing the Bootnode
 
 The consensus is that bootnodes have to be accessible in three ways:
 
 - **p2p**: the p2p port, which can be set by `--listen-addr /ip4/0.0.0.0/tcp/<port>`. This port is
-  not automatically set on a non validator node (for example an archive rpc node).
-- **p2p/ws**: the websocket version, which can be set by `--listen-addr /ip4/0.0.0.0/tcp/<port>/ws`.
-- **p2p/wss**: the _secure_ websocket version. A ssl secured connection to the p2p/ws port which
-  will have to be achieved by a proxy since the node itself has no way to include certificates. It
-  is needed for light clients. See [here](/docs/maintain-wss) for info about setting this up.
+  not automatically set on a non-validator node (for example, an archive RPC node).
+- **p2p/ws**: the WebSocket version, which can be set by `--listen-addr /ip4/0.0.0.0/tcp/<port>/ws`.
+- **p2p/wss**: the _secure_ websocket version. An SSL-secured connection to the p2p/ws port must be
+  achieved by a proxy since the node cannot include certificates. It is needed for light clients.
+  See [here](/docs/maintain-wss) for info about setting this up.
 
-## Your network key
+## Network Key
 
-When you startup a node it creates its node-key in the `chains/<chain>/network/secret_ed25519` file.
-You can also create a node-key by `polkadot key generate-node-key` and use that node-key in the
-startup command line.
+Starting a node creates its node key in the `chains/<chain>/network/secret_ed25519` file. You can
+also create a node-key by `polkadot key generate-node-key` and use that node-key in the startup
+command line.
 
-It is essential you backup the node-key, especially if it gets included in the polkadot binary
+It is essential you backup the node key, especially if it gets included in the polkadot binary
 because it gets hardcoded in the binary and needs to be recompiled to change.
 
-## Running the bootnode
+## Running the Bootnode
 
 Say we are running a polkadot node with
 `polkadot --chain polkadot --name dot-bootnode --listen-addr /ip4/0.0.0.0/tcp/30310 --listen-addr /ip4/0.0.0.0/tcp/30311/ws`
-then we would have the p2p on port 30310 and p2p/ws on port 30311. For the p2p/wss port we need to
-setup a proxy, a dns name and a corresponding certificate. These concepts and example setups are
+then we would have the p2p on port 30310 and p2p/ws on port 30311. For the p2p/wss port, we need to
+set up a proxy, a DNS name, and a corresponding certificate. These concepts and example setups are
 described [here](https://wiki.polkadot.network/docs/maintain-wss#secure-the-ws-port). The following
 example is for the popular nginx server and enables p2p/wss on port 30312 by proxying the p2p/ws
 port 30311:
@@ -70,9 +69,9 @@ server {
 }
 ```
 
-## Testing the bootnode connection
+## Testing Bootnode Connection
 
-If we have above node running with dns name `dot-bootnode.stakeworld.io`, proxied with a valid
+If we have the above node running with DNS name `dot-bootnode.stakeworld.io`, proxied with a valid
 certificate and node-id `12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg` then the following
 commands should give you a: "syncing 1 peers".
 

--- a/docs/maintain/maintain-bootnode.md
+++ b/docs/maintain/maintain-bootnode.md
@@ -10,7 +10,8 @@ slug: ../maintain-bootnode
 :::tip When you first start a node it has to find a way to find other nodes in the network. For that
 purpose you need "bootnodes". After the first bootnode is found it can use the connections of that
 node to continue expanding its network and be able to play its role in the network, like participate
-as a validator. :::
+as a validator. 
+:::
 
 ## Accessing the bootnode
 
@@ -73,7 +74,8 @@ certificate and node-id `12D3KooWAb5MyC1UJiEQJk4Hg4B2Vi3AJdqSUhTGYUqSnEqCFMFg` t
 commands should give you a: "syncing 1 peers".
 
 :::tip You can add `-lsub-libp2p=trace` on the end to get libp2p trace logging for debugging
-purposes. :::
+purposes. 
+:::
 
 **p2p**:
 

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -54,7 +54,7 @@ balances, making transfers, setting up session keys, staking, etc. An archive no
 history (database) of the network. It can be queried in various ways, such as providing historical
 information regarding transfers, balance histories, and more advanced queries involving past events.
 
-An archive node requires a lot more disk space. At the start of April 2023, polkadot disk usage was
+An archive node requires a lot more disk space. At the start of April 2023, Polkadot disk usage was
 160 GB for a pruned node and 1 TB for an archive node. This value will increase with time. For an
 archive node, you need the options `--state-pruning archive --blocks-pruning archive` in your
 startup settings.

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -27,7 +27,7 @@ can often lead to security problems
 
 Setting up any Substrate-based node relies on a similar process. For example, by default, they will
 all share the same WebSocket connection at port 9944 on localhost. In this example, we'll set up a
-polkadot sync node on a Debian-flavoured server (such as Ubuntu 22.04). Create a new server on your
+Polkadot sync node on a Debian-flavoured server (such as Ubuntu 22.04). Create a new server on your
 provider of choice or locally at home. See [Set up a Full Node](./maintain-sync) for additional
 instructions. You can install from the default apt repository or build from scratch. The startup
 options in the setup process provide various settings that can be modified.

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -1,0 +1,98 @@
+---
+id: maintain-rpc
+title: Set up a RPC node
+sidebar_label: Set up a RPC node
+description: Steps on setting up a RPC node.
+keywords: [rpc, rpc node, web socket, remote, connection, secure websocket]
+slug: ../maintain-rpc
+---
+
+The substrate node RPC server can be accessed over the websocket protocol, which can be used as a
+way to access the underlying network and/or validator node. By default you can access your node's
+RPC server from localhost (for example to rotate keys or do other maintenance). To access it from
+another server or from an applications UI (such as [Polkadot-JS UI](https://polkadot.js.org/apps))
+it is recommended to enable access to the RPC node over an TLS connection and as such encrypting the
+connection between the end user and the RPC server. This can be achieved by setting up a secure
+proxy. Many browsers such as Google Chrome will block non secure WS endpoints if they come from a
+different origin.
+
+:::note
+
+Enabling remote access to your validator node should not be necessary and is not suggested as it can
+often lead to security problems
+
+:::
+
+## Set up a node
+
+Setting up any Substrate-based node relies on a similar process. For example, they will all by
+default share the same websocket connection at port 9944 on localhost. In this example, we'll set up
+a polkadot sync node on a debian flavoured server (such as Ubuntu 22.04). Create a new server on
+your provider of choice or locally at home. See [Set up a Full Node](./maintain-sync) for additional
+instructions. You can choose to install from the default apt repository or build from scratch. The
+startup options in the setup process provide a variety of different settings that can be modified.
+
+A typically setting for an externally accessible polkadot archive RPC node would be:
+
+```config
+polkadot --chain polkadot --name myrpc --state-pruning archive --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
+```
+
+Or for a polkadot pruned RPC node:
+
+```config
+polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
+```
+
+The specified flag option are outlined in greater detail below.
+
+### Archive Node vs Pruned Node
+
+A pruned node only keeps a limited number of finalized blocks of the network and not its full
+history. Most frequently required actions can be completed with a pruned node, such as displaying
+account balances, making transfers, setting up session keys, staking, etc. An archive node has the
+full history (database) of the network and can be queried in all kind of ways, such as providing
+historical information regarding transfers, balance histories, and more advanced queries involving
+past events, etc.
+
+An archive node requires a lot more diskspace. At the start of January 2023, polkadot disk usage was
+at 115 GB for a pruned node and 765 GB for an archive node. This value will increase with time. For
+an archive node you need the options `--state-pruning archive --blocks-pruning archive` in your
+startup settings.
+
+:::tip
+
+Inclusion in the Polkadot.js UI requires an archive node.
+
+:::
+
+### Secure the RPC server
+
+The node startup settings allow you to choose **what** to expose, **how many** connections to expose
+and **from where** access should be granted through the rpc server.
+
+_How many_: You can set your maximum connections through `--ws-max-connections`, for example
+`--ws-max-connections 100`
+
+_From where_: by default localhost and the polkadot.js are allowed to access the RPC server, you can
+change this by setting `--rpc-cors`, to allow access from everywhere you need `--rpc-cors all`
+
+_What_: you can limit the methods to use with `--rpc-methods`, an easy way to set this to a safe
+mode is `--rpc-methods Safe`
+
+### Secure the ws port
+
+To safely access your ws connection over a ssl enabled connection (need for polkadot.js) you have to
+convert the ws connection to a secure (wss) connection by using a proxy and a ssl certificate, you
+can find instructions on securing the ws port [here](/docs/maintain-wss).
+
+## Connecting to the Node
+
+Open [Polkadot-JS UI](https://polkadot.js.org/apps) and click the logo in the top left to switch the
+node. Activate the "Development" toggle and input your node's address - either the domain or the IP
+address. Remember to prefix with `wss://` and if you're using the 443 port, append `:443`, like so:
+`wss://example.com:443`.
+
+![A sync-in-progress chain connected to Polkadot-JS UI](../assets/maintain-wss-image.png)
+
+Now you have a secure remote connect setup for your Substrate node.

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -38,7 +38,7 @@ A typical setting for an externally accessible polkadot archive RPC node would b
 polkadot --chain polkadot --name myrpc --state-pruning archive --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
 ```
 
-Or for a polkadot pruned RPC node:
+Or for a Polkadot pruned RPC node:
 
 ```config
 polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -11,9 +11,9 @@ The substrate node RPC server can be accessed over the websocket protocol, which
 way to access the underlying network and/or validator node. By default you can access your node's
 RPC server from localhost (for example to rotate keys or do other maintenance). To access it from
 another server or from an applications UI (such as [Polkadot-JS UI](https://polkadot.js.org/apps))
-it is recommended to enable access to the RPC node over an TLS connection and as such encrypting the
+it is recommended to enable access to the RPC node over an SSL connection and as such encrypting the
 connection between the end user and the RPC server. This can be achieved by setting up a secure
-proxy. Many browsers such as Google Chrome will block non secure WS endpoints if they come from a
+proxy. Many browsers such as Google Chrome will block non secure ws endpoints if they come from a
 different origin.
 
 :::note
@@ -44,7 +44,7 @@ Or for a polkadot pruned RPC node:
 polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
 ```
 
-The specified flag option are outlined in greater detail below.
+The specified flag options are outlined in greater detail below.
 
 ### Archive Node vs Pruned Node
 
@@ -55,10 +55,10 @@ full history (database) of the network and can be queried in all kind of ways, s
 historical information regarding transfers, balance histories, and more advanced queries involving
 past events, etc.
 
-An archive node requires a lot more diskspace. At the start of January 2023, polkadot disk usage was
-at 115 GB for a pruned node and 765 GB for an archive node. This value will increase with time. For
-an archive node you need the options `--state-pruning archive --blocks-pruning archive` in your
-startup settings.
+An archive node requires a lot more diskspace. At the start of April 2023, polkadot disk usage was
+at 160 GB for a pruned node and 1 TB for an archive node. This value will increase with time. For an
+archive node you need the options `--state-pruning archive --blocks-pruning archive` in your startup
+settings.
 
 :::tip
 
@@ -82,9 +82,9 @@ mode is `--rpc-methods Safe`
 
 ### Secure the ws port
 
-To safely access your ws connection over a ssl enabled connection (need for polkadot.js) you have to
-convert the ws connection to a secure (wss) connection by using a proxy and a ssl certificate, you
-can find instructions on securing the ws port [here](/docs/maintain-wss).
+To safely access your ws connection over a ssl enabled connection (needed for polkadot.js) you have
+to convert the ws connection to a secure (wss) connection by using a proxy and a ssl certificate,
+you can find instructions on securing the ws port [here](/docs/maintain-wss).
 
 ## Connecting to the Node
 

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -7,32 +7,32 @@ keywords: [rpc, rpc node, web socket, remote, connection, secure websocket]
 slug: ../maintain-rpc
 ---
 
-The substrate node RPC server can be accessed over the websocket protocol, which can be used as a
-way to access the underlying network and/or validator node. By default you can access your node's
-RPC server from localhost (for example to rotate keys or do other maintenance). To access it from
-another server or from an applications UI (such as [Polkadot-JS UI](https://polkadot.js.org/apps))
-it is recommended to enable access to the RPC node over an SSL connection and as such encrypting the
-connection between the end user and the RPC server. This can be achieved by setting up a secure
-proxy. Many browsers such as Google Chrome will block non secure ws endpoints if they come from a
-different origin.
+The substrate node RPC server can be accessed over the WebSocket protocol, which can be used to
+access the underlying network and/or validator node. By default, you can access your node's RPC
+server from localhost (for example, to rotate keys or do other maintenance). To access it from
+another server or an applications UI (such as [Polkadot-JS UI](https://polkadot.js.org/apps)) it is
+recommended to enable access to the RPC node over an SSL connection and encrypt the connection
+between the end user and the RPC server. This can be achieved by setting up a secure proxy. Many
+browsers, such as Google Chrome, will block non-secure ws endpoints if they come from a different
+origin.
 
 :::note
 
-Enabling remote access to your validator node should not be necessary and is not suggested as it can
-often lead to security problems
+Enabling remote access to your validator node should not be necessary and is not suggested, as it
+can often lead to security problems
 
 :::
 
-## Set up a node
+## Set up a Node
 
-Setting up any Substrate-based node relies on a similar process. For example, they will all by
-default share the same websocket connection at port 9944 on localhost. In this example, we'll set up
-a polkadot sync node on a debian flavoured server (such as Ubuntu 22.04). Create a new server on
-your provider of choice or locally at home. See [Set up a Full Node](./maintain-sync) for additional
-instructions. You can choose to install from the default apt repository or build from scratch. The
-startup options in the setup process provide a variety of different settings that can be modified.
+Setting up any Substrate-based node relies on a similar process. For example, by default, they will
+all share the same WebSocket connection at port 9944 on localhost. In this example, we'll set up a
+polkadot sync node on a Debian-flavoured server (such as Ubuntu 22.04). Create a new server on your
+provider of choice or locally at home. See [Set up a Full Node](./maintain-sync) for additional
+instructions. You can install from the default apt repository or build from scratch. The startup
+options in the setup process provide various settings that can be modified.
 
-A typically setting for an externally accessible polkadot archive RPC node would be:
+A typical setting for an externally accessible polkadot archive RPC node would be:
 
 ```config
 polkadot --chain polkadot --name myrpc --state-pruning archive --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
@@ -46,19 +46,18 @@ polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning arc
 
 The specified flag options are outlined in greater detail below.
 
-### Archive Node vs Pruned Node
+### Archive Node vs. Pruned Node
 
-A pruned node only keeps a limited number of finalized blocks of the network and not its full
-history. Most frequently required actions can be completed with a pruned node, such as displaying
-account balances, making transfers, setting up session keys, staking, etc. An archive node has the
-full history (database) of the network and can be queried in all kind of ways, such as providing
-historical information regarding transfers, balance histories, and more advanced queries involving
-past events, etc.
+A pruned node only keeps a limited number of finalized blocks of the network, not its full history.
+Most frequently required actions can be completed with a pruned node, such as displaying account
+balances, making transfers, setting up session keys, staking, etc. An archive node has the full
+history (database) of the network. It can be queried in various ways, such as providing historical
+information regarding transfers, balance histories, and more advanced queries involving past events.
 
-An archive node requires a lot more diskspace. At the start of April 2023, polkadot disk usage was
-at 160 GB for a pruned node and 1 TB for an archive node. This value will increase with time. For an
-archive node you need the options `--state-pruning archive --blocks-pruning archive` in your startup
-settings.
+An archive node requires a lot more disk space. At the start of April 2023, polkadot disk usage was
+160 GB for a pruned node and 1 TB for an archive node. This value will increase with time. For an
+archive node, you need the options `--state-pruning archive --blocks-pruning archive` in your
+startup settings.
 
 :::tip
 
@@ -69,12 +68,12 @@ Inclusion in the Polkadot.js UI requires an archive node.
 ### Secure the RPC server
 
 The node startup settings allow you to choose **what** to expose, **how many** connections to expose
-and **from where** access should be granted through the rpc server.
+and **from where** access should be granted through the RPC server.
 
 _How many_: You can set your maximum connections through `--ws-max-connections`, for example
 `--ws-max-connections 100`
 
-_From where_: by default localhost and the polkadot.js are allowed to access the RPC server, you can
+_From where_: by default localhost and the polkadot.js are allowed to access the RPC server; you can
 change this by setting `--rpc-cors`, to allow access from everywhere you need `--rpc-cors all`
 
 _What_: you can limit the methods to use with `--rpc-methods`, an easy way to set this to a safe
@@ -82,15 +81,15 @@ mode is `--rpc-methods Safe`
 
 ### Secure the ws port
 
-To safely access your ws connection over a ssl enabled connection (needed for polkadot.js) you have
-to convert the ws connection to a secure (wss) connection by using a proxy and a ssl certificate,
-you can find instructions on securing the ws port [here](/docs/maintain-wss).
+To safely access your ws connection over an SSL-enabled connection (needed for polkadot.js), you
+have to convert the ws connection to a secure (wss) connection by using a proxy and an SSL
+certificate, you can find instructions on securing the ws port [here](/docs/maintain-wss).
 
 ## Connecting to the Node
 
 Open [Polkadot-JS UI](https://polkadot.js.org/apps) and click the logo in the top left to switch the
 node. Activate the "Development" toggle and input your node's address - either the domain or the IP
-address. Remember to prefix with `wss://` and if you're using the 443 port, append `:443`, like so:
+address. Remember to prefix with `wss://`, and if you're using the 443 port, append `:443` like so:
 `wss://example.com:443`.
 
 ![A sync-in-progress chain connected to Polkadot-JS UI](../assets/maintain-wss-image.png)

--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -11,10 +11,10 @@ import Tabs from "@theme/Tabs";
 
 import TabItem from "@theme/TabItem";
 
-If you're building dapps or products on a Substrate-based chain like Polkadot, Kusama or a custom
-Substrate implementation, you probably want the ability to run a node-as-a-back-end. After all, it's
-always better to rely on your own infrastructure than on a third-party-hosted one in this brave new
-decentralized world.
+If you're building dApps or products on a Substrate-based chain like Polkadot, Kusama, or a custom
+Substrate implementation, you want the ability to run a node-as-a-back-end. After all, relying on
+your infrastructure is always better than a third-party-hosted one in this brave new decentralized
+world.
 
 This guide will show you how to connect to [Polkadot network](https://polkadot.network/), but the
 same process applies to any other [Substrate](https://substrate.io)-based chain. First, let's
@@ -25,20 +25,20 @@ clarify the term _full node_.
 A blockchain's growth comes from a _genesis block_, _extrinsics_, and _events_.
 
 When a validator seals block 1, it takes the blockchain's state at block 0. It then applies all
-pending changes on top of it, and emits the events that are the result of these changes. Later, the
-state of the chain at block 1 is used in the same way to build the state of the chain at block 2,
-and so on. Once two thirds of the validators agree on a specific block being valid, it is finalized.
+pending changes on top of it and emits the events resulting from these changes. Later, the chain’s
+state at block one is used the same way to build the chain’s state at block 2, and so on. Once
+two-thirds of the validators agree on a specific block being valid, it is finalized.
 
 An **archive node** keeps all the past blocks and their states. An archive node makes it convenient
 to query the past state of the chain at any point in time. Finding out what an account's balance at
-a certain block was, or which extrinsics resulted in a certain state change are fast operations when
-using an archive node. However, an archive node takes up a lot of disk space - around Kusama's 12
-millionth block this was around 660 GB.
+a particular block was or which extrinsics resulted in a specific state change are fast operations
+when using an archive node. However, an archive node takes up a lot of disk space - around Kusama's
+12 millionth block, this was around 660 GB.
 
 :::tip
 
 On the [Paranodes](https://paranodes.io/DBSize) or [Stakeworld](https://stakeworld.io/docs/dbsize)
-websites you can find lists of the database sizes of Polkadot and Kusama nodes.
+websites, you can find lists of the database sizes of Polkadot and Kusama nodes.
 
 :::
 
@@ -47,34 +47,34 @@ scanners, discussion platforms like [Polkassembly](https://polkassembly.io), and
 to be able to look at past on-chain data.
 
 A **full node** prunes historical states: all finalized blocks' states older than a configurable
-number except the genesis block's state. This is 256 blocks from the last finalized one, by default.
-A node that is pruned this way requires much less space than an archive node.
+number except the genesis block's state. This is 256 blocks from the last finalized one by default.
+A pruned node this way requires much less space than an archive node.
 
-A full node may eventually be able to rebuild every block's state with no additional information,
-and become an archive node, but at the time of writing, this is not implemented. If you need to
-query historical blocks' states past what you pruned, you need to purge your database and resync
-your node starting in archive mode. Alternatively you can use a backup or snapshot of a trusted
-source to avoid needing to sync from genesis with the network, and only need the states of blocks
-past that snapshot.
+A full node could eventually rebuild every block's state without additional information and become
+an archive node. This still needs to be implemented at the time of writing. If you need to query
+historical blocks' states past what you pruned, you must purge your database and resync your node,
+starting in archive mode. Alternatively, you can use a backup or snapshot of a trusted source to
+avoid needing to sync from genesis with the network and only need the states of blocks past that
+snapshot.
 
 Full nodes allow you to read the current state of the chain and to submit and validate extrinsics
 directly on the network without relying on a centralized infrastructure provider.
 
-Another type of node is a **light node**. A light node has only the runtime and the current state,
+Another type of node is a **light node**. A light node has only the runtime and the current state
 but does not store past blocks and so cannot read historical data without requesting it from a node
-that has it. Light nodes are useful for resource restricted devices. An interesting use-case of
+that has it. Light nodes are useful for resource-restricted devices. An interesting use-case of
 light nodes is a browser extension, which is a node in its own right, running the runtime in WASM
-format as well as a full or light node that is completely encapsulated in WASM and can be integrated
-into webapps: https://github.com/paritytech/smoldot#wasm-light-node
+format, as well as a full or light node that is completely encapsulated in WASM and can be
+integrated into web apps: https://github.com/paritytech/smoldot#wasm-light-node.
 
 :::note Substrate Connect
 
 [Substrate Connect](https://github.com/paritytech/substrate-connect) provides a way to interact with
-substrate based blockchains in the browser without using an RPC server. It is a light node that runs
+substrate-based blockchains in the browser without using an RPC server. It is a light node that runs
 entirely in Javascript. Substrate Connect uses a
 [smoldot WASM light client](https://github.com/paritytech/smoldot) to securely connect to the
-blockchain network without relying on specific 3rd parties. Substrate Connect is available as a
-[browser extension](https://substrate.io/developers/substrate-connect/) on both Chrome and Firefox.
+blockchain network without relying on specific 3rd parties. Substrate Connect is available on Chrome
+and Firefox as a [browser extension](https://substrate.io/developers/substrate-connect/).
 
 :::
 
@@ -92,8 +92,7 @@ This is not recommended if you're a validator. Please see the
 :::note The bash commands that are provided to run against **your node** use `Polkadot` as the
 default chain
 
-Use the `--chain` flag if you are following the setup instructions to setup a `Kusama` node. For
-example:
+Use the `--chain` flag if you follow the setup instructions to setup a `Kusama` node. For example:
 
 ```bash
 ./target/release/polkadot --name "Your Node's Name" --chain kusama
@@ -326,11 +325,11 @@ The built binary will be in the `target/release` folder, called `polkadot`.
 ./target/release/polkadot --name "Your Node's Name"
 ```
 
-Use the `--help` flag to find out which flags you can use when running the node. For example, if
+Use the `--help` flag to determine which flags you can use when running the node. For example, if
 [connecting to your node remotely](maintain-wss.md), you'll probably want to use `--ws-external` and
 `--rpc-cors all`.
 
-The syncing process will take a while depending on your bandwidth, processing power, disk speed and
+The syncing process will take a while, depending on your capacity, processing power, disk speed and
 RAM. On a \$10 DigitalOcean droplet, the process can complete in some 36 hours.
 
 Congratulations, you're now syncing with Polkadot. Keep in mind that the process is identical when
@@ -338,8 +337,8 @@ using any other Substrate chain.
 
 ## Running an Archive Node
 
-When running as a simple sync node (above), only the state of the past 256 blocks will be kept. When
-validating, it defaults to [archive mode](#types-of-nodes). To keep the full state use the
+When running as a simple sync node (above), only the state of the past 256 blocks will be kept. It
+defaults to [archive mode](#types-of-nodes) when validating. To support the full state, use the
 `--pruning` flag:
 
 **Polkadot**:
@@ -350,16 +349,16 @@ validating, it defaults to [archive mode](#types-of-nodes). To keep the full sta
 
 It is possible to almost quadruple synchronization speed by using an additional flag:
 `--wasm-execution Compiled`. Note that this uses much more CPU and RAM, so it should be turned off
-after the node is in sync.
+after the node syncs.
 
 ## Using Docker
 
-Finally, you can use Docker to run your node in a container. Doing this is a bit more advanced so
-it's best left up to those that either already have familiarity with docker, or have completed the
-other set-up instructions in this guide. Be aware that when you run polkadot in docker the process
-only listen on localhost by default. If you would like to connect to your node's services (rpc,
-websockets, and prometheus) you need to ensure that you run you node with the `--rpc-external`,
-`--ws-external`, and `--prometheus-external` commands.
+Finally, you can use Docker to run your node in a container. Doing this is more advanced, so it's
+best left up to those already familiar with docker or who have completed the other set-up
+instructions in this guide. Be aware that when you run polkadot in docker, the process only listens
+on localhost by default. If you would like to connect to your node's services (rpc, websockets, and
+prometheus) you need to ensure that you run you node with the `--rpc-external`, `--ws-external`, and
+`--prometheus-external` commands.
 
 ```zsh
 docker run -p 9944:9944 -p 9615:9615 parity/polkadot:v0.9.13 --name "calling_home_from_a_docker_container" --rpc-external --ws-external --prometheus-external

--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -37,8 +37,8 @@ millionth block this was around 660 GB.
 
 :::tip
 
-The [Paranodes](https://paranodes.io/DBSize) website lists the database sizes of Polkadot and Kusama
-nodes in real-time.
+On the [Paranodes](https://paranodes.io/DBSize) or [Stakeworld](https://stakeworld.io/docs/dbsize)
+websites you can find lists of the database sizes of Polkadot and Kusama nodes.
 
 :::
 

--- a/docs/maintain/maintain-wss.md
+++ b/docs/maintain/maintain-wss.md
@@ -1,91 +1,19 @@
 ---
 id: maintain-wss
-title: Secure WebSocket
-sidebar_label: Secure WebSocket
+title: Secure the WebSocket
+sidebar_label: Secure the WebSocket
 description: Steps on setting up a secure socket for remote connections.
 keywords: [web socket, remote, connection, secure websocket]
 slug: ../maintain-wss
 ---
 
-The substrate node RPC server can be accessed over the websocket protocol, which can be used as a
-way to access the underlying network and/or validator node. By default you can access your node's
-RPC server from localhost (for example to rotate keys or do other maintenance). To access it from
-another server or from an applications UI (such as [Polkadot-JS UI](https://polkadot.js.org/apps))
-it is recommended to enable access to the RPC node over an TLS connection and as such encrypting the
-connection between the end user and the RPC server. This can be achieved by setting up a secure
-proxy. Many browsers such as Google Chrome will block non secure WS endpoints if they come from a
-different origin.
-
-:::note
-
-Enabling remote access to your validator node should not be necessary and is not suggested as it can
-often lead to security problems
-
-:::
-
-## Set up a node
-
-Setting up any Substrate-based node relies on a similar process. For example, they will all by
-default share the same websocket connection at port 9944 on localhost. In this example, we'll set up
-a polkadot sync node on a debian flavoured server (such as Ubuntu 22.04). Create a new server on
-your provider of choice or locally at home. See [Set up a Full Node](./maintain-sync) for additional
-instructions. You can choose to install from the default apt repository or build from scratch. The
-startup options in the setup process provide a variety of different settings that can be modified.
-
-A typically setting for an externally accessible polkadot archive RPC node would be:
-
-```config
-polkadot --chain polkadot --name myrpc --state-pruning archive --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
-```
-
-Or for a polkadot pruned RPC node:
-
-```config
-polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
-```
-
-The specified flag option are outlined in greater detail below.
-
-### Archive Node vs Pruned Node
-
-A pruned node only keeps a limited number of finalized blocks of the network and not its full
-history. Most frequently required actions can be completed with a pruned node, such as displaying
-account balances, making transfers, setting up session keys, staking, etc. An archive node has the
-full history (database) of the network and can be queried in all kind of ways, such as providing
-historical information regarding transfers, balance histories, and more advanced queries involving
-past events, etc.
-
-An archive node requires a lot more diskspace. At the start of January 2023, polkadot disk usage was
-at 115 GB for a pruned node and 765 GB for an archive node. This value will increase with time. For
-an archive node you need the options `--state-pruning archive --blocks-pruning archive` in your
-startup settings.
-
-:::tip
-
-Inclusion in the Polkadot.js UI requires an archive node.
-
-:::
-
-### Secure the RPC server
-
-The node startup settings allow you to choose **what** to expose, **how many** connections to expose
-and **from where** access should be granted through the rpc server.
-
-_How many_: You can set your maximum connections through `--ws-max-connections`, for example
-`--ws-max-connections 100`
-
-_From where_: by default localhost and the polkadot.js are allowed to access the RPC server, you can
-change this by setting `--rpc-cors`, to allow access from everywhere you need `--rpc-cors all`
-
-_What_: you can limit the methods to use with `--rpc-methods`, an easy way to set this to a safe
-mode is `--rpc-methods Safe`
-
-## Secure the ws port
+## Secure a ws port
 
 A non secure ws port can be converted to a secure wss port by placing it behind an SSL enabled
-proxy. The SSL enabled apache2/nginx/other proxy server redirects requests to the internal rpc node.
-For this you will need an SSL certificate. There are different strategies for obtaining a cert, such
-as using a service like letsencrypt or self signing.
+proxy. This can be used to secure a [bootnode](/docs/maintain-bootnode) or secure a
+[RPC server](/docs/maintain-rpc). The SSL enabled apache2/nginx/other proxy server redirects
+requests to the internal ws and converts it so a secure (wss) connection. For this you will need an
+SSL certificate for which you can use a service like letsencrypt or self signing.
 
 ### Obtaining an SSL Certificate
 

--- a/docs/maintain/maintain-wss.md
+++ b/docs/maintain/maintain-wss.md
@@ -7,13 +7,13 @@ keywords: [web socket, remote, connection, secure websocket]
 slug: ../maintain-wss
 ---
 
-## Secure a ws port
+## Secure a WS Port
 
-A non secure ws port can be converted to a secure wss port by placing it behind an SSL enabled
+A non-secure ws port can be converted to a secure wss port by placing it behind an SSL-enabled
 proxy. This can be used to secure a [bootnode](/docs/maintain-bootnode) or secure a
-[RPC server](/docs/maintain-rpc). The SSL enabled apache2/nginx/other proxy server redirects
-requests to the internal ws and converts it so a secure (wss) connection. For this you will need an
-SSL certificate for which you can use a service like letsencrypt or self signing.
+[RPC server](/docs/maintain-rpc). The SSL-enabled apache2/nginx/other proxy server redirects
+requests to the internal ws and converts it to a secure (wss) connection. For this, you will need an
+SSL certificate for which you can use a service like letsencrypt or self-signing.
 
 ### Obtaining an SSL Certificate
 
@@ -21,9 +21,9 @@ One easy way to get a free SSL certificate can be achieved by following the Lets
 ([nginx](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal)/[apache](https://certbot.eff.org/instructions?ws=apache&os=ubuntufocal)).
 This will auto-generate an SSL certificate and include it in your configuration.
 
-Alternatively you can generate a self-signed certificate and rely on the raw IP address of your node
-when connecting to it. This is not preferable since you will have to whitelist the certificate to
-access it from a browser.
+Alternatively, you can generate a self-signed certificate and rely on the raw IP address of your
+node when connecting to it. This is not preferable since you will have to whitelist the certificate
+to access it from a browser.
 
 ```bash
 sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/selfsigned.key -out /etc/ssl/certs/selfsigned.crt
@@ -32,7 +32,7 @@ sudo openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
 
 ## Installing a Proxy Server
 
-There are a lot of different implementations of a websocket proxy, some of the more widely used are
+There are a lot of different implementations of a WebSocket proxy, some of the more widely used are
 [nginx](https://www.nginx.com/) and [apache2](https://httpd.apache.org/), for which configuration
 examples provided below.
 
@@ -42,7 +42,7 @@ examples provided below.
 apt install nginx
 ```
 
-In a SSL enabled virtualhost add:
+In an SSL-enabled virtual host add:
 
 ```conf
 server {
@@ -75,7 +75,7 @@ location / {
 
 ### Apache2
 
-You can run it in different modes such as prefork, worker or event. In this example, we use
+You can run it in different modes such as prefork, worker, or event. In this example, we use
 [event](https://httpd.apache.org/docs/2.4/mod/event.html) which works well on higher load
 environments but other modes are also useful given the requirements.
 
@@ -86,8 +86,8 @@ a2enmod mpm_event proxy proxy_html proxy_http proxy_wstunnel rewrite ssl
 ```
 
 The [mod_proxy_wstunnel](https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html) provides
-_support for the tunnelling of web socket connections to a backend websockets server. The connection
-is automatically upgraded to a websocket connection_. In a SSL enabled virtualhost add:
+_support for the tunneling of web socket connections to a backend websockets server. The connection
+is automatically upgraded to a WebSocket connection_. In an SSL-enabled virtualhost add:
 
 ```apacheconf
 (...)

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -256,8 +256,10 @@ module.exports = {
           label: "Nodes and Dapps",
           items: [
             "maintain/maintain-sync",
-            "maintain/maintain-networks",
+            "maintain/maintain-bootnode",
+            "maintain/maintain-rpc",
             "maintain/maintain-wss",
+            "maintain/maintain-networks",
             "maintain/maintain-errors",
           ],
         },


### PR DESCRIPTION
Hi, I have added a bootnode setup page, split the rpc from the maintain-wss page (since it is technically another subject) and made reference to the wss page from the rpc and bootnode page. Also made a reference to my database sizes page on the full node page if thats ok. 

Let me know if you have remarks or comments