### PR TITLE
Update information about testnets

### DIFF
--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -150,6 +150,11 @@ obtain ROC by posting `!drip <ROCOCO_ADDRESS>` in the Matrix chatroom
 [#rococo-faucet:matrix.org](https://matrix.to/#/#rococo-faucet:matrix.org). Learn more about Rococo
 on its [dedicated wiki section](../build/build-parachains.md##testing-a-parachains:-rococo-testnet).
 
+### Getting Tokens on the Wococo Testnet
+
+Wococo is a bridge testnet. General users can obtain WOOK by posting `!drip <WOCOCO_ADDRESS>` in the
+Matrix chatroom [#wococo-faucet:matrix.org](https://matrix.to/#/#wococo-faucet:matrix.org).
+
 ## Kusama Tokens
 
 Unlike testnet DOT, Kusama tokens are not freely given away. Kusama tokens are available via the

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -686,6 +686,23 @@ The Thousand Validators Programme is a joint initiative by Web3 Foundation and P
 to provide support for community validators. If you are interested in applying for the programme,
 you can find more information [on the wiki page](../general/thousand-validators.md).
 
+## Running a validator on a testnet
+
+To verify your validator set up, it is possible to run it against a PoS test network such as Westend
+or Wococo. However, validator slots are intentionally limited on Westend to ensure the stability and
+availability of the testnet for the Polkadot release process. As such it is advised for node
+operators wishing to run testnet validators to join the Wococo network. You can obtain WOOK tokens
+[here](../learn/learn-DOT.md#getting-tokens-on-the-wococo-testnet).
+
+Here is a small comparison of each network characteristics as relevant to validators:
+
+| Network           | Polkadot | Westend    | Wococo      |
+| ----------------- | -------- | ---------- | ----------- |
+| epoch             | 4h       | 1h         | 10m         |
+| era               | 1d       | 6h         | 1h          |
+| token             | DOT      | WND (test) | WOOK (test) |
+| active validators | ~300     | ~20        | 10<x<100    |
+
 ## FAQ
 
 ### Why am I unable to synchronize the chain with 0 peers?

--- a/docs/maintain/maintain-networks.md
+++ b/docs/maintain/maintain-networks.md
@@ -12,14 +12,14 @@ is to allow for connection to different networks using a single executable and c
 start-up flag. Here are some of the networks associated with Polkadot or Substrate that you may want
 to connect to and join.
 
-## Polkadot networks
+## Main networks
 
 To connect to a Polkadot network please follow the [instructions](maintain-sync.md) for installing
 the Polkadot executable.
 
 ### Polkadot Mainnet
 
-Currently Polkadot is built from the tip of master and is the default option when starting a node.
+Connecting to the Polkadot network is the default option when starting a node.
 
 To start a Polkadot node, run the Polkadot binary:
 
@@ -30,8 +30,8 @@ polkadot
 and you will connect and start syncing to Polkadot.
 
 Check your node is connected by viewing it on
-[Telemetry](https://telemetry.polkadot.io/#/Polkadot%20CC3) (you can set a custom name by specifying
-`--name "my custom name"`)
+[Telemetry](https://telemetry.polkadot.io/#list/0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3)
+(you can set a custom node name by specifying `--name "my-custom-node-name"`)
 
 ### Kusama Canary Network
 
@@ -46,13 +46,15 @@ polkadot --chain=kusama
 and you will connect and start syncing to Kusama.
 
 Check your node is connected by viewing it on
-[Telemetry](https://telemetry.polkadot.io/#/Kusama%20CC3) (you can set a custom name by specifying
-`--name "my custom name"`)
+[Kusama Telemetry](https://telemetry.polkadot.io/#list/0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe)
+(you can set a custom node name by specifying `--name "my-custom-node-name"`)
+
+## Test Networks
 
 ### Westend Test Network
 
-Westend is the latest test network for Polkadot. The tokens on this network are called _Westies_ and
-they purposefully hold no economic value.
+Westend is the primary test network of Polkadot. The tokens on this network are called _Westies_
+(WND) and they purposefully hold no economic value.
 
 Run the Polkadot binary and specify `westend` as the chain:
 
@@ -63,15 +65,59 @@ polkadot --chain=westend
 and you will connect and start syncing to Westend.
 
 Check that your node is connected by viewing it on
-[Telemetry](https://telemetry.polkadot.io/#list/Westend) (you can set a custom name by specifying
-`--name "my custom name"`).
+[Westend Telemetry](https://telemetry.polkadot.io/#list/0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e)
+(you can set a custom node name by specifying `--name "my-custom-node-name"`).
 
 #### Westend Faucet
 
-Follow the instruction [here](../learn/learn-DOT.md#getting-westies) for instructions on acquiring
-Westies.
+Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-westend-testnet) to get
+Westies (WND) tokens.
 
-### Differences
+### Rococo Test Network
+
+[Rococo](https://substrate.io/developers/rococo-network/) is a test network built for parachains.
+The native token of this network (ROC) holds no economic value.
+
+Run the Polkadot binary and specify `rococo` as the chain:
+
+```bash
+polkadot --chain=rococo
+```
+
+and you will connect and start syncing to Rococo.
+
+Check that your node is connected by viewing it on
+[Rococo Telemetry](https://telemetry.polkadot.io/#list/0x6408de7737c59c238890533af25896a2c20608d8b380bb01029acb392781063e)
+(you can set a custom node name by specifying `--name "my-custom-node-name"`).
+
+#### Rococo Faucet
+
+Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-rococo-testnet) to get
+ROCs tokens.
+
+### Wococo Test Network
+
+Wococo is a test network of Polkadot built for bridges. The native token of this network (WOOK)
+holds no economic value.
+
+Run the Polkadot binary and specify `rococo` as the chain:
+
+```bash
+polkadot --chain=wococo
+```
+
+and you will connect and start syncing to Wococo.
+
+Check that your node is connected by viewing it on
+[Wococo Telemetry](https://telemetry.polkadot.io/#list/0xdb4fd29dd914017e9dda3b751d6a4e0c5ca28cce7b6260cb063936633cc8175c)
+(you can set a custom node name by specifying `--name "my-custom-node-name"`).
+
+#### Wococo Faucet
+
+Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-wococo-testnet) to get
+WOOKs tokens.
+
+## Differences
 
 Runtime differences (e.g. existential and multisignature deposit sizes) between the different
 networks can be found by doing a `diff` between the `src/lib.rs` of the repositories. For example,
@@ -86,28 +132,6 @@ You can also paste the runtimes
 [Westend](https://github.com/paritytech/polkadot/blob/master/runtime/westend/src/lib.rs)) into a
 web-based diff tool like [Diffchecker](https://www.diffchecker.com/) if you're not comfortable with
 the CLI.
-
-## Substrate Networks
-
-To connect to a Substrate public network, follow the
-[instructions](https://docs.substrate.io/v3/getting-started/overview/) for installing the Substrate
-executable first.
-
-### Flaming Fir
-
-Flaming Fir is the public Substrate test network. It contains some pallets that will not be included
-in the Polkadot runtime.
-
-Flaming Fir is built from the tip of master and is the default option when running the Substrate
-executable.
-
-Run Substrate without a flag or explicitly state `fir`:
-
-```bash
-substrate --chain fir
-```
-
-and you will connect and start syncing Flaming Fir.
 
 ## Telemetry Dashboard
 


### PR DESCRIPTION
- Remove flaming fir docs as the network is no longer operating
- Fix networks telemetry links (use genesis hash anchor)
- Add Wococo testnet information
- Add section recommending joining Wococo for testnet validators

Note: the command `polkadot --chain=wococo` is broken on version 0.9.42 but will be fixed on the next-release (0.9.43). I'm keeping this PR as draft while waiting for the release.