### PR TITLE
Update build-protocol-info.md

### DIFF
--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -8,6 +8,8 @@ keywords: [build, protocol, extrinsics, events, transaction]
 slug: ../build-protocol-info
 ---
 
+import RPC from "./../../components/RPC-Connection";
+
 This page serves as a high-level introduction to the Polkadot protocol with terminology that may be
 specific to Polkadot, notable differences to other chains that you may have worked with, and
 practical information for dealing with the chain.
@@ -77,11 +79,11 @@ order to reduce the public key from 33 bytes to 32 bytes.
 
 Polkadot, and most Substrate-based chains, use an _existential deposit_ (ED) to prevent dust
 accounts from bloating chain state. If an account drops below the ED, it will be _reaped,_ i.e.
-completely removed from storage and the nonce reset. Polkadot's ED is 
-{{ polkadot: <RPC network="polkadot" path="consts.balances.existentialDeposit" defaultValue={10000000000} filter="humanReadable"/>. :polkadot }}
-{{  polkadot: <RPC network="polkadot" path="consts.balances.existentialDeposit" defaultValue={10000000000} filter="humanReadable"/>. :polkadot }}, while Kusama's is
-{{ kusama: <RPC network="kusama" path="consts.balances.existentialDeposit" defaultValue={333333333} filter="humanReadable"/>. :kusama }}
-{{ kusama: <RPC network="kusama" path="consts.balances.existentialDeposit" defaultValue={333333333} filter="humanReadable"/>. :kusama }} You can always verify the existential deposit by checking the
+completely removed from storage and the nonce reset. Polkadot's ED is
+<RPC network="polkadot" path="consts.balances.existentialDeposit" defaultValue={10000000000} filter="humanReadable"/>,
+while Kusama's is
+<RPC network="kusama" path="consts.balances.existentialDeposit" defaultValue={333333333} filter="humanReadable"/>.
+You can always verify the existential deposit by checking the
 [chain state](https://polkadot.js.org/apps/#/chainstate) for the constant
 `balances.existentialDeposit`.
 

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -78,7 +78,7 @@ order to reduce the public key from 33 bytes to 32 bytes.
 Polkadot, and most Substrate-based chains, use an _existential deposit_ (ED) to prevent dust
 accounts from bloating chain state. If an account drops below the ED, it will be _reaped,_ i.e.
 completely removed from storage and the nonce reset. Polkadot's ED is 1 DOT, while Kusama's is
-33.3333 microKSM (0.0000333333 KSM). You can always verify the existential deposit by checking the
+333.3333 microKSM (0.0003333333 KSM). You can always verify the existential deposit by checking the
 [chain state](https://polkadot.js.org/apps/#/chainstate) for the constant
 `balances.existentialDeposit`.
 

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -77,8 +77,11 @@ order to reduce the public key from 33 bytes to 32 bytes.
 
 Polkadot, and most Substrate-based chains, use an _existential deposit_ (ED) to prevent dust
 accounts from bloating chain state. If an account drops below the ED, it will be _reaped,_ i.e.
-completely removed from storage and the nonce reset. Polkadot's ED is 1 DOT, while Kusama's is
-333.3333 microKSM (0.0003333333 KSM). You can always verify the existential deposit by checking the
+completely removed from storage and the nonce reset. Polkadot's ED is 
+{{ polkadot: <RPC network="polkadot" path="consts.balances.existentialDeposit" defaultValue={10000000000} filter="humanReadable"/>. :polkadot }}
+{{  polkadot: <RPC network="polkadot" path="consts.balances.existentialDeposit" defaultValue={10000000000} filter="humanReadable"/>. :polkadot }}, while Kusama's is
+{{ kusama: <RPC network="kusama" path="consts.balances.existentialDeposit" defaultValue={333333333} filter="humanReadable"/>. :kusama }}
+{{ kusama: <RPC network="kusama" path="consts.balances.existentialDeposit" defaultValue={333333333} filter="humanReadable"/>. :kusama }} You can always verify the existential deposit by checking the
 [chain state](https://polkadot.js.org/apps/#/chainstate) for the constant
 `balances.existentialDeposit`.
 


### PR DESCRIPTION
This fixes an incorrect amount for the existential deposit of Kusama in the wiki.

For reference, taking a look at
https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/lib.rs
```
    /// The existential deposit.
    pub const EXISTENTIAL_DEPOSIT: Balance = 1 * CENTS;

    pub const UNITS: Balance = 1_000_000_000_000;
    pub const QUID: Balance = UNITS / 30;
    pub const CENTS: Balance = QUID / 100;
```
and at
https://github.com/paritytech/polkadot/blob/master/node/service/chain-specs/kusama.json
```
    "tokenDecimals": 12,
```
We can see that the minimum reserve is 0.0003333333333333333 KSM:
EXISTENTIAL_DEPOSIT = 1 * CENTS = QUID / 100 = UNITS / 30 / 100 = 1_000_000_000_000 / 30 / 100
And that ^ divided by 1e12 yields the result.