### PR TITLE
Fixing links

### DIFF
--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -71,12 +71,10 @@ you face any issues, join the rooms individually.
 
 ### Technical
 
-- [**Substrate Developers Public Space**](https://matrix.to/#/#substrate-builders-space:matrix.parity.io) -
-  Curated collection of rooms around all things Substrate. Contains the two below and many others.
 - [Substrate and Polkadot StackExchange](https://substrate.stackexchange.com/) - More advanced room
   for technical questions on building with Substrate.
-- [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:matrix.parity.io) - A room to discuss
-  developing Substrate smart contracts using Parity Ink!
+- [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:parity.io) - A room to discuss developing
+  Substrate smart contracts using Parity Ink!
 
 ## Socials
 

--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -71,6 +71,8 @@ you face any issues, join the rooms individually.
 
 ### Technical
 
+- [Substrate Developers Chat](https://matrix.to/#/#substratedevs:matrix.org) - A Matrix chat room
+  for Substrate development.
 - [Substrate and Polkadot StackExchange](https://substrate.stackexchange.com/) - More advanced room
   for technical questions on building with Substrate.
 - [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:parity.io) - A room to discuss developing

--- a/docs/general/kusama/kusama-community.md
+++ b/docs/general/kusama/kusama-community.md
@@ -52,8 +52,8 @@ application we use most often to interact with the Matrix protocol is the
 
 - [Substrate and Polkadot StackExchange](https://substrate.stackexchange.com/) - More advanced room
   for technical questions on building with Substrate.
-- [Smart Contracts & Parity Ink!](https://app.element.io/#/room/!tYUCYdSvSYPMjWNDDD:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=web3.foundation) -
-  A room to discuss developing Substrate smart contracts using Parity Ink!
+- [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:parity.io) - A room to discuss developing
+  Substrate smart contracts using Parity Ink!
 
 ## Social
 

--- a/docs/learn/learn-treasury.md
+++ b/docs/learn/learn-treasury.md
@@ -301,7 +301,7 @@ requested allocation (including curator's fee) and confirm the call.
 
 After this, a Council member will need to assist you to pass the bounty proposal for vote as a
 motion. You can contact the Council by joining the
-{{ polkadot: Polkadot Direction [channel](https://matrix.to/#/#polkadot-direction:matrix.parity.io) :polkadot }}
+{{ polkadot: Polkadot Direction [channel](https://matrix.to/#/#Polkadot-Direction:parity.io) :polkadot }}
 {{ kusama: Kusama Direction [channel](https://matrix.to/#/#Kusama-Direction:parity.io) :kusama }} in
 Element or joining our
 {{ polkadot: Polkadot Discord [server](https://parity.link/polkadot-discord) :polkadot }}


### PR DESCRIPTION
Addresses #4840 

- Fixed nameservers of a couple of links
- Removed - [**Substrate Developers Public Space**](https://matrix.to/#/#substrate-builders-space:parity.io), as it seems there is no suitable replacement.  Added https://matrix.to/#/#substratedevs:matrix.org as a placeholder for now.
