### PR TITLE
Fix locking period table

### DIFF
--- a/components/Voluntary-Locking.jsx
+++ b/components/Voluntary-Locking.jsx
@@ -77,7 +77,7 @@ const ksmLocking = {
 	p32: 256
 }
 
-function VoluntaryLocking({ network }) {
+function VoluntaryLocking() {
 	const [docType, setDocType] = useState("");
 
 	useEffect(() => {
@@ -86,9 +86,9 @@ function VoluntaryLocking({ network }) {
 		// can't be used to render a table (can't put a <table> in a <p>).
 		// So, we use the same component for Polkadot and Kusama and figure it out here.
 		const title = document.title;
-		if (title === "Governance · Polkadot Wiki" || title === "OpenGov · Polkadot Wiki") {
+		if (title === "Governance V1 · Polkadot Wiki" || title === "OpenGov · Polkadot Wiki") {
 			updateTable("polkadot")
-		} else if (title === "Governance · Guide" || title === "OpenGov · Guide") {
+		} else if (title === "Governance V1 · Guide" || title === "OpenGov · Guide") {
 			updateTable("kusama");
 		} else {
 			console.log("Unknown wiki/guide type");

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -329,8 +329,7 @@ votes = tokens * conviction_multiplier
 The conviction multiplier increases the vote multiplier by one every time the number of lock periods
 double.
 
-{{ polkadot: <VLTable network="polkadot"/> :polkadot }}
-{{ kusama: <VLTable network="kusama"/> :kusama }}
+<VLTable />
 
 The maximum number of "doublings" of the lock period is set to 6 (and thus 32 lock periods in
 total), and one lock period equals


### PR DESCRIPTION
Closes #4892 

- Removed unneeded conditional render (relying on page title for now, because we added 'V1' to titles)
- Ensured both Polkadot and Kusama render respective tables