### PR TITLE
Update Link for Learn Nav

### DIFF
--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -210,7 +210,7 @@ module.exports = {
           position: "right",
         },
         {
-          to: "docs/learn-launch",
+          to: "docs/learn-DOT",
           label: "Learn",
           position: "right",
         },

--- a/polkadot-wiki/pages/en/index.js
+++ b/polkadot-wiki/pages/en/index.js
@@ -48,7 +48,7 @@ class HomeNav extends React.Component {
           aosDelay="0"
         />
         <NavItem
-          href={this.props.docUrl("learn-launch")}
+          href={this.props.docUrl("learn-DOT")}
           content="Polkadot is a sharded protocol that enables blockchain networks to operate together seamlessly."
           title="Learn"
           aosDelay="300"

--- a/polkadot-wiki/src/pages/index.js
+++ b/polkadot-wiki/src/pages/index.js
@@ -41,7 +41,7 @@ function HomeNav() {
 
   return (
     <NavContainer>
-      <NavItem href={useDocUrl("getting-started")} aosDelay="0">
+      <NavItem href={useDocUrl("learn-DOT")} aosDelay="0">
         <NavItemContent>
           <NavItemTitle>
             <Translate


### PR DESCRIPTION
- Interim redirect from `learn-launch` to `learn-DOT` while we define an intro page for the "Learn" section of the Wiki.
- Also changed the front "Learn" card to match for consistency.