### PR TITLE
Updating faucets info

### DIFF
--- a/docs/build/build-parachains.md
+++ b/docs/build/build-parachains.md
@@ -344,7 +344,7 @@ proposed parachains is available
 
 ### Obtaining ROC
 
-Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-rococo-testnet) to get
+Follow the instructions [here](../learn/learn-DOT.md#getting-tokens-on-the-rococo-testnet) to get
 ROCs tokens.
 
 ### Build and Register a Rococo Parathread

--- a/docs/build/build-parachains.md
+++ b/docs/build/build-parachains.md
@@ -344,12 +344,8 @@ proposed parachains is available
 
 ### Obtaining ROC
 
-ROC are available in the [Rococo Faucet](https://app.element.io/#/room/#rococo-faucet:matrix.org)
-channel on Matrix. To receive ROC tokens, use the command:
-
-```
-!drip YOUR_ROCOCO_ADDRESS
-```
+Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-rococo-testnet) to get
+ROCs tokens.
 
 ### Build and Register a Rococo Parathread
 

--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -3,7 +3,7 @@ id: learn-DOT
 title: DOT
 sidebar_label: DOT
 description: Learn about the tokenomics of the Polkadot ecosystem.
-keywords: [token, DOT, what are the uses of DOT, KSM]
+keywords: [token, DOT, what are the uses of DOT, KSM, faucet]
 slug: ../learn-DOT
 ---
 
@@ -129,6 +129,9 @@ Matrix chatroom [#westend_faucet:matrix.org](https://matrix.to/#/#westend_faucet
 account will be credited with 1 WND by default. You can also specify to get more tokens by
 `!drip <WESTEND_ADDRESS> X`, where X is the number of tokens.
 
+Another way is to use our web-based
+[Westend faucet](https://paritytech.github.io/polkadot-testnet-faucet/westend).
+
 You can also earn WNDs as rewards by [becoming a validator](learn-validator.md) on Westend network.
 Watch the video below on how to get started on Westend.
 
@@ -150,10 +153,20 @@ obtain ROC by posting `!drip <ROCOCO_ADDRESS>` in the Matrix chatroom
 [#rococo-faucet:matrix.org](https://matrix.to/#/#rococo-faucet:matrix.org). Learn more about Rococo
 on its [dedicated wiki section](../build/build-parachains.md##testing-a-parachains:-rococo-testnet).
 
+Another way is to use our web-based
+[Rococo faucet](https://paritytech.github.io/polkadot-testnet-faucet/).
+
 ### Getting Tokens on the Wococo Testnet
 
 Wococo is a bridge testnet. General users can obtain WOOK by posting `!drip <WOCOCO_ADDRESS>` in the
 Matrix chatroom [#wococo-faucet:matrix.org](https://matrix.to/#/#wococo-faucet:matrix.org).
+
+### Faucets support
+
+If you require help with using faucets, or wish to report an issue, there is a support chat
+[#faucets-support:matrix.org](https://matrix.to/#/#faucets-support:matrix.org), or you can
+[create an issue](https://github.com/paritytech/polkadot-testnet-faucet/issues/new/choose) directly
+in the faucets repo
 
 ## Kusama Tokens
 

--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -148,13 +148,11 @@ Watch the video below on how to get started on Westend.
 ### Getting Tokens on the Rococo Testnet
 
 Rococo is a parachain testnet. Tokens are given directly to teams working on parachains or exploring
-the [cross consensus](learn-xcm.md) message passing aspects of this testnet. General users can
+the [cross consensus](learn-xcm.md) message-passing aspects of this testnet. General users can
 obtain ROC by posting `!drip <ROCOCO_ADDRESS>` in the Matrix chatroom
-[#rococo-faucet:matrix.org](https://matrix.to/#/#rococo-faucet:matrix.org). Learn more about Rococo
-on its [dedicated wiki section](../build/build-parachains.md##testing-a-parachains:-rococo-testnet).
-
-Another way is to use our web-based
-[Rococo faucet](https://paritytech.github.io/polkadot-testnet-faucet/).
+[#rococo-faucet:matrix.org](https://matrix.to/#/#rococo-faucet:matrix.org) or through the web-based
+[Rococo faucet](https://paritytech.github.io/polkadot-testnet-faucet/). Learn more about Rococo on
+its [dedicated wiki section](../build/build-parachains.md##testing-a-parachains:-rococo-testnet).
 
 ### Getting Tokens on the Wococo Testnet
 


### PR DESCRIPTION
1. Added links to web-based faucets
2. Added link to faucets support chat
3. Changed `build-parachains.md` in the same way how `maintain-networks.md` is written, to concentrate all info regarding testnet tokens on the same page, and direct links there.