### PR TITLE
Wiki Reorg: Cards for General Section

### DIFF
--- a/docs/general/contributing.md
+++ b/docs/general/contributing.md
@@ -1,7 +1,7 @@
 ---
 id: contributing
-title: Contributing
-sidebar_label: Contributing
+title: Contributing to the Polkadot Wiki
+sidebar_label: Contributing to the Wiki
 description:
   Steps on how to contribute to the Polkadot Wiki and the code of conduct to keep in mind.
 keywords: [contributing, contributions, translations]

--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -2,7 +2,7 @@
 id: getting-started
 title: Getting Started
 sidebar_label: Getting Started
-description: Get started with Polkadot.
+description: Get started with Polkadot and Web3.
 keywords: [introduction, getting started, what is polkadot, why polkadot]
 slug: ../getting-started
 ---

--- a/docs/general/polkadotjs.md
+++ b/docs/general/polkadotjs.md
@@ -2,7 +2,7 @@
 id: polkadotjs
 title: Polkadot-JS
 sidebar_label: Polkadot-JS
-description: Learn about PolkadotJS
+description: Learn about the Polkadot-JS tool collection.
 keywords: [polkadotjs, polkadotjs apps, apps UI, extension]
 slug: ../polkadotjs
 ---

--- a/docs/general/staking-dashboard.md
+++ b/docs/general/staking-dashboard.md
@@ -2,7 +2,7 @@
 id: staking-dashboard
 title: Polkadot Staking Dashboard
 sidebar_label: Staking Dashboard
-description: Everything about the Polkadot Staking Dashboard
+description: Everything about the Polkadot Staking Dashboard.
 keywords: [ledger, staking, polkadot, dashboard]
 slug: ../staking-dashboard
 ---

--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -225,7 +225,7 @@ module.exports = {
       },
       items: [
         {
-          to: "docs/getting-started",
+          to: "/docs/general",
           label: "Get Started",
           position: "right",
         },

--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -226,7 +226,7 @@ module.exports = {
       items: [
         {
           to: "/docs/general",
-          label: "Get Started",
+          label: "General",
           position: "right",
         },
         {

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -3,11 +3,24 @@ module.exports = {
     {
       type: "category",
       label: "General",
+      link: {
+        type: 'generated-index',
+        title: 'General Information',
+        description: 'General Information to get started with Polkadot & Web3.',
+        slug: '/general',
+      },
       items: [
         "general/getting-started",
         {
           type: "category",
           label: "Stay Safe",
+          description: 'Good-practices to stay safe while surfing in Web3.',
+          link: {
+            type: 'generated-index',
+            title: 'Stay Safe',
+            description: 'Learn about good-practices to stay safe while surfing in Web3.',
+            slug: '/stay-safe',
+          },
           items: [
             "general/scams",
             "general/how-to-dyor",
@@ -16,6 +29,7 @@ module.exports = {
         {
           type: "category",
           label: "Wallets",
+          description: 'Wallet options in the Polkadot and Kusama ecosystems.',
           link: {
             type: 'generated-index',
             title: 'Wallets',
@@ -34,6 +48,13 @@ module.exports = {
         {
           type: "category",
           label: "Community & Contributors",
+          description: 'Participate in the Polkadot community and contribute to the Wiki.',
+          link: {
+            type: 'generated-index',
+            title: 'Community & Contributors',
+            description: 'Learn about how to participate in the Polkadot community and how to contribute to the Polkadot Wiki.',
+            slug: '/community-and-contributors',
+          },
           items: [
             "general/community",
             "general/contributing",
@@ -43,6 +64,13 @@ module.exports = {
         {
           type: "category",
           label: "Programmes",
+          description: 'Programmes and initiatives within the Polkadot ecosystem.',
+          link: {
+            type: 'generated-index',
+            title: 'Programmes',
+            description: 'Learn about different programmes and initiatives within the Polkadot and Kusama ecosystems.',
+            slug: '/programmes',
+          },
           items: [
             "general/grants",
             "general/bug-bounty",

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -43,7 +43,20 @@ module.exports = {
             "general/polkadotjs-ui",
           ],
         },
-        "general/staking-dashboard",
+        {
+          type: "category",
+          label: "Dashboards",
+          description: 'Dashboards in the Polkadot and Kusama ecosystems.',
+          link: {
+            type: 'generated-index',
+            title: 'Dashboards',
+            description: 'Explore the different dashboards in the Polkadot and Kusama ecosystems.',
+            slug: '/dashboards',
+          },
+          items: [
+            "general/staking-dashboard",
+          ],
+        },
         "general/polkadotjs",
         {
           type: "category",


### PR DESCRIPTION
See [this issue](https://github.com/w3f/polkadot-wiki/issues/4376) and [this google doc](https://docs.google.com/document/d/1Fl8ReBIzcaQEOyF6s03d7MEcgk8aTVEt7xjmzAk_k5I/edit) for more information about the Wiki reorg.

This PR should improve navigation for the general section. If successful, the same will be applied to the other sections in the wiki. I also added a "Dashboard" category as we will likely create a page for the delegation dashboard :)