### PR TITLE
added custom id for reference hardware

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -91,7 +91,7 @@ choose whatever [VPS](#note-about-vps) provider that your prefer. As OS it is be
 Debian Linux. For this guide we will be using **Ubuntu 22.04**, but the instructions should be
 similar for other platforms.
 
-#### Reference Hardware
+#### Reference Hardware {#standard-hardware}
 
 The transaction weights in Polkadot are benchmarked on reference hardware. We ran the benchmark on
 VM instances of two major cloud providers: Google Cloud Platform (GCP) and Amazon Web Services


### PR DESCRIPTION
Closes #4949

Adds a custom id, so that `#standard-hardware` is a valid link