### PR TITLE
Update community.md and add telegram link for substrate devs

### DIFF
--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -79,6 +79,8 @@ you face any issues, join the rooms individually.
 
 - [Substrate Developers Chat](https://matrix.to/#/#substratedevs:matrix.org) - A Matrix chat room
   for Substrate development.
+- [Substrate Developers Telegram Chat](https://t.me/substratedevs) - A Telegram chat room
+  for Substrate development.
 - [Substrate and Polkadot StackExchange](https://substrate.stackexchange.com/) - More advanced room
   for technical questions on building with Substrate.
 - [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:parity.io) - A room to discuss developing

--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -80,7 +80,7 @@ you face any issues, join the rooms individually.
 - [Substrate Developers Chat](https://matrix.to/#/#substratedevs:matrix.org) - A Matrix chat room
   for Substrate development.
 - [Substrate Developers Telegram Chat](https://t.me/substratedevs) - A Telegram chat room
-  for Substrate development.
+  for Substrate development, bridged to Matrix chat room linked above.
 - [Substrate and Polkadot StackExchange](https://substrate.stackexchange.com/) - More advanced room
   for technical questions on building with Substrate.
 - [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:parity.io) - A room to discuss developing

--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -80,7 +80,7 @@ you face any issues, join the rooms individually.
 - [Substrate Developers Chat](https://matrix.to/#/#substratedevs:matrix.org) - A Matrix chat room
   for Substrate development.
 - [Substrate Developers Telegram Chat](https://t.me/substratedevs) - A Telegram chat room
-  for Substrate development, bridged to Matrix chat room linked above.
+  for Substrate development, bridged to Matrix Substrate Developers Chat linked above.
 - [Substrate and Polkadot StackExchange](https://substrate.stackexchange.com/) - More advanced room
   for technical questions on building with Substrate.
 - [Smart Contracts & Parity Ink!](https://matrix.to/#/#ink:parity.io) - A room to discuss developing


### PR DESCRIPTION
add telegram link for substrate devs

**Note** : the telegram channel is bridged to the element matrix channels, so same content is synced in both channels.

