### PR TITLE
Add Mermaid.js Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     - [Deployments](#deployments)
     - [GitHub Actions](#github-actions)
   - [Conditional Rendering](#conditional-rendering)
+  - [Mermaid JS Diagrams](#mermaid-js-diagrams)
   - [Inline React Components](#inline-react-components)
 - [Internationalization](#internationalization)
 - [License](#license)
@@ -233,6 +234,29 @@ To verify the appropriate values have been substituted in each scenario, run `po
 `[WARNING] Something is already running on port 3000. Would you like to run the app on another port instead?`,
 proceed with `yes`. This will likely launch one project on port 3000 and the other on 3001, allowing
 you to compare the rendered outputs for both projects locally and simultaneously.
+
+### Mermaid JS Diagrams
+
+This repository supports [Mermaid.js diagrams](https://mermaid.js.org/). Most graph types are
+supported, except for the asynchronous graphs which may be unstable at this time.
+
+Example:
+
+```mermaid
+---
+title: Staking Proxies
+---
+flowchart LR
+    subgraph PT1[Staking Proxies]
+        direction LR
+        dan[Dan's Proxy] ==> charly[Charly]
+    end
+    subgraph PT2[Dan's Proxy]
+        dan2[Dan] ==> pure[Pure Proxy]
+    end
+    PT2== Proxy-based Staking ==>PT1
+
+```
 
 ### Inline React Components
 

--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -201,13 +201,17 @@ module.exports = {
       theme: { light: 'base', dark: 'base' },
       options: {
         themeVariables: {
+          htmlLabels: false,
           fontFamily: 'Unbounded',
-          primaryColor: '#E6007A',
+          fontSize: '20px',
+          primaryColor: '#321D48',
+          background: '#321D48',
           primaryTextColor: '#fff',
           primaryBorderColor: '#E6007A',
           lineColor: '#140523',
-          secondaryColor: '#552BBF',
-          tertiaryColor: '#00B2FF'
+          titleColor: "#fff",
+          secondaryColor: '#321D48',
+          tertiaryColor: '#E6007A'
           }
         },
       },

--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -197,6 +197,20 @@ module.exports = {
     ],
   ],
   themeConfig: {
+    mermaid: {
+      theme: { light: 'base', dark: 'base' },
+      options: {
+        themeVariables: {
+          fontFamily: 'Unbounded',
+          primaryColor: '#E6007A',
+          primaryTextColor: '#fff',
+          primaryBorderColor: '#E6007A',
+          lineColor: '#140523',
+          secondaryColor: '#552BBF',
+          tertiaryColor: '#00B2FF'
+          }
+        },
+      },
     colorMode: {
       disableSwitch: true,
     },

--- a/polkadot-wiki/static/css/custom.css
+++ b/polkadot-wiki/static/css/custom.css
@@ -755,4 +755,15 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 
 .docusaurus-mermaid-container {
   text-align: center;
+  background-color: #e6007a;
+}
+
+.docusaurus-mermaid-container svg {
+  width: 100%;
+}
+
+.docusaurus-mermaid-container .edgeLabel {
+  font-size: 16px;
+  padding: 10px;
+  border-radius: 10px;
 }

--- a/polkadot-wiki/static/css/custom.css
+++ b/polkadot-wiki/static/css/custom.css
@@ -752,3 +752,7 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     max-width: 1140px;
   }
 }
+
+.docusaurus-mermaid-container {
+  text-align: center;
+}


### PR DESCRIPTION
As part of an effort to unify graphics, mermaid can be used.  This PR adds a basic theme for mermaid js diagrams.  

## todo
- [ ] test with multiple types of graphics
- [ ] Add Kusama theme