### PR TITLE
Fixed polkadot node binaries path in wsl command

### DIFF
--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -204,7 +204,7 @@ value: 'linux-package'} ]}>
 - Start your node:
 
   ```bash
-  ./target/release/polkadot --name "Your Node's Name"
+  ./polkadot --name "Your Node's Name"
   ```
 
 - Find your node on [Telemetry](https://telemetry.polkadot.io/#list/Polkadot)


### PR DESCRIPTION
The previous curl command in the instructions set doesn't specify the `./target/release/` subdirectories for the downloaded polkadot binaries

Here is an example of what happens when using the current instructions vs when using the updated one right after:

![WSL2](https://github.com/w3f/polkadot-wiki/assets/24867000/fb58e974-b59a-4426-99d0-4ee47bad5249)
