### PR TITLE
Add Sidecar's Asset Hub public instances

### DIFF
--- a/docs/build/build-integrate-assets.md
+++ b/docs/build/build-integrate-assets.md
@@ -100,14 +100,14 @@ info about assets and asset balances on the Asset Hub.
 - Please refer to [docs](https://paritytech.github.io/substrate-api-sidecar/dist/) for full usage
   information. Details on options like how to make a historical query are not included here.
 
-There are also available the following public instances:
+Here are the available public instances:
 
 - [Sidecar connected to Polkadot Asset Hub](https://polkadot-asset-hub-public-sidecar.parity-chains.parity.io)
   and
 - [Sidecar connected to Kusama Asset Hub](https://kusama-asset-hub-public-sidecar.parity-chains.parity.io)
 
-The purpose of these instances is to give the opportunity to anyone to quickly check and get an
-overview of the info that the asset related endpoints provide.
+The purpose of these instances is to allow anyone to check and get a quick
+overview of the info that the asset-related endpoints provide.
 
 :::caution
 

--- a/docs/build/build-integrate-assets.md
+++ b/docs/build/build-integrate-assets.md
@@ -100,6 +100,22 @@ info about assets and asset balances on the Asset Hub.
 - Please refer to [docs](https://paritytech.github.io/substrate-api-sidecar/dist/) for full usage
   information. Details on options like how to make a historical query are not included here.
 
+There are also available the following public instances:
+
+- [Sidecar connected to Polkadot Asset Hub](https://polkadot-asset-hub-public-sidecar.parity-chains.parity.io)
+  and
+- [Sidecar connected to Kusama Asset Hub](https://kusama-asset-hub-public-sidecar.parity-chains.parity.io)
+
+The purpose of these instances is to give the opportunity to anyone to quickly check and get an
+overview of the info that the asset related endpoints provide.
+
+:::caution
+
+These instances should only be used for ad-hoc checks or tests and not for production, heavy testing
+or any other critical purpose.
+
+:::
+
 ### Tx Wrapper Polkadot
 
 TxWrapper Polkadot is a library designed to facilitate transaction construction and signing in

--- a/docs/general/contributing.md
+++ b/docs/general/contributing.md
@@ -8,7 +8,7 @@ slug: ../contributing
 ---
 
 The wiki was started and is maintained by Web3 Foundation. It is an open source project and aims to
-be the most extensive resource of knowledge on Polkadot and Kusama the ecosystem. A large part of
+be the most extensive resource of knowledge on the Polkadot and Kusama ecosystem. A large part of
 the material currently focuses on Polkadot and Kusama directly but it is not opposed to covering
 informational material for community projects.
 


### PR DESCRIPTION
### Description
With this PR we would to add Sidecar's Asset Hub public instances links to the section of [sidecar](https://wiki.polkadot.network/docs/build-integrate-assets#sidecar) in the Assets page of the wiki. 

### Motivation
We would like to add those links in the wiki because they are quite useful for anyone who needs to quickly check/get an overview of what Sidecar (connected to Asset Hub) can offer.
We also added a `caution` clause after consulting with @PierreBesson to try to avoid heavy traffic to these instances. If those instances still get a lot of requests, we will also add a rate limit to the node that is supporting them (issue to be opened in devops)

cc @IkerAlus 