### PR TITLE
Fellowship level 3 or more is required to vote to whitelist calls

### DIFF
--- a/docs/learn/learn-polkadot-opengov.md
+++ b/docs/learn/learn-polkadot-opengov.md
@@ -591,7 +591,8 @@ referendum.
 ### Whitelisting
 
 Polkadot OpenGov allows the Fellowship to authorize a new origin (known as "Whitelisted-Caller") to
-execute with Root-level privileges for calls that have been approved by the Fellowship.
+execute with Root-level privileges for calls that have been approved by the Fellowship. (At the moment
+only fellows level 3 and above can vote to whitelist calls).
 
 The [Whitelist](https://paritytech.github.io/substrate/master/pallet_whitelist/) pallet allows one
 Origin to escalate the privilege level of another Origin for a certain operation. The pallet

--- a/docs/learn/learn-polkadot-opengov.md
+++ b/docs/learn/learn-polkadot-opengov.md
@@ -591,7 +591,7 @@ referendum.
 ### Whitelisting
 
 Polkadot OpenGov allows the Fellowship to authorize a new origin (known as "Whitelisted-Caller") to
-execute with Root-level privileges for calls that have been approved by the Fellowship. (At the moment
+execute with Root-level privileges for calls that have been approved by the Fellowship. (Currently
 only fellows level 3 and above can vote to whitelist calls).
 
 The [Whitelist](https://paritytech.github.io/substrate/master/pallet_whitelist/) pallet allows one

--- a/docs/learn/learn-polkadot-opengov.md
+++ b/docs/learn/learn-polkadot-opengov.md
@@ -591,8 +591,8 @@ referendum.
 ### Whitelisting
 
 Polkadot OpenGov allows the Fellowship to authorize a new origin (known as "Whitelisted-Caller") to
-execute with Root-level privileges for calls that have been approved by the Fellowship. (Currently
-only fellows level 3 and above can vote to whitelist calls).
+execute with Root-level privileges for calls that have been approved by the Fellowship (currently
+only level-three fellows and above can vote for whitelist calls).
 
 The [Whitelist](https://paritytech.github.io/substrate/master/pallet_whitelist/) pallet allows one
 Origin to escalate the privilege level of another Origin for a certain operation. The pallet


### PR DESCRIPTION
As a level 1 fellow I know this to be true and I feel it ought to be explicitly documented. 