### PR TITLE
Update prometheus binary download

### DIFF
--- a/docs/maintain/maintain-guides-how-to-monitor-your-node.md
+++ b/docs/maintain/maintain-guides-how-to-monitor-your-node.md
@@ -312,9 +312,9 @@ node goes down.
 First, download the latest binary of AlertManager and unzip it by running the command below:
 
 ```bash
-wget https://github.com/prometheus/alertmanager/releases/download/v0.21.0/alertmanager-0.21.0.linux-amd64.tar.gz
-tar -xvzf alertmanager-0.21.0.linux-amd64.tar.gz
-mv alertmanager-0.21.0.linux-amd64/alertmanager /usr/local/bin/
+wget https://github.com/prometheus/alertmanager/releases/download/v0.26.0/alertmanager-0.26.0.linux-amd64.tar.gz
+tar -xvzf alertmanager-0.26.0.linux-amd64.tar.gz
+mv alertmanager-0.26.0.linux-amd64/alertmanager /usr/local/bin
 ```
 
 ### Gmail Setup


### PR DESCRIPTION
Existing package mentioned was outdated - 
`alertmanager-0.21.0.linux-amd64` changed it to `alertmanager-0.26.0.linux-amd64`