### PR TITLE
fix: replace --ws-* flag with --rpc-* flag

### DIFF
--- a/docs/build/build-node-management.md
+++ b/docs/build/build-node-management.md
@@ -57,9 +57,9 @@ polkadot export-blocks --from 0 <output_file>
 
 **RPC ports**
 
-Use the `--rpc-external` flag to expose RPC ports and `--ws-external` to expose websockets. Not all
+Use the `--rpc-external` flag to expose RPC ports. Not all
 RPC calls are safe to allow and you should use an RPC proxy to filter unsafe calls. Select ports
-with the `--rpc-port` and `--ws-port` options. To limit the hosts who can access, use the
+with the `--rpc-port` option. To limit the hosts who can access, use the
 `--rpc-cors` option.
 
 **Execution**

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -193,14 +193,14 @@ binaries are needed to properly run a validator node. More context on these chan
 #### Installation from official releases
 
 The official binaries can be downloaded from the
-[Github Releases](https://github.com/paritytech/polkadot/releases). You should download the latest
+[Github Releases](https://github.com/paritytech/polkadot-sdk/releases). You should download the latest
 available version. You can also download the binaries by using the following direct links (replace
 X.Y.Z by the appropriate version):
 
 ```sh
-https://github.com/paritytech/polkadot/releases/download/vX.Y.Z/polkadot
-https://github.com/paritytech/polkadot/releases/download/vX.Y.Z/polkadot-execute-worker
-https://github.com/paritytech/polkadot/releases/download/vX.Y.Z/polkadot-prepare-worker
+https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-vX.Y.Z/polkadot
+https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-vX.Y.Z/polkadot-execute-worker
+https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-vX.Y.Z/polkadot-prepare-worker
 ```
 
 #### Optional: Installation with Package Managers

--- a/docs/maintain/maintain-rpc.md
+++ b/docs/maintain/maintain-rpc.md
@@ -35,13 +35,13 @@ options in the setup process provide various settings that can be modified.
 A typical setting for an externally accessible polkadot archive RPC node would be:
 
 ```config
-polkadot --chain polkadot --name myrpc --state-pruning archive --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
+polkadot --chain polkadot --name myrpc --state-pruning archive --blocks-pruning archive --rpc-max-connections 100 --rpc-cors all --rpc-methods Safe --rpc-port 9944
 ```
 
 Or for a Polkadot pruned RPC node:
 
 ```config
-polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning archive --ws-max-connections 100 --rpc-cors all --rpc-methods Safe --ws-port 9944
+polkadot --chain polkadot --name myrpc --state-pruning 1000 --blocks-pruning archive --rpc-max-connections 100 --rpc-cors all --rpc-methods Safe --rpc-port 9944
 ```
 
 The specified flag options are outlined in greater detail below.
@@ -70,8 +70,8 @@ Inclusion in the Polkadot.js UI requires an archive node.
 The node startup settings allow you to choose **what** to expose, **how many** connections to expose
 and **from where** access should be granted through the RPC server.
 
-_How many_: You can set your maximum connections through `--ws-max-connections`, for example
-`--ws-max-connections 100`
+_How many_: You can set your maximum connections through `--rpc-max-connections`, for example
+`--rpc-max-connections 100`
 
 _From where_: by default localhost and the polkadot.js are allowed to access the RPC server; you can
 change this by setting `--rpc-cors`, to allow access from everywhere you need `--rpc-cors all`

--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -373,7 +373,7 @@ The built binary will be in the `target/release` folder, called `polkadot`.
 ```
 
 Use the `--help` flag to determine which flags you can use when running the node. For example, if
-[connecting to your node remotely](maintain-wss.md), you'll probably want to use `--ws-external` and
+[connecting to your node remotely](maintain-wss.md), you'll probably want to use `--rpc-external` and
 `--rpc-cors all`.
 
 The syncing process will take a while, depending on your capacity, processing power, disk speed and
@@ -403,10 +403,10 @@ after the node syncs.
 Finally, you can use Docker to run your node in a container. Doing this is more advanced, so it's
 best left up to those already familiar with docker or who have completed the other set-up
 instructions in this guide. Be aware that when you run polkadot in docker, the process only listens
-on localhost by default. If you would like to connect to your node's services (rpc, websockets, and
-prometheus) you need to ensure that you run you node with the `--rpc-external`, `--ws-external`, and
+on localhost by default. If you would like to connect to your node's services (rpc, and
+prometheus) you need to ensure that you run you node with the `--rpc-external`, and
 `--prometheus-external` commands.
 
 ```zsh
-docker run -p 9944:9944 -p 9615:9615 parity/polkadot:v0.9.13 --name "calling_home_from_a_docker_container" --rpc-external --ws-external --prometheus-external
+docker run -p 9944:9944 -p 9615:9615 parity/polkadot:v0.9.13 --name "calling_home_from_a_docker_container" --rpc-external --prometheus-external
 ```


### PR DESCRIPTION
#### Description
Based on the release notes of polkadot [v0.9.43](https://github.com/paritytech/polkadot/releases/tag/v0.9.43) the CLI parameter :
- `--ws-external` was replaced by `--rpc-external`
- `--ws-port` was replaced by `--rpc-port`
- `--ws-max-connections` was replaced by `--rpc-max-connections`

The corresponding [PR](https://github.com/paritytech/substrate/pull/13384/files) that implements these changes.

#### Additional Change
Updated the links in the Validator page to point to the polkadot-sdk releases page and updated the links of the binaries. 