### PR TITLE
Move /General inside /Learn

### DIFF
--- a/polkadot-wiki/docusaurus.config.js
+++ b/polkadot-wiki/docusaurus.config.js
@@ -208,11 +208,6 @@ module.exports = {
       },
       items: [
         {
-          to: "/docs/general-index",
-          label: "General",
-          position: "right",
-        },
-        {
           to: "docs/learn-index",
           label: "Learn",
           position: "right",

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -2,121 +2,6 @@ module.exports = {
   docs: [
     {
       type: "category",
-      label: "General",
-      link: {
-        type: 'generated-index',
-        title: 'General',
-        description: 'General Information to get started with Polkadot and Web3.',
-        slug: '/general-index',
-      },
-      items: [
-        "general/getting-started",
-        {
-          type: "category",
-          label: "Polkadot Vision",
-          description: "Polkadot's Vision revealed by Gavin Wood at Decoded 2023.",
-          link: {
-            type: 'generated-index',
-            title: 'Polkadot Vision',
-            description: "Polkadot's Vision revealed by Gavin Wood at Decoded 2023.",
-            slug: '/polkadot-vision-index',
-          },
-          items: [
-            "general/polkadot-v1",
-          ],
-        },
-        {
-          type: "category",
-          label: "Stay Safe",
-          description: 'Good-practices to Stay Safe while Surfing in Web3.',
-          link: {
-            type: 'generated-index',
-            title: 'Stay Safe',
-            description: 'Learn about good-practices to stay safe while surfing in Web3.',
-            slug: '/stay-safe-index',
-          },
-          items: [
-            "general/scams",
-            "general/how-to-dyor",
-          ],
-        },
-        {
-          type: "category",
-          label: "Wallets",
-          description: 'Wallet Options in the Polkadot Ecosystem.',
-          link: {
-            type: 'generated-index',
-            title: 'Wallets',
-            description: 'Explore the different wallet options in the Polkadot and Kusama ecosystems.',
-            slug: '/wallets-index',
-          },
-          items: [
-            "general/wallets-and-extensions",
-            "general/ledger",
-            "general/polkadot-vault",
-            "general/polkadotjs-ui",
-          ],
-        },
-        {
-          type: "category",
-          label: "Dashboards",
-          description: 'Dashboards in the Polkadot Ecosystem.',
-          link: {
-            type: 'generated-index',
-            title: 'Dashboards',
-            description: 'Explore the different dashboards in the Polkadot and Kusama ecosystems.',
-            slug: '/dashboards-index',
-          },
-          items: [
-            "general/staking-dashboard",
-          ],
-        },
-        "general/polkadotjs",
-        {
-          type: "category",
-          label: "Community & Contributors",
-          description: 'Polkadot Community and Wiki Contributors.',
-          link: {
-            type: 'generated-index',
-            title: 'Community & Contributors',
-            description: 'Learn about how to participate in the Polkadot community and how to contribute to the Polkadot Wiki.',
-            slug: '/community-index',
-          },
-          items: [
-            "general/community",
-            "general/contributing",
-            "general/contributors",
-          ],
-        },
-        {
-          type: "category",
-          label: "Programmes",
-          description: 'Programmes and Initiatives within the Polkadot Ecosystem.',
-          link: {
-            type: 'generated-index',
-            title: 'Programmes',
-            description: 'Learn about different programmes and initiatives within the Polkadot and Kusama ecosystems.',
-            slug: '/programmes-index',
-          },
-          items: [
-            "general/grants",
-            "general/bug-bounty",
-            "general/ambassadors",
-            "general/builders-program",
-            "general/doc-thousand-validators",
-            "general/doc-thousand-contributors",
-            "general/dev-heroes",
-          ],
-        },
-        "general/start-building",
-        "general/research",
-        "general/metadata",
-        "general/faq",
-        "general/glossary",
-      ],
-    },
-    {
-      type: "category",
       label: "Learn",
       link: {
         type: 'generated-index',
@@ -125,6 +10,122 @@ module.exports = {
         slug: '/learn-index',
       },
       items: [
+        {
+          type: "category",
+          label: "General",
+          description: 'General Information to get started with Polkadot and Web3.',
+          link: {
+            type: 'generated-index',
+            title: 'General',
+            description: 'General Information to get started with Polkadot and Web3.',
+            slug: '/general-index',
+          },
+          items: [
+            "general/getting-started",
+            {
+              type: "category",
+              label: "Polkadot Vision",
+              description: "Polkadot's Vision revealed by Gavin Wood at Decoded 2023.",
+              link: {
+                type: 'generated-index',
+                title: 'Polkadot Vision',
+                description: "Polkadot's Vision revealed by Gavin Wood at Decoded 2023.",
+                slug: '/polkadot-vision-index',
+              },
+              items: [
+                "general/polkadot-v1",
+              ],
+            },
+            {
+              type: "category",
+              label: "Stay Safe",
+              description: 'Good-practices to Stay Safe while Surfing in Web3.',
+              link: {
+                type: 'generated-index',
+                title: 'Stay Safe',
+                description: 'Learn about good-practices to stay safe while surfing in Web3.',
+                slug: '/stay-safe-index',
+              },
+              items: [
+                "general/scams",
+                "general/how-to-dyor",
+              ],
+            },
+            {
+              type: "category",
+              label: "Wallets",
+              description: 'Wallet Options in the Polkadot Ecosystem.',
+              link: {
+                type: 'generated-index',
+                title: 'Wallets',
+                description: 'Explore the different wallet options in the Polkadot and Kusama ecosystems.',
+                slug: '/wallets-index',
+              },
+              items: [
+                "general/wallets-and-extensions",
+                "general/ledger",
+                "general/polkadot-vault",
+                "general/polkadotjs-ui",
+              ],
+            },
+            {
+              type: "category",
+              label: "Dashboards",
+              description: 'Dashboards in the Polkadot Ecosystem.',
+              link: {
+                type: 'generated-index',
+                title: 'Dashboards',
+                description: 'Explore the different dashboards in the Polkadot and Kusama ecosystems.',
+                slug: '/dashboards-index',
+              },
+              items: [
+                "general/staking-dashboard",
+              ],
+            },
+            "general/polkadotjs",
+            {
+              type: "category",
+              label: "Community & Contributors",
+              description: 'Polkadot Community and Wiki Contributors.',
+              link: {
+                type: 'generated-index',
+                title: 'Community & Contributors',
+                description: 'Learn about how to participate in the Polkadot community and how to contribute to the Polkadot Wiki.',
+                slug: '/community-index',
+              },
+              items: [
+                "general/community",
+                "general/contributing",
+                "general/contributors",
+              ],
+            },
+            {
+              type: "category",
+              label: "Programmes",
+              description: 'Programmes and Initiatives within the Polkadot Ecosystem.',
+              link: {
+                type: 'generated-index',
+                title: 'Programmes',
+                description: 'Learn about different programmes and initiatives within the Polkadot and Kusama ecosystems.',
+                slug: '/programmes-index',
+              },
+              items: [
+                "general/grants",
+                "general/bug-bounty",
+                "general/ambassadors",
+                "general/builders-program",
+                "general/doc-thousand-validators",
+                "general/doc-thousand-contributors",
+                "general/dev-heroes",
+              ],
+            },
+            "general/start-building",
+            "general/research",
+            "general/metadata",
+            "general/faq",
+            "general/glossary",
+          ],
+        },
         {
           type: "category",
           label: "Basics",


### PR DESCRIPTION
The "General" section contains key information, but does not get the spotlight for people landing on the Wiki and clicking on the "Learn" card. 

<img width="1305" alt="Screenshot 2023-09-20 at 09 14 23" src="https://github.com/w3f/polkadot-wiki/assets/110459737/44f7973d-3ca6-46ac-b3f6-dd9ce68f6de1">

I suggest moving "General" under "Learn" until a better strategy is implemented.