### PR TITLE
Add more context to advanced how-to guides

### DIFF
--- a/docs/learn/learn-guides-identity.md
+++ b/docs/learn/learn-guides-identity.md
@@ -2,10 +2,14 @@
 id: learn-guides-identity
 title: Identity How-to Guides
 sidebar_label: Identity
-description: Advanced How-to Guides about Identity.
-keywords: [registrar, identity]
+description: Advanced How-to Guides about Identity - Registrars and Sub-Identity.
+keywords: [registrar, identity, sub-identity]
 slug: ../learn-guides-identity
 ---
+
+This is an advanced guide that is relevant for entities that would like to become registrars or would
+like to set sub-identities to an existing account with an identity. The [learn identity](https://wiki.polkadot.network/docs/learn-identity)
+page provides information on how to set an identity and have it verified.
 
 ## Registrars
 

--- a/docs/learn/learn-guides-polkadot-opengov.md
+++ b/docs/learn/learn-guides-polkadot-opengov.md
@@ -9,7 +9,7 @@ slug: ../learn-guides-polkadot-opengov
 
 import RPC from "./../../components/RPC-Connection";
 
-This page is for advanced users of Polkadot OpenGov. If you would like to participate in OpenGov, please navigate
+This page is for advanced users of Polkadot OpenGov. If you would learn about and participate in OpenGov, please navigate
 to the page on [participating in Polkadot Opengov.](https://wiki.polkadot.network/docs/maintain-guides-polkadot-opengov)
 
 ## Cancel or Kill a Referendum

--- a/docs/learn/learn-guides-polkadot-opengov.md
+++ b/docs/learn/learn-guides-polkadot-opengov.md
@@ -9,6 +9,9 @@ slug: ../learn-guides-polkadot-opengov
 
 import RPC from "./../../components/RPC-Connection";
 
+This page is for advanced users of Polkadot OpenGov. If you would like to participate in OpenGov, please navigate
+to the page on [participating in Polkadot Opengov.](https://wiki.polkadot.network/docs/maintain-guides-polkadot-opengov)
+
 ## Cancel or Kill a Referendum
 
 :::info

--- a/docs/learn/learn-guides-staking-pools.md
+++ b/docs/learn/learn-guides-staking-pools.md
@@ -9,6 +9,9 @@ slug: ../learn-guides-staking-pools
 
 import RPC from "./../../components/RPC-Connection";
 
+This page is for pool creators and maintainers. If you like to participate in staking through nomination pools,
+please navigate to this page on [how to join a nomination pool.](https://support.polkadot.network/support/solutions/articles/65000182376-staking-dashboard-how-to-join-a-nomination-pool)
+
 ## Pool Creation
 
 :::info

--- a/docs/learn/learn-guides-staking.md
+++ b/docs/learn/learn-guides-staking.md
@@ -9,6 +9,9 @@ slug: ../learn-guides-staking
 
 import RPC from "./../../components/RPC-Connection";
 
+This page focuses on the advanced staking features of the network. If you like to learn about staking,
+check this page on the [introduction to staking.](https://wiki.polkadot.network/docs/learn-staking)
+
 ## Claiming Rewards with the Polkadot-JS UI
 
 Anyone can trigger a payout for any validator, as long as they are willing to pay the transaction


### PR DESCRIPTION
These documents show up as results on the search bar. Should provide a link back to beginner docs, so a beginner can hop on to those pages easily