### PR TITLE
bad link error

### DIFF
--- a/docs/build/build-guide.md
+++ b/docs/build/build-guide.md
@@ -29,7 +29,7 @@ This build guide provides four different tracks:
 1.  [Building Parachains](#building-parachains)
 2.  [Building a Pallet](#building-a-pallet)
 3.  [Developing Smart Contracts](#developing-smart-contracts)
-4.  [Developing a dApp](#developing-a-dapp)
+4.  [Developing a dApp](#developing-a-dappuapp)
 
 :::info
 


### PR DESCRIPTION
## Title and link bug

I was looking at the Polkadot wiki documentation and found this bug, where it doesn't work if you click on the "Developing a dapp" section. It´s a minor bug, but I already fix it. 

### Before

![Captura de pantalla 2023-09-23 a la(s) 16 53 22](https://github.com/w3f/polkadot-wiki/assets/67608482/09737e7c-4894-4e91-b5ac-46031ee45b55)

![Captura de pantalla 2023-09-23 a la(s) 16 54 16](https://github.com/w3f/polkadot-wiki/assets/67608482/b2946765-e3b2-4015-a6e2-077d71a5cbd0)

![Captura de pantalla 2023-09-23 a la(s) 16 54 49](https://github.com/w3f/polkadot-wiki/assets/67608482/62e08eda-19b7-420c-ba44-82c1228b6685)

### Now

![Captura de pantalla 2023-09-23 a la(s) 16 59 49](https://github.com/w3f/polkadot-wiki/assets/67608482/08f888c9-7b00-4923-b8a9-342befbc8ffa)
It works.
