### PR TITLE
Fix 404 wallet link

### DIFF
--- a/docs/build/build-tools-index.md
+++ b/docs/build/build-tools-index.md
@@ -13,7 +13,7 @@ developers, feel free to [add it in](../general/contributing.md).
 
 ## Wallets
 
-Please see the [Wallets](./wallets) page.
+Please see the [Wallets](../general/wallets-and-extensions.md) page.
 
 ## Block Explorers
 


### PR DESCRIPTION
Fix the `wallet` link from [Tools Index](https://wiki.polkadot.network/docs/build-tools-index#wallets) page that was leading to 404 