### PR TITLE
Add links to Polkadot Network Wallets page

### DIFF
--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -145,6 +145,12 @@ See the videos below to know more about Polkadot.
 transaction fees, staking, governance, acquisition of a parachain slot and for enabling several key
 functionalities on Polkadot.
 
+:::info
+
+Explore Polkadot with a secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
+
+:::
+
 - {{ polkadot: __<RPC network="polkadot" path="consts.balances.existentialDeposit" defaultValue={10000000000} filter="humanReadable"/>:__ :polkadot }}
   the minimum balance required to have an active account on Polkadot Network. If your account
   balance drops below the minimum, your account will be reaped. Learn more about

--- a/docs/general/polkadotjs.md
+++ b/docs/general/polkadotjs.md
@@ -14,12 +14,13 @@ consult the [**official documentation**](https://polkadot.js.org/docs/).
 
 ## Polkadot-JS UI
 
-:::info Supported Wallet
+:::info For Developers and Power Users Only
 
+Please note that this wallet UI is oriented toward developers and power users.
+Explore Polkadot with a secure and user-friendly wallets listed on 
+the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
 If you need help using the Polkadot-JS UI you can contact the
-[**Polkadot Support Team**](https://support.polkadot.network/support/home). Please note that this
-wallet is oriented toward developers and power users. For more user-friendly wallets, check out the
-supported and treasury-funded wallets on the [Wallets Page](./wallets-and-extensions.md).
+[**Polkadot Support Team**](https://support.polkadot.network/support/home).
 
 :::
 

--- a/docs/general/wallets-and-extensions.md
+++ b/docs/general/wallets-and-extensions.md
@@ -14,6 +14,12 @@ issues related to these wallet, reach out to their support teams directly.
 
 :::
 
+:::info 
+
+Explore Polkadot with a secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
+
+:::
+
 If you are new to blockchain technology, generally a typical blockchain network account is a
 public-private key pair. Access to a private key gives full access to all the allowed transactions
 on that blockchain account. It is essential to keep the private key secure.

--- a/docs/learn/learn-accounts.md
+++ b/docs/learn/learn-accounts.md
@@ -16,6 +16,12 @@ accounts such as [account derivation](./learn-account-advanced.md#derivation-pat
 behind {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} accounts, please see
 [the cryptography page](learn-cryptography.md).
 
+:::info User friendly wallets
+
+Create your Polkadot accounts with a secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
+
+:::
+
 ## Account Address
 
 An address is the public part of a {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -11,7 +11,9 @@ import RPC from "./../../components/RPC-Connection";
 
 :::tip New to Staking?
 
-Start your staking journey or explore more information about staking on
+Explore Polkadot with a secure and user-friendly wallets listed on the 
+[Polkadot website](https://www.polkadot.network/ecosystem/wallets/) and start 
+your staking journey or explore more information about staking on
 [Polkadot's Home Page](https://polkadot.network/staking/). Discover the new
 [Staking Dashboard](https://staking.polkadot.network/#/overview) that makes staking much easier and
 check this

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -14,7 +14,7 @@ import RPC from "./../../components/RPC-Connection";
 Explore Polkadot with a secure and user-friendly wallets listed on the 
 [Polkadot website](https://www.polkadot.network/ecosystem/wallets/) and start 
 your staking journey or explore more information about staking on
-[Polkadot's Home Page](https://polkadot.network/staking/). Discover the new
+[Polkadot's Staking Page](https://polkadot.network/staking/). Discover the new
 [Staking Dashboard](https://staking.polkadot.network/#/overview) that makes staking much easier and
 check this
 [extensive article list](https://support.polkadot.network/support/solutions/articles/65000182104) to


### PR DESCRIPTION
Polkadot website added a wallets page which can be included in the Wiki in relevant pages https://www.polkadot.network/ecosystem/wallets/