### PR TITLE
Improve Navigation on Staking Apps page

### DIFF
--- a/docs/general/staking-apps.md
+++ b/docs/general/staking-apps.md
@@ -15,6 +15,10 @@ and add your protocol native, permissionless, non-custodial NPoS Staking app to 
 
 :::
 
+- [Polkadot Staking Dashboard](#polkadot-staking-dashboard)
+- [Sub.ID](#sub.id)
+
+
 ## Polkadot Staking Dashboard
 
 The [Polkadot Staking Dashboard](https://staking.polkadot.network/#/overview) is a web3 application
@@ -30,8 +34,6 @@ PolkaGate, and Enkrypt. The dashboard also supports
 
 You can find more information about the Polkadot staking dashboard on the
 [dedicated page](./staking-dashboard.md).
-
-### Staking Dashboard Video Tutorials
 
 <tr class="cards-container">
   <td>
@@ -86,9 +88,9 @@ You can find more information about the Polkadot staking dashboard on the
 
 [Sub.ID](https://sub.id/) is a one-stop-shop for managing your Polkadot accounts, viewing your addresses and balances, and looking at other accounts. 
 
-![](https://cdn.discordapp.com/attachments/893485384154095640/1166807359411204228/image.png?ex=654bd508&is=65396008&hm=ddf3dc26f525d0021df4d8879f19973b81040514bfb10423e748d397c7a66329&)
+[![](https://cdn.discordapp.com/attachments/893485384154095640/1166807359411204228/image.png?ex=654bd508&is=65396008&hm=ddf3dc26f525d0021df4d8879f19973b81040514bfb10423e748d397c7a66329&)](https://sub.id/)
 
 It features a Polkadot [staking page](https://sub.id/validator/polkadot), where you can easily get started staking DOT. Stakers can choose their own validators, or stake with the recommended validator set.
 
-![](https://cdn.discordapp.com/attachments/893485384154095640/1166807508837474394/image.png?ex=654bd52c&is=6539602c&hm=f78e346cfd364529b1b03d5207a8ad0cd100fc5093ee832eece397e788200cf0&)
+[![](https://cdn.discordapp.com/attachments/893485384154095640/1166807508837474394/image.png?ex=654bd52c&is=6539602c&hm=f78e346cfd364529b1b03d5207a8ad0cd100fc5093ee832eece397e788200cf0&)](https://sub.id/validator/polkadot)
 

--- a/docs/general/staking-apps.md
+++ b/docs/general/staking-apps.md
@@ -16,8 +16,7 @@ and add your protocol native, permissionless, non-custodial NPoS Staking app to 
 :::
 
 - [Polkadot Staking Dashboard](#polkadot-staking-dashboard)
-- [Sub.ID](#sub.id)
-
+- [Sub.ID](#subid)
 
 ## Polkadot Staking Dashboard
 
@@ -86,11 +85,13 @@ You can find more information about the Polkadot staking dashboard on the
 
 ## Sub.ID
 
-[Sub.ID](https://sub.id/) is a one-stop-shop for managing your Polkadot accounts, viewing your addresses and balances, and looking at other accounts. 
+[Sub.ID](https://sub.id/) is a one-stop-shop for managing your Polkadot accounts, viewing your
+addresses and balances, and looking at other accounts.
 
 [![](https://cdn.discordapp.com/attachments/893485384154095640/1166807359411204228/image.png?ex=654bd508&is=65396008&hm=ddf3dc26f525d0021df4d8879f19973b81040514bfb10423e748d397c7a66329&)](https://sub.id/)
 
-It features a Polkadot [staking page](https://sub.id/validator/polkadot), where you can easily get started staking DOT. Stakers can choose their own validators, or stake with the recommended validator set.
+It features a Polkadot [staking page](https://sub.id/validator/polkadot), where you can easily get
+started staking DOT. Stakers can choose their own validators, or stake with the recommended
+validator set.
 
 [![](https://cdn.discordapp.com/attachments/893485384154095640/1166807508837474394/image.png?ex=654bd52c&is=6539602c&hm=f78e346cfd364529b1b03d5207a8ad0cd100fc5093ee832eece397e788200cf0&)](https://sub.id/validator/polkadot)
-

--- a/docs/general/staking-apps.md
+++ b/docs/general/staking-apps.md
@@ -90,8 +90,8 @@ addresses and balances, and looking at other accounts.
 
 [![](https://cdn.discordapp.com/attachments/893485384154095640/1166807359411204228/image.png?ex=654bd508&is=65396008&hm=ddf3dc26f525d0021df4d8879f19973b81040514bfb10423e748d397c7a66329&)](https://sub.id/)
 
-It features a Polkadot [staking page](https://sub.id/validator/polkadot), where you can easily get
-started staking DOT. Stakers can choose their own validators, or stake with the recommended
-validator set.
+It features a Polkadot [staking page](https://sub.id/validator/polkadot), where you can easily start
+staking {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }}. Stakers can choose their preferred
+validators or stake with the recommended validator set.
 
 [![](https://cdn.discordapp.com/attachments/893485384154095640/1166807508837474394/image.png?ex=654bd52c&is=6539602c&hm=f78e346cfd364529b1b03d5207a8ad0cd100fc5093ee832eece397e788200cf0&)](https://sub.id/validator/polkadot)


### PR DESCRIPTION
As more and more sections get added, it makes sense to improve navigation on the page like https://wiki.polkadot.network/docs/learn-nft-projects

Also, added links to sub.id images