### PR TITLE
Getting Started Page - Explore section

### DIFF
--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -11,6 +11,7 @@ module.exports = {
         slug: '/explore-index',
       },
       items: [
+        "general/getting-started",
         {
           type: "category",
           label: "Wallets",
@@ -119,7 +120,6 @@ module.exports = {
             slug: '/general-index',
           },
           items: [
-            "general/getting-started",
             "general/web3-and-polkadot",
             {
               type: "category",


### PR DESCRIPTION
Having "Getting Started" as starting doc on the Wiki navigational sidebar makes sense. As this doc is exploratory, it is better positioned in "Explore" than "Learn".


<img width="1018" alt="image" src="https://github.com/w3f/polkadot-wiki/assets/86818441/91b7d34f-be44-4f90-9b44-73dfcd792207">
