### PR TITLE
Remove documentation related to Wococo following its shut down

### DIFF
--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -195,11 +195,6 @@ obtain ROC by posting `!drip <ROCOCO_ADDRESS>` in the Matrix chatroom
 [Rococo faucet](https://paritytech.github.io/polkadot-testnet-faucet/). Learn more about Rococo on
 its [dedicated wiki section](../build/build-parachains.md##testing-a-parachains:-rococo-testnet).
 
-### Getting Tokens on the Wococo Testnet
-
-Wococo is a bridge testnet. General users can obtain WOOK by posting `!drip <WOCOCO_ADDRESS>` in the
-Matrix chatroom [#wococo-faucet:matrix.org](https://matrix.to/#/#wococo-faucet:matrix.org).
-
 ### Faucets support
 
 If you require help with using faucets, or wish to report an issue, there is a support chat

--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -31,7 +31,6 @@ tables below list these endpoints.
 | ------- | ----------------------------- |
 | Westend | wss://westend-rpc.polkadot.io |
 | Rococo  | wss://rococo-rpc.polkadot.io  |
-| Wococo  | wss://wococo-rpc.polkadot.io  |
 
 #### Example usage with Polkadot-JS API
 

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -764,8 +764,9 @@ you can find more information [on the wiki page](../general/thousand-validators.
 
 ## Running a validator on a testnet
 
-To verify your validator set up, it is possible to run it against a PoS test network such as Westend. However, validator slots are intentionally limited on Westend to ensure the stability and
-availability of the testnet for the Polkadot release process.
+To verify your validator setup, it is possible to run it against a PoS test network such as Westend.
+However, validator slots are intentionally limited on Westend to ensure stability and availability
+of the testnet for the Polkadot release process.
 
 Here is a small comparison of each network characteristics as relevant to validators:
 

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -764,20 +764,17 @@ you can find more information [on the wiki page](../general/thousand-validators.
 
 ## Running a validator on a testnet
 
-To verify your validator set up, it is possible to run it against a PoS test network such as Westend
-or Wococo. However, validator slots are intentionally limited on Westend to ensure the stability and
-availability of the testnet for the Polkadot release process. As such it is advised for node
-operators wishing to run testnet validators to join the Wococo network. You can obtain WOOK tokens
-[here](../learn/learn-DOT.md#getting-tokens-on-the-wococo-testnet).
+To verify your validator set up, it is possible to run it against a PoS test network such as Westend. However, validator slots are intentionally limited on Westend to ensure the stability and
+availability of the testnet for the Polkadot release process.
 
 Here is a small comparison of each network characteristics as relevant to validators:
 
-| Network           | Polkadot | Westend    | Wococo      |
-| ----------------- | -------- | ---------- | ----------- |
-| epoch             | 4h       | 1h         | 10m         |
-| era               | 1d       | 6h         | 1h          |
-| token             | DOT      | WND (test) | WOOK (test) |
-| active validators | ~300     | ~20        | 10<x<100    |
+| Network           | Polkadot | Westend    |
+| ----------------- | -------- | ---------- |
+| epoch             | 4h       | 1h         |
+| era               | 1d       | 6h         |
+| token             | DOT      | WND (test) |
+| active validators | ~300     | ~20        |
 
 ## FAQ
 

--- a/docs/maintain/maintain-networks.md
+++ b/docs/maintain/maintain-networks.md
@@ -97,8 +97,8 @@ ROCs tokens.
 
 ### Wococo Test Network (inactive)
 
-Wococo used to be a test network of Polkadot built for testing bridges.
-The network has been shut down following the deployment of the bridge between Westend and Rococo.
+Wococo used to be a Polkadot test network for testing bridges. The network was shut down following
+the bridge between Westend and Rococo deployment.
 
 ## Differences
 

--- a/docs/maintain/maintain-networks.md
+++ b/docs/maintain/maintain-networks.md
@@ -95,27 +95,10 @@ Check that your node is connected by viewing it on
 Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-rococo-testnet) to get
 ROCs tokens.
 
-### Wococo Test Network
+### Wococo Test Network (inactive)
 
-Wococo is a test network of Polkadot built for bridges. The native token of this network (WOOK)
-holds no economic value.
-
-Run the Polkadot binary and specify `rococo` as the chain:
-
-```bash
-polkadot --chain=wococo
-```
-
-and you will connect and start syncing to Wococo.
-
-Check that your node is connected by viewing it on
-[Wococo Telemetry](https://telemetry.polkadot.io/#list/0xdb4fd29dd914017e9dda3b751d6a4e0c5ca28cce7b6260cb063936633cc8175c)
-(you can set a custom node name by specifying `--name "my-custom-node-name"`).
-
-#### Wococo Faucet
-
-Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-wococo-testnet) to get
-WOOKs tokens.
+Wococo used to be a test network of Polkadot built for testing bridges.
+The network has been shut down following the deployment of the bridge between Westend and Rococo.
 
 ## Differences
 


### PR DESCRIPTION
As part of the deployment of the Westend <> Rococo bridge, the Wococo testnet (which was one side of the old Wococo <> Rococo test bridge) was shut down. I am removing any Wococo related documentation except for a small explanation that we can keep as reference if anyone is looking for information about Wococo.