### PR TITLE
Update DB snapshot link in maintain-guides-how-to-validate-polkadot.md

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -108,7 +108,7 @@ slashed.
     performance can be found [here](https://www.cpubenchmark.net/singleThread.html).
 - **Storage**
   - An NVMe SSD of 1 TB (As it should be reasonably sized to deal with blockchain growth). An
-    estimation of current chain snapshot sizes can be found [here](https://paranodes.io/DBSize). In
+    estimation of current chain snapshot sizes can be found [here](https://stakeworld.io/docs/dbsize). In
     general, the latency is more important than the throughput.
 - **Memory**
   - 32 GB DDR4 ECC.


### PR DESCRIPTION
https://paranodes.io/DBSize is not up and available. Replaced with the link below, got it from Kusama validator's lounge.

https://stakeworld.io/docs/dbsize