### PR TITLE
Fix a broken link (for Proxy Accounts)

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -573,7 +573,7 @@ bond all your DOT balance since you will be unable to pay transaction fees from 
 Controller accounts are deprecated. For more information, see
 [this discussion](https://forum.polkadot.network/t/staking-controller-deprecation-plan-staking-ui-leads-comms/2748).
 It is highly recommended that you setup an account with a staking proxy, which can be used for
-issuing start and stop validating calls. Read more about [proxy accounts](../docs/learn-proxies)
+issuing start and stop validating calls. Read more about [proxy accounts](../learn/learn-proxies.md)
 here.
 
 :::

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -573,7 +573,7 @@ bond all your DOT balance since you will be unable to pay transaction fees from 
 Controller accounts are deprecated. For more information, see
 [this discussion](https://forum.polkadot.network/t/staking-controller-deprecation-plan-staking-ui-leads-comms/2748).
 It is highly recommended that you setup an account with a staking proxy, which can be used for
-issuing start and stop validating calls. Read more about [proxy accounts](../learn/learn-proxies)
+issuing start and stop validating calls. Read more about [proxy accounts](../docs/learn-proxies)
 here.
 
 :::

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -54,7 +54,7 @@ You can have a rough estimate on that by using the methods listed
 [here](../general/faq.md/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
 To be elected into the set, you need a minimum stake behind your validator. This stake can come from
 yourself or from [nominators](../learn/learn-nominator.md). This means that as a minimum, you will
-need enough DOT to set up stash and staking proxy [accounts](../learn/learn-cryptography.md) with
+need enough DOT to set up stash (and optionally a staking [proxy account](../learn/learn-proxies.md)) with
 the existential deposit, plus a little extra for transaction fees. The rest can come from
 nominators. To understand how validators are elected, check the
 [NPoS Election algorithms](../learn/learn-phragmen.md) page.


### PR DESCRIPTION
- The link learn/proxy-accounts does not exist and results in a "Page not Found" error

- Documentation on Proxy accounts is at docs/learn-proxies so point it there.