### PR TITLE
Edit HRMP opening info

### DIFF
--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -21,9 +21,10 @@ the second chain needs to accept and do the same.
 To do this, the calls to be dispatched from both chains are:
 
 1. `hrmp > hrmpInitOpenChannel(recipient, proposedMaxCapacity, proposedMaxMessageSize)`: this call
-   initiates opening a channel from a parachain to a given recipient with a given channel
+   initiates opening a channel from a parachain to a given recipient.
 
-2. `hrmp > hrmpAcceptOpenChannel(sender)`: accepting the channel open request from the given sender.
+2. `hrmp > hrmpAcceptOpenChannel(sender)`: this call is for accepting the channel open request from
+   the given sender.
 
 Each parachain is to use its governance process to execute this. The call will be executed on the
 Relay Chain.

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -7,9 +7,9 @@ keywords: [HRMP, parachain, statemint, proposal, asset hub, statemine]
 slug: ../build-hrmp-channels
 ---
 
-[HRMP](../learn/learn-xcm.md#xcmp-lite-hrmp) has the same interface and functionality as
-[XCMP](../learn/learn-xcm.md#xcmp-cross-chain-message-passing) but is much more demanding on
-resources since it passes all messages via the Relay Chain. When XCMP is implemented on Polkadot,
+[HRMP](../learn/learn-xcm-transport.md#hrmp-xcmp-lite) has the same interface and functionality as
+[XCMP](../learn/learn-xcm-transport.md#xcmp-cross-chain-message-passing) but is much more demanding
+on resources since it passes all messages via the Relay Chain. When XCMP is implemented on Polkadot,
 HRMP is planned to be deprecated and phased out in favor of it.
 
 ## Opening HRMP channel: parachain to parachain
@@ -40,9 +40,7 @@ then submitting the proposal on-chain.
 Before submitting the proposal, both the system parachain's and the parachain's sovereign accounts
 (both [system accounts](../learn/learn-account-advanced.md#system-accounts)) must have the channel
 deposit of 20 DOT plus the
-[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping). At the time of
-execution, each parachain's sovereign account must have a free balance greater than or equal to the
-sum of the sender deposit, recipient deposit, and existential deposit.
+[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping).
 
 :::info
 

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -14,19 +14,19 @@ HRMP is planned to be deprecated and phased out in favor of it.
 
 ## Opening HRMP channel: parachain to parachain
 
-To open a channel from one parachain to another that are not system chains on Polkadot, the
-governance of each parachain needs to declare its intent to open a channel on the Relay Chain, and
+To open a channel from one parachain to another, that is not system chains on Polkadot, the
+governance of each parachain needs to declare its intent to open a channel on the Relay Chain and
 the second chain needs to accept and do the same.
 
-In order to do this, the calls to be dispatched from both chains are:
+To do this, the calls to be dispatched from both chains are:
 
 1. `hrmp > hrmpInitOpenChannel(recipient, proposedMaxCapacity, proposedMaxMessageSize)`: this call
-   initiates opening a channel from a parachain to a given recipient with given channel
+   initiates opening a channel from a parachain to a given recipient with a given channel
 
 2. `hrmp > hrmpAcceptOpenChannel(sender)`: accepting the channel open request from the given sender.
 
-Each parachain is to use its own governance process to execute this. The call will be executed on
-the Relay Chain.
+Each parachain is to use its governance process to execute this. The call will be executed on the
+Relay Chain.
 
 ## Opening HRMP Channels with System Parachains
 
@@ -40,8 +40,8 @@ then submitting the proposal on-chain.
 Before submitting the proposal, both the system parachain's and the parachain's sovereign accounts
 (both [system accounts](../learn/learn-account-advanced.md#system-accounts)) must have the channel
 deposit of 20 DOT plus the
-[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping). Opening an HRMP
-channels requires submitting a transactions, therefore make sure you have some extra funds to cover
+[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping). Opening HRMP
+channels requires submitting a transaction; therefore, ensure you have some extra funds to cover
 transaction fees.
 
 :::info
@@ -67,9 +67,9 @@ than the old two-phase channel request/accept method.
 ## Publication on Polkassembly for discussion and feedback
 
 The [discussions section of Polkassembly](https://polkadot.polkassembly.io/discussions) is the best
-place to share the reasoning behind your proposal: make sure to log in with the proposer address (if
-possible) before publishing yours, and if you can do this also make sure the address has an on-chain
-identity.
+place to share the reasoning behind your proposal: make sure to log in with the proposer’s address
+(if possible) before publishing yours, and if you can do this, also make sure the address has an
+on-chain identity.
 
 ### Example: Opening an HRMP Channel with the AssetHub
 
@@ -95,27 +95,27 @@ the community to review and ultimately vote on:
     the preimage hash needs to be submitted to and whitelisted by the
     [Technical Fellowship](../learn/learn-polkadot-opengov.md#the-technical-fellowship).
 
-Below is an example of how teams followed this process on Kusama, as a way to:
+Below is an example of how teams followed this process on Kusama as a way to:
 
 - Proposal to open HRMP channel between Bifrost and the Asset Hub: the motion can be found
   [here](https://kusama.polkassembly.io/motion/418).
 
 ## Preimage submission on democracy tab (Polkadot-JS UI)
 
-Once the community has given enough feedback (we expect these proposal to be non controversial)
-please submit the image on the discussion post in the
+Once the community has given enough feedback (we expect this proposal to be noncontroversial) please
+submit the image on the discussion post in the
 [Democracy](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.polkadot.io#/democracy) tab on
 Polkadot JS Apps, by using the "Submit Preimage" button:
 
 ![submit preimage](../assets/democracy/submit-preimage.png)
 
-On the pop up window, compose the preimage in the discussion post: making sure the proposal hash is
+On the pop-up window, compose the preimage in the discussion post, making sure the proposal hash is
 the same as in the post.
 
 ## Vote by the community
 
-After the community voting period, there will be an enactment period. In general, on Kusama these
-have been defined in shorter terms than the voting periods. Again, it is very important you
-encourage the community to vote on this, highlighting the benefits for your chain, use cases enabled
-with this submission, among other things. After the enactment period is over, both chains will
-authorize the channel.
+After the community voting period, there will be an enactment period. In general, these have been
+defined in shorter terms than the voting periods on Kusama. Again, it would be best to encourage the
+community to vote on this, highlighting the benefits for your chain use cases enabled with this
+submission, among other things. After the enactment period is over, both chains will authorize the
+channel.

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -14,7 +14,7 @@ HRMP is planned to be deprecated and phased out in favor of it.
 
 ## Opening HRMP channel: parachain to parachain
 
-To open a channel from one parachain to another, that is not system chains on Polkadot, the
+To open a channel from one parachain to another, that is not a system chain on Polkadot, the
 governance of each parachain needs to declare its intent to open a channel on the Relay Chain and
 the second chain needs to accept and do the same.
 

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -40,11 +40,17 @@ then submitting the proposal on-chain.
 Before submitting the proposal, both the system parachain's and the parachain's sovereign accounts
 (both [system accounts](../learn/learn-account-advanced.md#system-accounts)) must have the channel
 deposit of 20 DOT plus the
-[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) and some extra
-funds to cover for fees. Anyone can send those funds via `balances.transferKeepAlive` call to the
-system parachain's sovereign account (if funds are not already available). System parachains have ID
-< 2000 and they can be found on
-[Subscan](https://polkadot.subscan.io/parachain_list?page=2&status=parachain).
+[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping). At the time of
+execution, each parachain's sovereign account must have a free balance greater than or equal to the
+sum of the sender deposit, recipient deposit, and existential deposit.
+
+:::info
+
+After runtime 1,001,000, chains will not need any deposit for channels with system chains (and
+should be fine without any balance in their accounts). There will be a `poke_deposit` function that
+will refund any existing deposits.
+
+:::
 
 Proposals should generally be a `batch_all` call containing:
 
@@ -74,13 +80,10 @@ the community to review and ultimately vote on:
 1.  A request on what the proposal aims to do (opening an HRMP channel with the AssetHub);
 2.  The use cases this channel will support for your chain;
 3.  Technical details of the proposal, including proposal parameters and technical details of this
-    call (On Kusama, most proposals were designed as a batchAll calls):
+    call:
 
     - A `forceOpenhrmpchannel` from AssetHub (1,000) to ParaID.
     - A `forceOpenhrmpChannel` from ParaID to AssetHub (1,000).
-
-    Please note that if governance decides to reduce the HRMP channel deposit on Polkadot to 0 DOT,
-    the first transaction should not be necessary (these guidelines will be updated accordingly).
 
 4.  The XCM message to the Asset Hub, which can be decoded on the network;
 5.  The call data to verify on
@@ -97,7 +100,7 @@ Below is an example of how teams followed this process on Kusama, as a way to:
 - Proposal to open HRMP channel between Bifrost and the Asset Hub: the motion can be found
   [here](https://kusama.polkassembly.io/motion/418).
 
-## Preimage submission on democracy tab (Polkadot JS Apps)
+## Preimage submission on democracy tab (Polkadot-JS UI)
 
 Once the community has given enough feedback (we expect these proposal to be non controversial)
 please submit the image on the discussion post in the

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -38,11 +38,13 @@ governance proposals, proposers should follow best practices like opening a disc
 then submitting the proposal on-chain.
 
 Before submitting the proposal, both the system parachain's and the parachain's sovereign accounts
-must have the channel deposit of 20 DOT plus the
+(both [system accounts](../learn/learn-account-advanced.md#system-accounts)) must have the channel
+deposit of 20 DOT plus the
 [existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) and some extra
-funds to cover for fees. The parachain's sovereign account can send those funds via
-`balances.transferKeepAlive` call to the system parachain's sovereign account (if funds are not
-already available).
+funds to cover for fees. Anyone can send those funds via `balances.transferKeepAlive` call to the
+system parachain's sovereign account (if funds are not already available). System parachains have ID
+< 2000 and they can be found on
+[Subscan](https://polkadot.subscan.io/account_list?page=1&role=module&value_dimension=token).
 
 Proposals should generally be a `batch_all` call containing:
 

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -30,17 +30,24 @@ the Relay Chain.
 
 ## Opening HRMP Channels with System Parachains
 
-Opening an HRMP channel with a system parachain requires a referendum. Like all other governance
-proposals, proposers should follow best practices like opening a discussion on
+Opening an HRMP channel with a system parachain requires an
+[OpenGov referendum](../learn/learn-guides-polkadot-opengov.md) using the
+[General Admin Track](../learn/learn-polkadot-opengov-origins.md#general-admin). Like all other
+governance proposals, proposers should follow best practices like opening a discussion on
 [Polkassembly](https://polkadot.polkassembly.io/) or [Subsquare](https://polkadot.subsquare.io/) and
 then submitting the proposal on-chain.
 
+Before submitting the proposal, both the system parachain's and the parachain's sovereign accounts
+must have the channel deposit of 20 DOT plus the
+[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) and some extra
+funds to cover for fees. The parachain's sovereign account can send those funds via
+`balances.transferKeepAlive` call to the system parachain's sovereign account (if funds are not
+already available).
+
 Proposals should generally be a `batch_all` call containing:
 
-1. A `force_transfer` of the channel deposit from the Treasury to the System parachain's sovereign
-   account. Remember that a bi-direction channel is _two_ channels so will need double the amount.
 1. A `force_open_hrmp_channel` from your chain to the system chain.
-1. A `force_open_hrmp_channel` from the system chain to your chain.
+2. A `force_open_hrmp_channel` from the system chain to your chain.
 
 :::caution
 
@@ -67,7 +74,6 @@ the community to review and ultimately vote on:
 3.  Technical details of the proposal, including proposal parameters and technical details of this
     call (On Kusama, most proposals were designed as a batchAll calls):
 
-    - A `forceTransfer` of 20 DOT from the Treasury to AssetHub sovereign account.
     - A `forceOpenhrmpchannel` from AssetHub (1,000) to ParaID.
     - A `forceOpenhrmpChannel` from ParaID to AssetHub (1,000).
 

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -44,7 +44,7 @@ deposit of 20 DOT plus the
 funds to cover for fees. Anyone can send those funds via `balances.transferKeepAlive` call to the
 system parachain's sovereign account (if funds are not already available). System parachains have ID
 < 2000 and they can be found on
-[Subscan](https://polkadot.subscan.io/account_list?page=1&role=module&value_dimension=token).
+[Subscan](https://polkadot.subscan.io/parachain_list?page=2&status=parachain).
 
 Proposals should generally be a `batch_all` call containing:
 

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -15,7 +15,7 @@ HRMP is planned to be deprecated and phased out in favor of it.
 ## Opening HRMP channel: parachain to parachain
 
 To open a channel from one parachain to another, that is not a system chain on Polkadot, the
-governance of each parachain needs to declare its intent to open a channel on the Relay Chain and
+governance of each parachain needs to declare its intent to open a channel on the Relay Chain through a `Transact` XCM message with parachain origin, and
 the second chain needs to accept and do the same.
 
 To do this, the calls to be dispatched from both chains are:

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -18,7 +18,7 @@ To open a channel from one parachain to another, that is not a system chain on P
 governance of each parachain needs to declare its intent to open a channel on the Relay Chain through a `Transact` XCM message with parachain origin, and
 the second chain needs to accept and do the same.
 
-To do this, the calls to be dispatched from both chains are:
+To do this, the calls to be included in the `Transact` message from both chains are:
 
 1. `hrmp > hrmpInitOpenChannel(recipient, proposedMaxCapacity, proposedMaxMessageSize)`: this call
    initiates opening a channel from a parachain to a given recipient.

--- a/docs/build/build-hrmp-channels.md
+++ b/docs/build/build-hrmp-channels.md
@@ -40,7 +40,9 @@ then submitting the proposal on-chain.
 Before submitting the proposal, both the system parachain's and the parachain's sovereign accounts
 (both [system accounts](../learn/learn-account-advanced.md#system-accounts)) must have the channel
 deposit of 20 DOT plus the
-[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping).
+[existential deposit](../learn/learn-accounts.md#existential-deposit-and-reaping). Opening an HRMP
+channels requires submitting a transactions, therefore make sure you have some extra funds to cover
+transaction fees.
 
 :::info
 

--- a/docs/build/build-parachains.md
+++ b/docs/build/build-parachains.md
@@ -325,9 +325,10 @@ available for this type of work.
 ### Rococo Testnet
 
 [Rococo](https://github.com/paritytech/cumulus#rococo-crown) is a testnet built for testing
-parachains. Rococo utilizes Cumulus and [HRMP](../learn/learn-xcm.md#xcmp-lite-hrmp) (Horizontal
-Relay-routed Message Passing) in order to send transfers and messages between parachains and a Relay
-Chain. Every message is sent to the Relay Chain, then from the Relay Chain to the desired parachain.
+parachains. Rococo utilizes Cumulus and [HRMP](../learn/learn-xcm-transport.md#hrmp-xcmp-lite)
+(Horizontal Relay-routed Message Passing) in order to send transfers and messages between parachains
+and a Relay Chain. Every message is sent to the Relay Chain, then from the Relay Chain to the
+desired parachain.
 
 Rococo runs a few test system parachains:
 [Rockmine](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-asset-hub-rpc.polkadot.io#/explorer),


### PR DESCRIPTION
Removed the info about using the `force_transfer` within the batchAll call, as now the track is General Admin (not Root), which does not have permissions.

Added info about transferring funds deposit (20 DOT + existential deposit + fees) to the system parachain's sovereign account before opening the channel and doing the proposal.