### PR TITLE
Hardcoded Values for deprecated pallets

### DIFF
--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -7,8 +7,6 @@ keywords: [governance, referenda, proposal, voting, endorse]
 slug: ../learn-governance
 ---
 
-import RPC from "./../../components/RPC-Connection";
-
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} uses a sophisticated governance
 mechanism that allows it to evolve gracefully overtime at the ultimate behest of its assembled
 stakeholders. The stated goal is to ensure that the majority of the stake can always command the

--- a/docs/learn/learn-governance.md
+++ b/docs/learn/learn-governance.md
@@ -183,10 +183,8 @@ they will require a heavy supermajority of _aye_ votes to pass at low turnouts b
 increases towards 100%, it will require a simple majority of _aye_ votes to pass (i.e. 51% wins).
 
 Note that the bonded tokens will be released once the proposal is tabled (that is, brought to a
-vote), and a maximum of
-{{ polkadot: <RPC network="polkadot" path="consts.democracy.maxProposals" defaultValue={100} /> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.democracy.maxProposals" defaultValue={100} /> :kusama }}
-public proposals can be in the proposal queue.
+vote), and a maximum of {{ polkadot: 100 :polkadot }} {{ kusama: 100 :kusama }} public proposals can
+be in the proposal queue.
 
 :::info turnout
 
@@ -222,13 +220,11 @@ in the same period, excluding emergency referenda. An emergency referendum occur
 time as a regular referendum (either public- or council-proposed) is the only time multiple
 referenda can be voted on.
 
-Every
-{{ polkadot: <RPC network="polkadot" path="consts.democracy.votingPeriod" defaultValue={403200} filter="blocksToDays" /> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.democracy.votingPeriod" defaultValue={100800} filter="blocksToDays" /> :kusama }}
-days, a new referendum will come up for a vote, assuming there is at least one proposal in one of
-the queues. There is a queue for Council-approved proposals and a queue for publicly-submitted
-proposals. The referendum to be voted upon alternates between the top proposal in the two queues,
-where the proposals' rank is based on [endorsement](#endorsing-proposals) (i.e. bonded tokens).
+Every {{ polkadot: 28 :polkadot }} {{ kusama: 7 :kusama }} days, a new referendum will come up for a
+vote, assuming there is at least one proposal in one of the queues. There is a queue for
+Council-approved proposals and a queue for publicly-submitted proposals. The referendum to be voted
+upon alternates between the top proposal in the two queues, where the proposals' rank is based on
+[endorsement](#endorsing-proposals) (i.e. bonded tokens).
 
 ### Adaptive Quorum Biasing
 
@@ -335,10 +331,9 @@ All referenda are associated with an enactment delay or **enactment period**. Th
 between a referendum ending and (assuming it was approved) the changes being enacted.
 
 For public and Council referenda, the enactment period is a fixed time of
-{{ polkadot: <RPC network="polkadot" path="consts.democracy.enactmentPeriod" defaultValue={403200} filter="blocksToDays" /> :polkadot }}{{ kusama: <RPC network="kusama" path="consts.democracy.enactmentPeriod" defaultValue={115200} filter="blocksToDays" /> :kusama }}.
-For proposals submitted as part of the enactment of a prior referendum, it can be set as desired.
-Emergency proposals deal with major problems with the network and need to be "fast-tracked". These
-will have a shorter enactment period.
+{{ polkadot: 28 days :polkadot }}{{ kusama: 8 days :kusama }}. For proposals submitted as part of
+the enactment of a prior referendum, it can be set as desired. Emergency proposals deal with major
+problems with the network and need to be "fast-tracked". These will have a shorter enactment period.
 
 ## Voting on a Referendum
 
@@ -383,9 +378,7 @@ To represent passive stakeholders, {{ polkadot: Polkadot :polkadot }}{{ kusama: 
 introduces the idea of a "council". The council is an on-chain entity comprising several actors,
 each represented as an on-chain account. On
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, the council currently consists of
-{{ polkadot: <RPC network="polkadot" path="query.council.members" defaultValue={Array(13)} filter="arrayLength" /> :polkadot }}
-{{ kusama: <RPC network="kusama" path="query.council.members" defaultValue={Array(19)} filter="arrayLength" /> :kusama }}
-members.
+{{ polkadot: 13 :polkadot }} {{ kusama: 19 :kusama }} members.
 
 Along with [controlling the treasury](learn-treasury.md), the council is called upon primarily for
 three tasks of governance:

--- a/docs/learn/learn-treasury.md
+++ b/docs/learn/learn-treasury.md
@@ -7,8 +7,6 @@ keywords: [treasury, funds, funding, tips, tipping]
 slug: ../learn-treasury
 ---
 
-import RPC from "./../../components/RPC-Connection";
-
 :::info Use OpenGov to access treasury funds
 
 Governance v1 is deprecated. To access
@@ -26,10 +24,8 @@ accessible by anyone; only the system internal logic can access it. Funds can be
 spending proposal that, if approved by the [Council](learn-governance.md#council), will enter a
 waiting period before distribution. This waiting period is known as the _spend period_, and its
 duration is subject to [governance](learn-governance.md), with the current default set to
-{{ polkadot: <RPC network="polkadot" path="consts.treasury.spendPeriod" defaultValue={345600} filter="blocksToDays"/> :polkadot }}
-{{ kusama: <RPC network="kusama" path="consts.treasury.spendPeriod" defaultValue={86400} filter="blocksToDays"/> :kusama }}
-days. The Treasury attempts to spend as many proposals in the queue as it can without running out of
-funds.
+{{ polkadot: 28 :polkadot }} {{ kusama: 6 :kusama }} days. The Treasury attempts to spend as many
+proposals in the queue as it can without running out of funds.
 
 Treasury payout is an automatic process:
 
@@ -104,13 +100,9 @@ be paid out.
 There are two types of tips:
 
 - public: A small bond is required to place them. This bond depends on the tip message length, and a
-  fixed bond constant defined on chain, currently
-  {{ polkadot: <RPC network="polkadot" path="consts.tips.tipReportDepositBase" defaultValue={10000000000} filter="humanReadable"/>. :polkadot }}
-  {{ kusama: <RPC network="kusama" path="consts.tips.tipReportDepositBase" defaultValue={166000000000} filter="humanReadable"/>. :kusama }}
-  Public tips carry a finder's fee of
-  {{ polkadot: <RPC network="polkadot" path="consts.tips.tipFindersFee" defaultValue={20}/>%, :polkadot }}
-  {{ kusama: <RPC network="kusama" path="consts.tips.tipFindersFee" defaultValue={20}/>%, :kusama }}
-  which is paid out from the total amount.
+  fixed bond constant defined on chain, currently {{ polkadot: 1 DOT. :polkadot }}
+  {{ kusama: 0.166 KSM. :kusama }} Public tips carry a finder's fee of
+  {{ polkadot: 20%, :polkadot }} {{ kusama: 20%, :kusama }} which is paid out from the total amount.
 - tipper-initiated: Tips that a Council member published, do not have a finder's fee or a bond.
 
 :::info


### PR DESCRIPTION
Some pages in the archive did not render. The problem is deprecated pallets in the RPC calls. I hardcoded those values. Since those pages will likely migrate outside of the Wiki in the future, hardcoding the values is necessary anyway.