### PR TITLE
Clarify Multi-sig call deposits

### DIFF
--- a/docs/learn/learn-guides-accounts-multisig.md
+++ b/docs/learn/learn-guides-accounts-multisig.md
@@ -63,7 +63,7 @@ signatories to approve the call before finally executing it.
 
 When you create a new multi-sig call, you will need to place a {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} 
 deposit. The deposit stays locked until the call is executed. This deposit is to establish an economic cost on the 
-storage space that the multisig call takes up on the chain and discourage users from creating multisig
+storage space that the multisig call takes up on the chain state and discourage users from creating multisig
 calls that never get executed. The deposit will be reserved in the call initiator's account.
 
 The deposit is dependent on the `threshold` parameter and is calculated as follows:

--- a/docs/learn/learn-guides-accounts-multisig.md
+++ b/docs/learn/learn-guides-accounts-multisig.md
@@ -61,10 +61,10 @@ signatories to approve the call before finally executing it.
 
 ### Multisig Call Deposit
 
-When you create a new call, you will need to place a small deposit. The deposit stays locked in the pallet
-until the call is executed. The deposit is to establish an economic cost on the storage space that
-the multisig call takes up on the chain and discourage users from creating dangling multisig
-operations that never get executed. The deposit will be reserved in the call initiator's account.
+When you create a new multi-sig call, you will need to place a {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} 
+deposit. The deposit stays locked until the call is executed. This deposit is to establish an economic cost on the 
+storage space that the multisig call takes up on the chain and discourage users from creating multisig
+calls that never get executed. The deposit will be reserved in the call initiator's account.
 
 The deposit is dependent on the `threshold` parameter and is calculated as follows:
 
@@ -81,8 +81,8 @@ and the deposit factor equals
 {{ polkadot: <RPC network="polkadot" path="consts.multisig.depositFactor" defaultValue={320000000} filter="humanReadable"/>. :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.multisig.depositFactor" defaultValue={1066665600} filter="humanReadable"/>. :kusama }}
 
-The other signatory accounts should have enough funds to pay for the transaction fees to sign and submit the multisig transaction.
-No deposit is held on the signatory accounts. Once the multi-sig transaction is executed or rejected, the deposit is released on the
+The other signatory accounts should have enough funds to pay for the transaction fees to sign and submit the multi-sig transaction.
+No deposit is held from the signatory accounts. Once the multi-sig transaction is executed or rejected, the deposit is released on the
 account that created the multi-sig transaction.
 
 ### Example using Multisig Accounts

--- a/docs/learn/learn-guides-accounts-multisig.md
+++ b/docs/learn/learn-guides-accounts-multisig.md
@@ -57,12 +57,14 @@ Parity Technologies. There is a detailed
 that you can try out and change to see how it works.
 
 However, in anything but the simple one approval case, you will likely need more than one of the
-signatories to approve the call before finally executing it. When you create a new call or approve a
-call as a multisig, you will need to place a small deposit. The deposit stays locked in the pallet
+signatories to approve the call before finally executing it. 
+
+### Multisig Call Deposit
+
+When you create a new call, you will need to place a small deposit. The deposit stays locked in the pallet
 until the call is executed. The deposit is to establish an economic cost on the storage space that
 the multisig call takes up on the chain and discourage users from creating dangling multisig
-operations that never get executed. The deposit will be reserved in the caller's accounts, so
-participants in multisig wallets should have spare funds available.
+operations that never get executed. The deposit will be reserved in the call initiator's account.
 
 The deposit is dependent on the `threshold` parameter and is calculated as follows:
 
@@ -78,6 +80,10 @@ the deposit base equals
 and the deposit factor equals
 {{ polkadot: <RPC network="polkadot" path="consts.multisig.depositFactor" defaultValue={320000000} filter="humanReadable"/>. :polkadot }}
 {{ kusama: <RPC network="kusama" path="consts.multisig.depositFactor" defaultValue={1066665600} filter="humanReadable"/>. :kusama }}
+
+The other signatory accounts should have enough funds to pay for the transaction fees to sign and submit the multisig transaction.
+No deposit is held on the signatory accounts. Once the multi-sig transaction is executed or rejected, the deposit is released on the
+account that created the multi-sig transaction.
 
 ### Example using Multisig Accounts
 


### PR DESCRIPTION
Remove ambiguity about deposit being held for signatory accounts and explain the process in detail.