### PR TITLE
Move Fellowship JS Guides

### DIFF
--- a/docs/learn/learn-guides-fellowships.md
+++ b/docs/learn/learn-guides-fellowships.md
@@ -2,7 +2,7 @@
 id: learn-guides-fellowships
 title: Polkadot-JS Guides about Fellowships
 sidebar_label: Fellowships
-description: Polkadot-JS Guides for Bounties
+description: Polkadot-JS Guides for Fellowship Members.
 keyword: [polkadot-js, guides, fellowships, technical fellowship]
 slug: ../learn-guides-fellowships
 ---

--- a/docs/learn/learn-guides-fellowships.md
+++ b/docs/learn/learn-guides-fellowships.md
@@ -1,0 +1,68 @@
+---
+id: learn-guides-fellowships
+title: Polkadot-JS Guides about Fellowships
+sidebar_label: Fellowships
+description: Polkadot-JS Guides for Bounties
+keyword: [polkadot-js, guides, fellowships, technical fellowship]
+slug: ../learn-guides-fellowships
+---
+
+## Becoming a Member of the Polkadot Technical Fellowship
+
+:::info
+
+Currently, only members of the fellowship can add new members. For more information about the
+Polkadot Technical Fellowship see [this page](./learn-polkadot-technical-fellowship.md).
+
+:::
+
+Before starting the candidate induction process, please ensure the candidate account is active and
+has a balance greater than the existential deposit of the collectives system chain (0.1 DOT). It is
+recommended that the candidate account also has a verified identity.
+
+The first step is to add a preimage on the collectives system chain. This preimage should include
+the call to `induct` a candidate account, as shown below. The preimage can be added by any account
+on the collectives system chain. The preimage hash of this call will later be used for creating a
+fellowship referenda with an approriate origin and track.
+
+![candidate-induct](../assets/fellowship-induct-candidate.png)
+
+The next step is to create a fellowship referenda, which can only be done by a pre-existing
+Technical Fellowship member. When a fellowship member navigates to Governance > Fellowship >
+Referenda, they should be able to see a submit proposal button. In the example below,submission
+track is chosen as `1/members`, origin as `FellowshipOrigins` and fellowship origins as `Members`.
+This selection should work for inducting an account without any rank to the fellowship as a
+candidate with rank 0. After copying the preimage hash in the designated field, the preimage length
+will automatically be populated.
+
+![candidate-induct-proposal](../assets/fellowship-candidate-proposal.png)
+
+After submitting the proposal, the voting can commence. A decision deposit needs to be placed for
+this fellowship referendum to be decided. After the fellowship referenda successfully passes, the
+candidate is successfully inducted into the Polkadot Fellowship with rank 0.
+
+### Technical Fellowship Rank Updates
+
+The Polkadot Technical Fellowship members are expected to provide a periodic evidence to request for
+retaining their rank or to get promoted to a higher rank. Any fellowship member upto rank 4 can be
+promoted to the next rank through a fellowship referenda that can be voted by the members who are 2
+ranks higher. For instance, the fellowship
+[referenda 64](https://collectives.subsquare.io/fellowship/referenda/64) which promotes a member
+from rank 1 to rank 2 can only be voted by members whose ranks are greater than or equal to 3.
+Promotion of the Polkadot Fellowship members from rank 5 needs to be done through an OpenGov
+referendum.
+
+This preimage example should include the call to `promote` an account to a specific rank, as shown
+below. This preimage can be added by any account on the collectives system chain.
+
+![candidate-promote](../assets/fellowship-promote-member.png)
+
+In the snapshot below, the submission track is chosen as `21/Promote to I Dan`, origin as
+`FellowshipOrigins` and fellowship origins as `PromoteTo1Dan`. This selection should work for
+promoting a candidate with rank 0 to a member with rank 1.
+
+![candidate-promote-proposal](../assets/fellowship-promotion-proposal.png)
+
+For promoting a member from Rank 1 to Rank 2, the submission track can be chosen as
+`22/Promote to  II Dan`, origin as `FellowshipOrigins` and fellowship origins as `PromoteTo2Dan`.
+Only the members with Rank >= 3 can vote on this proposal.

--- a/docs/learn/learn-guides-polkadot-opengov.md
+++ b/docs/learn/learn-guides-polkadot-opengov.md
@@ -84,7 +84,8 @@ Let's consider increasing the number of validators participating in parachain co
 deposit and has very conservative passing parameters such that it will probably need the entire
 28-day voting period to pass.
 
-Operations that are deemed safe or time critical by the Polkadot Technical Fellowship can use the
+Operations that are deemed safe or time critical by
+[the Polkadot Technical Fellowship](./learn-polkadot-technical-fellowship.md) can use the
 Whitelisted Caller track. This track requires less turnout in the first half of the decision period
 so that it can pass more quickly. This track is typically used for more neutral, technical proposals
 like runtime upgrades or changing the system's parachain validation configuration.

--- a/docs/learn/learn-polkadot-opengov.md
+++ b/docs/learn/learn-polkadot-opengov.md
@@ -106,7 +106,7 @@ following main changes:
 - Dissolving the current [Council](./learn-governance.md#council) collective
 - Allowing users to delegate voting power in more ways to community members
 - Dissolving the [Technical Committee](./learn-governance.md#technical-committee) and establishing
-  the broader [Polkadot Technical Fellowship](#the-technical-fellowship)
+  the broader [Polkadot Technical Fellowship](./learn-polkadot-technical-fellowship.md)
 
 The figure below shows an overview of Polkadot OpenGov's structure.
 
@@ -128,7 +128,7 @@ be submitted in different tracks depending on the amount requested. A proposal f
 need to be submitted in the Small Tipper track, while a proposal requiring substantial funds will
 need to be submitted to the Medium or Big Spender track.
 
-The [Polkadot Technical Fellowship](#the-technical-fellowship) can decide to
+The [Polkadot Technical Fellowship](./learn-polkadot-technical-fellowship.md) can decide to
 [whitelist](#whitelisting) a proposal that will be enacted through the Whitelist Caller origin.
 Those proposals will have a shorter Lead-in, Confirmation, and Enactment period when compared to the
 Root Origin track.
@@ -162,7 +162,7 @@ and learn how to use it.
 
 | Governance V1                                                                                                                                                                                                                                                                                                                                  | Polkadot OpenGov                                                                                                                                                                                                                                       | Polkadot OpenGov Benefit                                                                                                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Includes the [Council](./learn-governance.md#council), the [Technical Committee](./learn-governance.md#technical-committee), and the Public (i.e. token holders).                                                                                                                                                                              | Includes the Public and the [Technical Fellowship](#the-technical-fellowship).                                                                                                                                                                         | Simpler and more decentralized structure.                                                                                                                                      |
+| Includes the [Council](./learn-governance.md#council), the [Technical Committee](./learn-governance.md#technical-committee), and the Public (i.e. token holders).                                                                                                                                                                              | Includes the Public and the [Technical Fellowship](./learn-polkadot-technical-fellowship.md).                                                                                                                                                          | Simpler and more decentralized structure.                                                                                                                                      |
 | Referenda executed only from one origin (Root). Referenda in this origin must be carefully scrutinized. Therefore, there is only one track (i.e. only one referendum at a time can be executed).                                                                                                                                               | Referenda executed from [multiple origins](./learn-polkadot-opengov-origins.md#origins-and-tracks-info), each with a different track that shapes proposals’ timelines. Depending on the origin, multiple referenda within the same track are possible. | Possibility to categorize proposals (based on importance and urgency) and execute them simultaneously within and between origin tracks.                                        |
 | Proposals can be submitted by either the Council or the Public.                                                                                                                                                                                                                                                                                | The public submits proposals.                                                                                                                                                                                                                          | More democratic.                                                                                                                                                               |
 | Uses [Adaptive Quorum Biasing](./learn-governance.md#adaptive-quorum-biasing) to define the approval threshold based on turnout. Given the same turnout, council-initiated referenda require fewer Aye votes to pass compared to public referenda.                                                                                             | Uses origin-specific approval and support curves defining the amount of approval and support (i.e. turnout) needed as a function of time. The same curves are applied to all referenda within the same origin track.                                   | Referenda timeline depends on the origin and not on who submitted the proposal (i.e. Council or Public). This is a more democratic and equalitarian system.                    |
@@ -229,8 +229,8 @@ in Governance v1.
 :::
 
 **In Polkadot OpenGov all referenda are public.** The
-[Technical Fellowship](#the-technical-fellowship) has the option to [whitelist](#whitelisting)
-referenda that can be then proposed in the track with
+[Technical Fellowship](./learn-polkadot-technical-fellowship.md) has the option to
+[whitelist](#whitelisting) referenda that can be then proposed in the track with
 [whitelist origin](./learn-polkadot-opengov-origins.md#whitelisted-caller).
 
 ### Referenda Timeline
@@ -535,26 +535,30 @@ to pay for transaction fees.
 #### Voting Without Conviction
 
 A lock is placed on the {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} when you vote on an
-Ongoing referendum. If you choose to remove your vote when the referendum is still in the decision period, 
-your voting lock is removed. Once the referendum is decided (accepted or rejected), your {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} 
-will be available for unlocking if you voted with zero conviction. The governance app or interface you 
-used for participating in Polkadot OpenGov should show an option to unlock your {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }}.
-[Here](https://support.polkadot.network/support/solutions/articles/65000184129) are the instructions to 
-do it on the Polkadot-JS UI.
+Ongoing referendum. If you choose to remove your vote when the referendum is still in the decision
+period, your voting lock is removed. Once the referendum is decided (accepted or rejected), your
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} will be available for unlocking if you voted
+with zero conviction. The governance app or interface you used for participating in Polkadot OpenGov
+should show an option to unlock your {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }}.
+[Here](https://support.polkadot.network/support/solutions/articles/65000184129) are the instructions
+to do it on the Polkadot-JS UI.
 
 #### Voting with Conviction
 
-If you voted with conviction, the corresponding locks start at the end of the Referendum and not at the moment you voted.
-For instance, let's say you voted AYE with 6X conviction on a referendum, and it got accepted; the 
-{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} you voted with is locked for 32 weeks from that moment.
-If you voted NAY with 6X conviction on a referendum and it got accepted, then your {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }}
-would be ready to be unlocked immediately. Polkadot OpenGov is designed to ensure that only the winning side 
-is mandated to lock their {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} and the losing side can claim 
-{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} and have it added to the transferable balance on their account.
+If you voted with conviction, the corresponding locks start at the end of the Referendum and not at
+the moment you voted. For instance, let's say you voted AYE with 6X conviction on a referendum, and
+it got accepted; the {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} you voted with is locked
+for 32 weeks from that moment. If you voted NAY with 6X conviction on a referendum and it got
+accepted, then your {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} would be ready to be
+unlocked immediately. Polkadot OpenGov is designed to ensure that only the winning side is mandated
+to lock their {{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} and the losing side can claim
+{{ polkadot: DOT :polkadot }}{{ kusama: KSM :kusama }} and have it added to the transferable balance
+on their account.
 
-For unlocking generic account locks, navigate to [this section](./learn-guides-accounts.md#unlocking-locks). When you
-delegate your votes, the locking mechanism differs slightly. Please check the next section on Multirole Delegation for
-more information.
+For unlocking generic account locks, navigate to
+[this section](./learn-guides-accounts.md#unlocking-locks). When you delegate your votes, the
+locking mechanism differs slightly. Please check the next section on Multirole Delegation for more
+information.
 
 ### Multirole Delegation
 

--- a/docs/learn/learn-polkadot-technical-fellowship.md
+++ b/docs/learn/learn-polkadot-technical-fellowship.md
@@ -129,56 +129,11 @@ pallet.
 
 :::
 
-Before starting the candidate induction process, please ensure the candidate account is active and
-has a balance greater than the existential deposit of the collectives system chain (0.1 DOT). It is
-recommended that the candidate account also has a verified identity.
-
-The first step is to add a preimage on the collectives system chain. This preimage should include
-the call to `induct` a candidate account, as shown below. The preimage can be added by any account
-on the collectives system chain. The preimage hash of this call will later be used for creating a
-fellowship referenda with an approriate origin and track.
-
-![candidate-induct](../assets/fellowship-induct-candidate.png)
-
-The next step is to create a fellowship referenda, which can only be done by a pre-existing
-Technical Fellowship member. When a fellowship member navigates to Governance > Fellowship >
-Referenda, they should be able to see a submit proposal button. In the example below,submission
-track is chosen as `1/members`, origin as `FellowshipOrigins` and fellowship origins as `Members`.
-This selection should work for inducting an account without any rank to the fellowship as a
-candidate with rank 0. After copying the preimage hash in the designated field, the preimage length
-will automatically be populated.
-
-![candidate-induct-proposal](../assets/fellowship-candidate-proposal.png)
-
-After submitting the proposal, the voting can commence. A decision deposit needs to be placed for
-this fellowship referendum to be decided. After the fellowship referenda successfully passes, the
-candidate is successfully inducted into the Polkadot Fellowship with rank 0.
-
-### Rank Updates
-
-The Polkadot Technical Fellowship members are expected to provide a periodic evidence to request for
-retaining their rank or to get promoted to a higher rank. Any fellowship member upto rank 4 can be
-promoted to the next rank through a fellowship referenda that can be voted by the members who are 2
-ranks higher. For instance, the fellowship
-[referenda 64](https://collectives.subsquare.io/fellowship/referenda/64) which promotes a member
-from rank 1 to rank 2 can only be voted by members whose ranks are greater than or equal to 3.
-Promotion of the Polkadot Fellowship members from rank 5 needs to be done through an OpenGov
-referendum.
-
-This preimage example should include the call to `promote` an account to a specific rank, as shown
-below. This preimage can be added by any account on the collectives system chain.
-
-![candidate-promote](../assets/fellowship-promote-member.png)
-
-In the snapshot below, the submission track is chosen as `21/Promote to I Dan`, origin as
-`FellowshipOrigins` and fellowship origins as `PromoteTo1Dan`. This selection should work for
-promoting a candidate with rank 0 to a member with rank 1.
-
-![candidate-promote-proposal](../assets/fellowship-promotion-proposal.png)
-
-For promoting a member from Rank 1 to Rank 2, the submission track can be chosen as
-`22/Promote to  II Dan`, origin as `FellowshipOrigins` and fellowship origins as `PromoteTo2Dan`.
-Only the members with Rank >= 3 can vote on this proposal.
+See
+[these Polkadot-JS Guides](./learn-guides-fellowships.md#becoming-a-member-of-the-polkadot-technical-fellowship)
+to learn more about how to become a member of the Polkadot Technical Fellowship. In-depth
+information about the fellowship can be found
+[here](https://polkadot-fellows.github.io/dashboard/#/overview).
 
 #### Retain Rank
 

--- a/docs/learn/learn-polkadot-technical-fellowship.md
+++ b/docs/learn/learn-polkadot-technical-fellowship.md
@@ -131,8 +131,8 @@ pallet.
 
 See
 [these Polkadot-JS Guides](./learn-guides-fellowships.md#becoming-a-member-of-the-polkadot-technical-fellowship)
-to learn more about how to become a member of the Polkadot Technical Fellowship. In-depth
-information about the fellowship can be found
+to learn more about how to become a member of the Polkadot Technical Fellowship. The official
+documentation about the fellowship can be found
 [here](https://polkadot-fellows.github.io/dashboard/#/overview).
 
 #### Retain Rank

--- a/docs/learn/learn-polkadot-technical-fellowship.md
+++ b/docs/learn/learn-polkadot-technical-fellowship.md
@@ -117,7 +117,7 @@ This initiative is funded by Polkadot treasury through
 
 :::
 
-:::info
+:::info Only Pre-existing members can currently add new members
 
 The fellowship manifesto states that any account may register to become a candidate for a basic
 deposit, but that feature has not been added to the collectives runtime yet. To be added as a

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -334,6 +334,7 @@ module.exports = {
                     "learn/learn-guides-treasury",
                     "learn/learn-guides-bounties",
                     "learn/learn-guides-identity",
+                    "learn/learn-guides-fellowships",
                     "learn/learn-guides-ledger",
                     "learn/learn-guides-vault",
                     {


### PR DESCRIPTION
This PR moved the JS guides from the fellowship Learn page to a new page dedicated the JS guides for fellowships in the Advanced section. It also fixes some broken links on the OpenGov page.