### PR TITLE
Async Backing Guide: Ignore warn block in prettier

### DIFF
--- a/docs/maintain/maintain-guides-async-backing.md
+++ b/docs/maintain/maintain-guides-async-backing.md
@@ -92,8 +92,11 @@ zombienet):
 "scheduling_lookahead": 2
 ```
 
+<!-- prettier-ignore-start -->
 :::warning warning `scheduling_lookahead` must be set to 2, otherwise parachain block times will
-degrade to worse than with sync backing! :::
+degrade to worse than with sync backing! 
+:::
+<!-- prettier-ignore-end -->
 
 ## Phase 1 - Update Parachain Runtime
 


### PR DESCRIPTION
Bug:
![image](https://github.com/w3f/polkadot-wiki/assets/5718005/d2330e60-4a55-4585-931c-9c8e788e30f8)


A recent run of prettier seems to have messed up the warning block pretty bad, it included the entire rest of the page. It should be ignored now.