### PR TITLE
Build Clean-Up and Reorg

### DIFF
--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -131,10 +131,7 @@ decentralized _content-centric_ approach.
 [IPFS](https://ipfs.io/) is a peer-to-peer distributed file system that seeks to connect all
 computing devices with the same system of files, by utilizing features such as content-addressing,
 content-signing, and enhanced security methods through encryption. IPFS aims to address the current
-hurdles of the HTTP-based Internet.
-
-</TabItem>
-<TabItem value="crust">
+hurdles of the HTTP-based Internet. </TabItem> <TabItem value="crust">
 
 [Crust Network](https://crust.network) provides a Web3.0 decentralized storage network for the
 Metaverse. It is designed to realize core values of decentralization, privacy, and assurance. Crust

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -177,6 +177,8 @@ an S3-compatible API for widespread integrations and configurations in current w
 To learn more about Filebase, check out the [Filebase Documentation](https://docs.filebase.com), and
 specifically the documentation on
 [deploying Polkadot dApp on decentralized storage.](https://docs.filebase.com/web3-education/web3-tutorials/polkadot/polkadot-deploy-a-polkadot-dapp-on-decentralized-storage)
-You can get started with Filebase by signing up [here.](https://filebase.com/signup) </TabItem>
+You can get started with Filebase by signing up [here.](https://filebase.com/signup)
+
+</TabItem>
 
 </Tabs>

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -1,0 +1,177 @@
+---
+id: build-client-side
+title: Building Client-side Apps
+sidebar_label: Building Client-side Apps
+description: An overview about building clients that use Polkadot
+keywords: [data, index, query, explorer, dashboard, dapp, uapp, app, frontend, client]
+slug: ../build-client-side
+---
+
+import Tabs from "@theme/Tabs"; import TabItem from "@theme/TabItem";
+
+As with any blockchain, building decentralized applications (dApps) is a significant part of how a
+developer can build on Polkadot. Within the ecosystem, you also hear the term "Unstoppable App", or
+uApp. While the naming isn't too important, what is important is building resilient applications
+using decentralized technology.
+
+As an application developer, you can compose your front-end apps in a few different ways. Because
+Polkadot and its parachains are all built using Substraste; you can often use the same SDK to
+communicate with Polkadot, a parachain, or any other Substrate-based chain.
+
+:::note Substrate-based chains use an SS58 encoding for their address formats.
+
+Please see the [SS58 registry](https://github.com/paritytech/ss58-registry/) to see which
+[chain corresponds to a given prefix](https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json),
+and which prefixes are available.
+
+:::
+
+## SDKS & Libraries
+
+If one aims to develop a **dApp** (Decentralized App) or **uApp** (Unstoppable App), the Polkadot
+ecosystem contains various SDKs to tap into the relay chain and parachains. There are several
+languages already supported -
+[see the tooling page for a detailed overview of different SDKs and libraries that are available.](./build-tools-index.md)
+
+## Frameworks & Toolkits
+
+For front-end applications, several options exist for interfacing with Substrate-based chains
+(parachains, relay chains, etc.) and smart contracts. These often will interact with the RPC of a
+Substrate node:
+
+<!-- prettier-ignore -->
+<Tabs groupId="clients" values={[ {label: 'Polkadot.js', value: 'pjs'}, { label: 'Polkadot API (under development)', value: 'papi'}, {label: 'Subxt', value: 'subxt'}, {label: 'React Hooks for ink!', value: 'useink'}, {label: 'ink!athon Boilerplate', value: 'inkathon'}, { label: 'Polkadot Cloud', value: 'pcloud'} ]}>
+
+<TabItem value="pjs"> Promise and RxJS APIs around Polkadot and Substrate-based chains via RPC
+calls. It is dynamically generated based on what the Substrate runtime provides regarding metadata.
+Full documentation & examples
+available&nbsp;<a href="https://polkadot.js.org/docs" target="_blank">here</a>. </TabItem>
+
+<TabItem value="papi"> The Polkadot API (formerly known as "CAPI") is currently under development,
+but will serve as a replacement for Polkadot JS. While still under construction, you may view the
+current progress on GitHub
+&nbsp;<a href="https://github.com/paritytech/polkadot-api/" target="_blank">here</a>. </TabItem>
+
+<TabItem value="subxt"> Query and submit extrinsics (transactions) to a Substrate node via RPC using
+Rust. Also referred to as Rust Parity. Full documentation & examples
+available&nbsp;<a href="https://github.com/paritytech/subxt" target="_blank">here</a>. </TabItem>
+
+<TabItem value="useink"> React hooks library for ink! smart contracts that abstract the
+functionality of polkadot.js. Full documentation & examples
+available&nbsp;<a href="https://use.ink" target="_blank">here</a>. </TabItem>
+
+<TabItem value="inkathon">ink!athon is a starter kit for full-stack dApp development with ink! smart
+contracts and a React-based frontend in one place. With convenient helper scripts and a
+pre-configured project setup, you can quickly scaffold any dApp. Live example & full documentation
+available&nbsp;<a href="https://inkathon.xyz" target="_blank">here</a>. </TabItem>
+
+<TabItem value="pcloud">Polkadot Cloud hosts a library of assets, ranging from data sources,
+graphical elements, to fully functional components, for app developers to plug and play into their
+codebases. &nbsp;<a href="https://polkadot.cloud/" target="_blank">Learn more here</a>. </TabItem>
+
+</Tabs>
+
+## Oracle Options for Polkadot
+
+In the blockchain context, an _oracle_ is a way to bring real-world data onto the blockchain so that
+it can be used by a decentralized application.
+
+Oracles serve many purposes for application builder, as they allow for outside data (price feeds,
+the ability to make HTTP requests, etc) to enter the decentralized world.
+
+Oracle solutions range from centralized and trusted to decentralized and game-theory based. On the
+centralized end of the spectrum, an oracle could be a single account that has the authority to
+dictate the real-world data on-chain. On the decentralized end, a
+[complex game of "chicken"](https://blog.ethereum.org/2014/03/28/schellingcoin-a-minimal-trust-universal-data-feed/)
+can be played among various staked actors who risk getting slashed if they don't submit the same
+data as everyone else.
+
+<!-- prettier-ignore -->
+<Tabs groupId="clients" values={[ {label: 'Chainlink', value: 'chainlink'}, {label: 'Acurast', value: 'acurast'} ]}>
+
+<TabItem value="chainlink"> Solutions such as
+<a href="https://polkadot.network/chainlink-reaches-milestone-with-polkadot/" target="_blank">
+Chainlink</a> fit somewhere in the middle, where the amount of trust you put into the reporting
+oracles can be adjusted based on your preferences. A Chainlink
+<a href="https://github.com/smartcontractkit/chainlink-polkadot/blob/master/pallet-chainlink-feed/README.md" target="_blank">Feed
+Pallet</a> is available to allow smart contracts across smart contract-enabled parachains to access
+price reference data, and is available as a Substrate oracle pallet.&nbsp; </TabItem>
+
+<TabItem value="acurast"> Solutions such as
+<a href="https://acurast.com" target="_blank">Acurast</a> enables developers to delegate oracle
+requests to their network of phones, which provide off-chain data and computation to the
+<a href="https://docs.acurast.com/integrations/substrate" target="_blank">Acurast Pallet</a>.
+Acurast supports both Substrate (WASM) and EVM environments. </TabItem> </Tabs>
+
+When using an oracle in your application you should be aware of the benefits and risks that are
+baked into its specific model.
+
+## Decentralized Storage Options
+
+Storage is an integral part of modern computer systems, and the same is true for distributed and
+decentralized systems like a blockchain. When interacting with the
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} ecosystem, it will be helpful if you
+familiarize yourself with the current Web3 approach towards decentralized storage.
+
+## DCS (Decentralized Cloud Storage)
+
+The key attribute that characterizes centralized cloud storage is the location of data.
+
+In decentralized cloud storage, the key attribute becomes the data itself instead of the data's
+location.
+
+This can be viewed as the shift from the centralized _location-centric_ storage approach to the
+decentralized _content-centric_ approach.
+
+<!-- prettier-ignore -->
+<Tabs groupId="clients" values={[ {label: 'IPFS (Interplanetary File System)', value: 'ipfs'}, {label: 'Crust Storage', value: 'crust'}, {label: 'Filebase', value: 'filebase'} ]}>
+
+<TabItem value="ipfs">
+
+[IPFS](https://ipfs.io/) is a peer-to-peer distributed file system that seeks to connect all
+computing devices with the same system of files, by utilizing features such as content-addressing,
+content-signing, and enhanced security methods through encryption. IPFS aims to address the current
+hurdles of the HTTP-based Internet.
+
+</TabItem>
+<TabItem value="crust">
+
+[Crust Network](https://crust.network) provides a Web3.0 decentralized storage network for the
+Metaverse. It is designed to realize core values of decentralization, privacy, and assurance. Crust
+supports multiple storage-layer protocols such as [IPFS](#ipfs-interplanetary-file-system), and
+exposes instant accessible on-chain storage functions to users. Crustʼs technical stack is also
+capable of supporting data manipulating and computing.
+
+Crust provides a native cross-chain communication pallet based on
+[XCMP](https://wiki.polkadot.network/docs/learn-xcm), called
+[xStorage](https://github.com/crustio/crust/tree/parachain/shadow/crust-collator/pallets/xstorage).
+
+The protocol also supports most smart contract platforms, including Ethereum, with its
+[cross-chain dStorage solution](https://wiki.crust.network/docs/en/buildCrossChainSolution).
+
+To learn more about Crust, check out the [Crust Network Wiki](https://wiki.crust.network/en). Try
+integrating with Crust by following their
+[Crust Storage 101](https://wiki.crust.network/docs/en/build101) guide.
+
+</TabItem>
+<TabItem value="filebase">
+
+[Filebase](https://filebase.com) is the first S3-compatible object storage platform that allows you
+to store data in a secure, redundant, and performant manner across multiple decentralized storage
+networks.
+
+Filebase offers a geo-redundant IPFS pinning service that allows you to pin files to IPFS across
+multiple diverse geographic locations. All files uploaded to IPFS through Filebase are automatically
+pinned to the Filebase infrastructure with 3x replication across the globe. This ensures that your
+data is globally available and redundant at all times.
+
+Filebase acts as an easy on-ramp to IPFS and decentralized storage by offering a user-friendly web
+console dashboard, making drag-and-dropping files onto Web3 simple and easy. Filebase also provides
+an S3-compatible API for widespread integrations and configurations in current workflows.
+
+To learn more about Filebase, check out the [Filebase Documentation](https://docs.filebase.com), and
+specifically the documentation on
+[deploying Polkadot dApp on decentralized storage.](https://docs.filebase.com/web3-education/web3-tutorials/polkadot/polkadot-deploy-a-polkadot-dapp-on-decentralized-storage)
+You can get started with Filebase by signing up [here.](https://filebase.com/signup) </TabItem>
+
+</Tabs>

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -15,7 +15,7 @@ uApp. While the naming isn't too important, what is important is building resili
 using decentralized technology.
 
 As an application developer, you can compose your front-end apps in a few different ways. Because
-Polkadot and its parachains are all built using Substraste; you can often use the same SDK to
+Polkadot and its parachains are all built using the Polkadot SDK. You can often use the same SDK to
 communicate with Polkadot, a parachain, or any other Substrate-based chain.
 
 :::note Substrate-based chains use an SS58 encoding for their address formats.

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -132,7 +132,9 @@ decentralized _content-centric_ approach.
 [IPFS](https://ipfs.io/) is a peer-to-peer distributed file system that seeks to connect all
 computing devices with the same system of files, by utilizing features such as content-addressing,
 content-signing, and enhanced security methods through encryption. IPFS aims to address the current
-hurdles of the HTTP-based Internet. </TabItem>
+hurdles of the HTTP-based Internet.
+
+</TabItem>
 
 <!-- prettier-ignore -->
 <TabItem value="crust">

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -10,13 +10,13 @@ slug: ../build-client-side
 import Tabs from "@theme/Tabs"; import TabItem from "@theme/TabItem";
 
 As with any blockchain, building decentralized applications (dApps) is a significant part of how a
-developer can build on Polkadot. Within the ecosystem, you also hear the term "Unstoppable App", or
-uApp. While the naming isn't too important, what is important is building resilient applications
-using decentralized technology.
+developer can build on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}.
 
 As an application developer, you can compose your front-end apps in a few different ways. Because
-Polkadot and its parachains are all built using Substraste; you can often use the same SDK to
-communicate with Polkadot, a parachain, or any other Substrate-based chain.
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} and its parachains are all built
+using Substraste; you can often use the same SDK to communicate with
+{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}, a parachain, or any other
+Substrate-based chain.
 
 :::note Substrate-based chains use an SS58 encoding for their address formats.
 
@@ -28,23 +28,22 @@ and which prefixes are available.
 
 ## SDKS & Libraries
 
-If one aims to develop a **dApp** (Decentralized App) or **uApp** (Unstoppable App), the Polkadot
-ecosystem contains various SDKs to tap into the relay chain and parachains. There are several
-languages already supported -
+If one aims to develop a **dApp** (Decentralized App), the Polkadot ecosystem contains various SDKs
+to tap into the relay chain and parachains. There are several languages already supported -
 [see the tooling page for a detailed overview of different SDKs and libraries that are available.](./build-tools-index.md)
 
 ## Frameworks & Toolkits
 
 For front-end applications, several options exist for interfacing with Substrate-based chains
-(parachains, relay chains, etc.) and smart contracts. These often will interact with the RPC of a
+(parachains, relay chains, etc.) and smart contracts. These will often interact with the RPC of a
 Substrate node:
 
 <!-- prettier-ignore -->
 <Tabs groupId="clients" values={[ {label: 'Polkadot.js', value: 'pjs'}, { label: 'Polkadot API (under development)', value: 'papi'}, {label: 'Subxt', value: 'subxt'}, {label: 'React Hooks for ink!', value: 'useink'}, {label: 'ink!athon Boilerplate', value: 'inkathon'}, { label: 'Polkadot Cloud', value: 'pcloud'} ]}>
 
-<TabItem value="pjs"> Promise and RxJS APIs around Polkadot and Substrate-based chains via RPC
-calls. It is dynamically generated based on what the Substrate runtime provides regarding metadata.
-Full documentation & examples
+<TabItem value="pjs"> Promise and RxJS APIs around Polkadot, Kusama, and other Substrate-based
+chains via RPC calls. It is dynamically generated based on what the Substrate runtime provides
+regarding metadata. Full documentation & examples
 available&nbsp;<a href="https://polkadot.js.org/docs" target="_blank">here</a>. </TabItem>
 
 <TabItem value="papi"> The Polkadot API (formerly known as "CAPI") is currently under development,
@@ -71,7 +70,7 @@ codebases. &nbsp;<a href="https://polkadot.cloud/" target="_blank">Learn more he
 
 </Tabs>
 
-## Oracle Options for Polkadot
+## Oracle Options
 
 In the blockchain context, an _oracle_ is a way to bring real-world data onto the blockchain so that
 it can be used by a decentralized application.

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -126,12 +126,16 @@ decentralized _content-centric_ approach.
 <!-- prettier-ignore -->
 <Tabs groupId="clients" values={[ {label: 'IPFS (Interplanetary File System)', value: 'ipfs'}, {label: 'Crust Storage', value: 'crust'}, {label: 'Filebase', value: 'filebase'} ]}>
 
+<!-- prettier-ignore -->
 <TabItem value="ipfs">
 
 [IPFS](https://ipfs.io/) is a peer-to-peer distributed file system that seeks to connect all
 computing devices with the same system of files, by utilizing features such as content-addressing,
 content-signing, and enhanced security methods through encryption. IPFS aims to address the current
-hurdles of the HTTP-based Internet. </TabItem> <TabItem value="crust">
+hurdles of the HTTP-based Internet. </TabItem>
+
+<!-- prettier-ignore -->
+<TabItem value="crust">
 
 [Crust Network](https://crust.network) provides a Web3.0 decentralized storage network for the
 Metaverse. It is designed to realize core values of decentralization, privacy, and assurance. Crust
@@ -151,6 +155,8 @@ integrating with Crust by following their
 [Crust Storage 101](https://wiki.crust.network/docs/en/build101) guide.
 
 </TabItem>
+
+<!-- prettier-ignore -->
 <TabItem value="filebase">
 
 [Filebase](https://filebase.com) is the first S3-compatible object storage platform that allows you

--- a/docs/build/build-client-side.md
+++ b/docs/build/build-client-side.md
@@ -95,13 +95,19 @@ Chainlink</a> fit somewhere in the middle, where the amount of trust you put int
 oracles can be adjusted based on your preferences. A Chainlink
 <a href="https://github.com/smartcontractkit/chainlink-polkadot/blob/master/pallet-chainlink-feed/README.md" target="_blank">Feed
 Pallet</a> is available to allow smart contracts across smart contract-enabled parachains to access
-price reference data, and is available as a Substrate oracle pallet.&nbsp; </TabItem>
+price reference data, and is available as a Substrate oracle pallet.&nbsp;
+
+</TabItem>
 
 <TabItem value="acurast"> Solutions such as
 <a href="https://acurast.com" target="_blank">Acurast</a> enables developers to delegate oracle
 requests to their network of phones, which provide off-chain data and computation to the
 <a href="https://docs.acurast.com/integrations/substrate" target="_blank">Acurast Pallet</a>.
-Acurast supports both Substrate (WASM) and EVM environments. </TabItem> </Tabs>
+Acurast supports both Substrate (WASM) and EVM environments.
+
+</TabItem>
+
+</Tabs>
 
 When using an oracle in your application you should be aware of the benefits and risks that are
 baked into its specific model.
@@ -115,13 +121,10 @@ familiarize yourself with the current Web3 approach towards decentralized storag
 
 ## DCS (Decentralized Cloud Storage)
 
-The key attribute that characterizes centralized cloud storage is the location of data.
-
-In decentralized cloud storage, the key attribute becomes the data itself instead of the data's
-location.
-
-This can be viewed as the shift from the centralized _location-centric_ storage approach to the
-decentralized _content-centric_ approach.
+The key attribute that characterizes centralized cloud storage is the location of data. In
+decentralized cloud storage, the key attribute becomes the data itself instead of the data's
+location. This can be viewed as the shift from the centralized _location-centric_ storage approach
+to the decentralized _content-centric_ approach.
 
 <!-- prettier-ignore -->
 <Tabs groupId="clients" values={[ {label: 'IPFS (Interplanetary File System)', value: 'ipfs'}, {label: 'Crust Storage', value: 'crust'}, {label: 'Filebase', value: 'filebase'} ]}>

--- a/docs/build/build-dapp.md
+++ b/docs/build/build-dapp.md
@@ -10,9 +10,7 @@ slug: ../build-dapp
 import Tabs from "@theme/Tabs"; import TabItem from "@theme/TabItem";
 
 As with any blockchain, building decentralized applications (dApps) is a huge part of how a
-developer can build on Polkadot. Within the ecosystem, you also hear the term "Unstoppable App", or
-uApp. While the naming isn't too important, what is important is building resilient applications
-using decentralized technology.
+developer can build on Polkadot.
 
 As an application developer, you can compose your front-end apps in a few different ways. Because
 Polkadot and its parachains are all built using Substraste; you can often use the same SDK to
@@ -28,9 +26,8 @@ and which prefixes are available.
 
 ## SDKS & Libraries
 
-If one aims to develop a **dApp** (Decentralized App) or **uApp** (Unstoppable App), the Polkadot
-ecosystem contains various SDKs to tap into the relay chain and parachains. There are several
-languages already supported -
+If one aims to develop a **dApp** (Decentralized App), the Polkadot ecosystem contains various SDKs
+to tap into the relay chain and parachains. There are several languages already supported -
 [see the tooling page for a detailed overview of different SDKs and libraries that are available.](./build-tools-index.md)
 
 ## Frameworks & Toolkits

--- a/docs/build/build-guide.md
+++ b/docs/build/build-guide.md
@@ -314,3 +314,15 @@ Substrate node.
 
 For a complete list of tools, please take a look here:
 [Tools, APIs, and Languages](build-open-source.md)
+
+## Resources
+
+- [System (Common Good) Parachains](https://polkadot.network/blog/common-good-parachains-an-introduction-to-governance-allocated-parachain-slots/)
+- [The Launch of Parachains](https://polkadot.network/blog/the-launch-of-parachains/)
+- [Parathreads: Pay-as-you-go Parachains](https://medium.com/polkadot-network/parathreads-pay-as-you-go-parachains-7440d23dde06)
+- [Polkadot Bridges](https://medium.com/polkadot-network/polkadot-bridges-connecting-the-polkadot-ecosystem-with-external-networks-1118916392e3)
+- [The Path of a Parachain Block](https://polkadot.network/blog/the-path-of-a-parachain-block/)
+- [The Path of a Parachain Block (Video)](https://www.crowdcast.io/e/polkadot-path-of-a-parachain-block?utm_source=profile&utm_medium=profile_web&utm_campaign=profile)
+- [Polkadot Parachain Slots](https://polkadot.network/polkadot-parachain-slots/)
+- [How to become a parachain on Polkadot (Video)](https://www.youtube.com/watch?v=fYc1yolanoE)
+- [Trusted Execution Environments and the Polkadot Ecosystem](https://polkadot.network/blog/trusted-execution-environments-and-the-polkadot-ecosystem/)

--- a/docs/build/build-guide.md
+++ b/docs/build/build-guide.md
@@ -303,8 +303,8 @@ a smart contract.
 
 ## Developing a dApp/uApp
 
-If one aims to develop a **dApp** (Decentralized App) or **uApp** (Unstoppable App), the Polkadot
-ecosystem contains various SDKs to tap into the relay chain and parachains.
+If one aims to develop a **dApp** (Decentralized App), the Polkadot ecosystem contains various SDKs
+to tap into the relay chain and parachains.
 
 For front-end applications, several options exist for interfacing with Substrate-based chains
 (parachains, relay chains, etc.) and smart contracts. These often will interact with the RPC of a

--- a/docs/build/build-integrate-assets.md
+++ b/docs/build/build-integrate-assets.md
@@ -1,8 +1,8 @@
 ---
 id: build-integrate-assets
-title: Assets on Polkadot
-sidebar_label: Integrating Assets
-description: Tools that you can use to integrating assets.
+title: Using AssetHub
+sidebar_label: Using AssetHub
+description: Tools that you can use for integrating assets.
 keywords: [assets, integration, api, operations]
 slug: ../build-integrate-assets
 ---

--- a/docs/build/build-network-overview.md
+++ b/docs/build/build-network-overview.md
@@ -1,7 +1,7 @@
 ---
 id: build-network-overview
-title: Networks Overview
-sidebar_label: Networks Overview
+title: Development Networks
+sidebar_label: Development Networks
 description: An overview of the different networks on Polkadot
 keywords: [data, index, query, explorer, dashboard, dapp, uapp, app, frontend, client]
 slug: ../build-network-overview

--- a/docs/build/build-parachains.md
+++ b/docs/build/build-parachains.md
@@ -7,14 +7,6 @@ keywords: [build, parachain, develop, implement, PDK]
 slug: ../build-pdk
 ---
 
-### Your Go-To Overview for Developing a Parachain
-
-This guide will cover the motivation to build a parachain or parathread, the tools available to
-facilitate this, the steps to test, and finally, how to launch your network on
-{{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} .
-
-### Why Create a Parachain?
-
 Parachains are connected to and secured by the Relay Chain. They benefit from the _pooled security_,
 _thought-through governance_, and overall _scalability_ of the heterogeneous sharding approach of
 the network. Creating a parachain can be seen as creating a **Layer-1 blockchain**, which has its

--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -1,7 +1,7 @@
 ---
 id: build-protocol-info
-title: Polkadot Protocol Information
-sidebar_label: Polkadot Protocol
+title: Polkadot Protocol Overview
+sidebar_label: Polkadot Protocol Overview
 description:
   Characteristics about the Polkadot protocol, and what you need to consider when building.
 keywords: [build, protocol, extrinsics, events, transaction]
@@ -13,6 +13,10 @@ import RPC from "./../../components/RPC-Connection";
 This page serves as a high-level introduction to the Polkadot protocol with terminology that may be
 specific to Polkadot, notable differences to other chains that you may have worked with, and
 practical information for dealing with the chain.
+
+> If the below does not offer a sufficient amount of information regarding the Polkadot protocol, be
+> sure to visit the [Polkadot Spec](https://spec.polkadot.network/id-polkadot-protocol), which is
+> more verbose than this Wiki page.
 
 ## Tokens
 

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -659,7 +659,6 @@ module.exports = {
           items: [
             "build/build-client-side",
             "build/build-light-clients",
-            "build/build-transaction-construction",
             "build/build-node-interaction",
           ],
         },
@@ -680,22 +679,7 @@ module.exports = {
             "build/build-hrmp-channels"
           ],
         },
-        {
-          type: "category",
-          label: "Development Networks & Node Management",
-          link: {
-            type: 'generated-index',
-            title: "Development Networks & Node Management",
-            description: "Learn how to get started with building parachains, solo-chains, and other aspects of protocol development.",
-            slug: '/build-network-index',
-          },
-          items: [
-            "build/build-network-overview",
-            "build/build-integration",
-            "build/build-node-management",
-          ],
-        },
-
+        "build/build-network-overview",
         {
           type: "category",
           label: "Tooling",
@@ -711,6 +695,21 @@ module.exports = {
         {
           type: "doc",
           id: "build/build-hackathon",
+        },
+        {
+          type: "category",
+          label: "Build Archive",
+          link: {
+            type: 'generated-index',
+            title: "Archived Build Resources",
+            description: "Archived build resources for building on Polkadot",
+            slug: '/build-archive-index',
+          },
+          items: [
+            "build/build-transaction-construction",
+            "build/build-integration",
+            "build/build-node-management",
+          ],
         },
       ],
     },

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -657,10 +657,8 @@ module.exports = {
             slug: '/build-client-index',
           },
           items: [
-            "build/build-dapp",
-            "build/build-oracle", 
+            "build/build-client-side",
             "build/build-light-clients",
-            "build/build-storage",
             "build/build-transaction-construction",
             "build/build-node-interaction",
           ],

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -674,7 +674,6 @@ module.exports = {
           },
           items: [
             "build/build-protocol-info",
-            "build/build-parachains",
             "build/build-integrate-assets",
             "build/build-hrmp-channels"
           ],
@@ -709,6 +708,7 @@ module.exports = {
             "build/build-transaction-construction",
             "build/build-integration",
             "build/build-node-management",
+            "build/build-parachains"
           ],
         },
       ],


### PR DESCRIPTION
This PR further organizes, removes, and cleans up the build section.

- Makes use of tabs to consolidate information
- Stick to more concise, up-to-date "one-pagers" rather than outdated guides
- Offer clear paths to external resources