### PR TITLE
Fix ipfs gateway domain.

### DIFF
--- a/docs/build/build-storage.md
+++ b/docs/build/build-storage.md
@@ -24,7 +24,7 @@ decentralized _content-centric_ approach.
 
 ### IPFS (Interplanetary File System)
 
-[IPFS](https://ipfs.io/) is a peer-to-peer distributed file system that seeks to connect all
+[IPFS](https://ipfs.tech/) is a peer-to-peer distributed file system that seeks to connect all
 computing devices with the same system of files, by utilizing features such as content-addressing,
 content-signing, and enhanced security methods through encryption. IPFS aims to address the current
 hurdles of the HTTP-based Internet.

--- a/docs/build/build-tools-index.md
+++ b/docs/build/build-tools-index.md
@@ -19,7 +19,7 @@ Please see the [Wallets](../general/wallets-and-extensions.md) page.
 
 - [Polkadot-JS Apps Explorer](https://polkadot.js.org/apps/#/explorer) - Polkadot dashboard block
   explorer. Supports dozens of other networks, including Kusama, Westend, and other remote or local
-  endpoints. [Access via IPFS](https://dweb.link/ipns/dotapps.io)
+  endpoints. [Access via IPFS](https://cloudflare-ipfs.com/ipns/dotapps.io)
 - [Polkascan](https://polkascan.io/) - Blockchain explorer for Polkadot, Kusama, and other related
   chains. [Repo](https://github.com/polkascan/polkascan-os).
 - [Subscan](https://subscan.io) - Blockchain explorer for Substrate chains.

--- a/docs/build/build-tools-index.md
+++ b/docs/build/build-tools-index.md
@@ -19,7 +19,7 @@ Please see the [Wallets](../general/wallets-and-extensions.md) page.
 
 - [Polkadot-JS Apps Explorer](https://polkadot.js.org/apps/#/explorer) - Polkadot dashboard block
   explorer. Supports dozens of other networks, including Kusama, Westend, and other remote or local
-  endpoints. [Access via IPFS](https://ipfs.io/ipns/dotapps.io)
+  endpoints. [Access via IPFS](https://dweb.link/ipns/dotapps.io)
 - [Polkascan](https://polkascan.io/) - Blockchain explorer for Polkadot, Kusama, and other related
   chains. [Repo](https://github.com/polkascan/polkascan-os).
 - [Subscan](https://subscan.io) - Blockchain explorer for Substrate chains.

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -85,7 +85,7 @@ size of the active set and how many validators are waiting in the pool.
 There are a few ways to estimate the minimum stake.
 
 One way can be to navigate to the
-[Polkadot Apps Targets tab](https://ipfs.io/ipns/polkadot.dotapps.io/#/staking/targets). The value
+[Polkadot Apps Targets tab](https://dweb.link/ipns/polkadot.dotapps.io/#/staking/targets). The value
 at the top of the screen saying "Lowest" is the least staked validator. You need at least this
 much + 1 to enter the set.
 
@@ -308,7 +308,7 @@ libp2p and the standard and custom protocols, please see the
 
 ### How does libp2p differ from IPFS?
 
-The [Interplanetary File System](https://ipfs.io/) (IPFS) is a peer-to-peer hypermedia protocol used
+The [Interplanetary File System](https://ipfs.tech/) (IPFS) is a peer-to-peer hypermedia protocol used
 primarily for storage of files. It allows one to upload a file onto the network and share it with
 its content addressable URI. IPFS, like Substrate, is an application of libp2p and exists higher on
 the technology stack. Although both IPFS and Substrate use libp2p, it cannot be said that Substrate

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -85,7 +85,7 @@ size of the active set and how many validators are waiting in the pool.
 There are a few ways to estimate the minimum stake.
 
 One way can be to navigate to the
-[Polkadot Apps Targets tab](https://dweb.link/ipns/polkadot.dotapps.io/#/staking/targets). The value
+[Polkadot Apps Targets tab](https://cloudflare-ipfs.com/ipns/polkadot.dotapps.io/#/staking/targets). The value
 at the top of the screen saying "Lowest" is the least staked validator. You need at least this
 much + 1 to enter the set.
 

--- a/docs/maintain/kusama/maintain-guides-society-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-society-kusama.md
@@ -59,7 +59,7 @@ any questions if anything is unclear.
 ### 1. Bid Phase
 
 To submit a bid, click the Submit Bid button on the
-[Society page](https://ipfs.io/ipns/kusama.dotapps.io/#/society).
+[Society page](https://dweb.link/ipns/kusama.dotapps.io/#/society).
 
 Anyone can submit a bid to join the society by reserving a deposit or finding an existing member to
 create a bid on their behalf by vouching for them. At every rotation period, as many bids as the
@@ -73,7 +73,7 @@ declare the bid amount (1 KSM in this case) that they will receive for joining t
 ![test_bid](../../assets/society/test_bid.jpg)
 
 Once you have submitted the transaction, your bid will be shown on the
-[Society page](https://ipfs.io/ipns/kusama.dotapps.io/#/society) under the bids section. You can
+[Society page](https://dweb.link/ipns/kusama.dotapps.io/#/society) under the bids section. You can
 cancel the bidding if you changed your mind about joining the society by calling `unbid` on the same
 page.
 

--- a/docs/maintain/kusama/maintain-guides-society-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-society-kusama.md
@@ -59,7 +59,7 @@ any questions if anything is unclear.
 ### 1. Bid Phase
 
 To submit a bid, click the Submit Bid button on the
-[Society page](https://dweb.link/ipns/kusama.dotapps.io/#/society).
+[Society page](https://cloudflare-ipfs.com/ipns/kusama.dotapps.io/#/society).
 
 Anyone can submit a bid to join the society by reserving a deposit or finding an existing member to
 create a bid on their behalf by vouching for them. At every rotation period, as many bids as the
@@ -73,7 +73,7 @@ declare the bid amount (1 KSM in this case) that they will receive for joining t
 ![test_bid](../../assets/society/test_bid.jpg)
 
 Once you have submitted the transaction, your bid will be shown on the
-[Society page](https://dweb.link/ipns/kusama.dotapps.io/#/society) under the bids section. You can
+[Society page](https://cloudflare-ipfs.com/ipns/kusama.dotapps.io/#/society) under the bids section. You can
 cancel the bidding if you changed your mind about joining the society by calling `unbid` on the same
 page.
 


### PR DESCRIPTION
Hello my friends,
Domain `ipfs.io` does not work anymore, let's replace it to by another gateway --`dweb.link` which is also managed by Protocol Labs.