### PR TITLE
Remove Polkascan references

### DIFF
--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -366,5 +366,4 @@ like locking or reserving tokens for operations that utilize state.
 **What is an external source to see the current chain height?**
 
 - [Polkadot-JS explorer](https://polkadot.js.org/apps/#/explorer)
-- [Polkascan block explorer](https://polkascan.io/)
 - [Subscan block explorer](https://www.subscan.io/)

--- a/docs/build/build-tools-index.md
+++ b/docs/build/build-tools-index.md
@@ -20,8 +20,6 @@ Please see the [Wallets](../general/wallets-and-extensions.md) page.
 - [Polkadot-JS Apps Explorer](https://polkadot.js.org/apps/#/explorer) - Polkadot dashboard block
   explorer. Supports dozens of other networks, including Kusama, Westend, and other remote or local
   endpoints. [Access via IPFS](https://cloudflare-ipfs.com/ipns/dotapps.io)
-- [Polkascan](https://polkascan.io/) - Blockchain explorer for Polkadot, Kusama, and other related
-  chains. [Repo](https://github.com/polkascan/polkascan-os).
 - [Subscan](https://subscan.io) - Blockchain explorer for Substrate chains.
   [Repo](https://github.com/itering/subscan-essentials).
 - [DotScanner](https://dotscanner.com?utm_source=polkadot_wiki) - Polkadot & Kusama Blockchain
@@ -220,9 +218,6 @@ languages exist:
 
 The following tools help you extract and structure data from a Substrate node.
 
-- [Polkascan PRE Harvester](https://github.com/polkascan/polkascan-pre-harvester)
-  ([matching explorer for harvested data](https://github.com/polkascan/polkascan-pre-explorer-gui)) -
-  Transforms raw blockchain data into relational data.
 - [Parity's Substrate Archive](https://github.com/paritytech/substrate-archive) - Can be run
   alongside a Substrate node to archive all blocks, state, and extrinsic data into PostgreSQL
   database.

--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -280,8 +280,6 @@ and maintain on the Kusama network, please head over to our
   Web3 Foundation has done.
 - [Polkadot Explorer](https://polkadot.js.org/apps/#/explorer) - Browser for the Polkadot network;
   can be used for Polkadot, Kusama, or any Substrate-based chain.
-- [Polkascan](http://polkascan.io/) \- Real-time multi-chain data for Polkadot Relay Chain and
-  Parity Substrate chains.
 - [Subscan.io](https://subscan.io) - Explorer for Substrate based chains.
 - [Polkadot Overview](https://youtu.be/lIghiCmHz0U) - Dr. Gavin Wood presents an overview of
   Polkadot. (Video)

--- a/docs/general/kusama/kusama-timeline.md
+++ b/docs/general/kusama/kusama-timeline.md
@@ -49,7 +49,7 @@ would last only 10 minutes until the validators caught up to the present moment.
 
 The above plan was executed successfully on January 7, 2020. Due to the time warp, the number of
 missed blocks in the sessions directly following
-[block #516558](https://polkascan.io/kusama/block/516558) was significantly higher. This is partly
+[block #516558](https://kusama.subscan.io/block/516558) was significantly higher. This is partly
 what contributes to the much higher ratio of missed blocks on Kusama versus Polkadot today.
 
 ## Kusama's Current Adventure: Auctions

--- a/docs/maintain/archive/maintain-guides-democracy.md
+++ b/docs/maintain/archive/maintain-guides-democracy.md
@@ -229,7 +229,7 @@ following extrinsic: `democracy.removeVote(index)` using the account that you vo
 index number (ReferendumIndex), enter the number of the referendum for which you voted ("12" in the
 image below).
 
-The number of the referendum for which you voted is visible in an explorer such as Polkascan.
+The number of the referendum for which you voted is visible in an explorer such as Subscan.
 
 You need to press the "Submit Transaction" button to submit the extrinsic.
 

--- a/docs/maintain/maintain-errors.md
+++ b/docs/maintain/maintain-errors.md
@@ -41,12 +41,13 @@ is a live example of the above.
 If you cannot look up the error this way, or there is no message in the `details` field, consult the
 table below.
 
-## Polkascan and Subscan
+## Subscan
 
-Polkascan and Subscan show the `ExtrinsicFailed` event when a transaction does not succeed
-([example](https://polkascan.io/polkadot/event/2836233-3)). This event gives us the `error` and
-`index` indices of the error but does not give us a nice message to understand what it means. We
-will look up the error in the codebase ourselves to understand what went wrong.
+The `ExtrinsicFailed` event indicates when a transaction does not succeed
+([example](https://polkadot.subscan.io/extrinsic/19983878-2?event=19983878-53)). This event gives us
+the `error` and `index` (as seen in the table of the event, in the `dispatch_error` row) indices of
+the error but does not give us a nice message to understand what it means. We will look up the error
+in the codebase ourselves to understand what went wrong.
 
 First, we should understand that the `index` number is the index of the pallet in the runtime from
 which the error originated. The `error` is likewise the index of that pallet's errors which is the


### PR DESCRIPTION
Closes issue #5703 

- Removes references to Polkascan and replacing with Subscan
- Minor edits to pages mentioning old UI and adding Subscan instead