### PR TITLE
Change Start Card Links

### DIFF
--- a/polkadot-wiki/src/pages/index.js
+++ b/polkadot-wiki/src/pages/index.js
@@ -41,7 +41,7 @@ function HomeNav() {
 
   return (
     <NavContainer>
-      <NavItem href={useDocUrl("explore-index")} aosDelay="0">
+      <NavItem href={useDocUrl("getting-started")} aosDelay="0">
         <NavItemContent>
           <NavItemTitle>
             <Translate
@@ -61,7 +61,7 @@ function HomeNav() {
           </p>
         </NavItemContent>
       </NavItem>
-      <NavItem href={useDocUrl("learn-index")} aosDelay="200">
+      <NavItem href={useDocUrl("web3-and-polkadot")} aosDelay="200">
         <NavItemContent>
           <NavItemTitle>
             <Translate


### PR DESCRIPTION
 Direct links to the new design "getting started" cards from "Explore" and to "web3 and Polkadot" from "Learn" main card. People will be presented with some catchy cards to explore topics, and with an introduction to Web3 to learn more about it. The current issue is that the reader is presented with indexes and cards with confusing names. This can discourage and lead to less time spent on the wiki.