### PR TITLE
Temporarily disable Sticky banner

### DIFF
--- a/polkadot-wiki/static/css/custom.css
+++ b/polkadot-wiki/static/css/custom.css
@@ -314,9 +314,8 @@ div[role=banner] .close:focus {
 }
 
 div.sticky {
-  position: -webkit-sticky;
   position: sticky;
-  top: 0;
+  top: 10;
   background-color: #f5cbc4;
   padding: 30px;
   font-size: 20px;


### PR DESCRIPTION
Let's find a way to move this to bottom right part of the Wiki. For now, a prominent (non)-sticky banner on each Polkadot-JS guide should suffice.