### PR TITLE
Use curl instead of websocat in validator section

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -681,7 +681,7 @@ If you are on a remote server, it is easier to run this command on the same mach
 is running with the default WS RPC port configured):
 
 ```sh
-echo '{"id":1,"jsonrpc":"2.0","method":"author_rotateKeys","params":[]}' | websocat -n1 -B 99999999 ws://127.0.0.1:9933
+echo '{"id":1,"jsonrpc":"2.0","method":"author_rotateKeys","params":[]}' | websocat -n1 -B 99999999 ws://127.0.0.1:9944
 ```
 
 The output will have a hex-encoded "result" field. The result is the concatenation of the four

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -681,7 +681,7 @@ If you are on a remote server, it is easier to run this command on the same mach
 is running with the default WS RPC port configured):
 
 ```sh
-echo '{"id":1,"jsonrpc":"2.0","method":"author_rotateKeys","params":[]}' | websocat -n1 -B 99999999 ws://127.0.0.1:9944
+curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_rotateKeys", "params":[]}' http://localhost:9944
 ```
 
 The output will have a hex-encoded "result" field. The result is the concatenation of the four


### PR DESCRIPTION
I think using curl instead of websocat is more straightforward to new users as it's more readily available.