### PR TITLE
Improve Coretime Guides / Docs

### DIFF
--- a/docs/learn/learn-guides-coretime-marketplaces.md
+++ b/docs/learn/learn-guides-coretime-marketplaces.md
@@ -7,10 +7,19 @@ keywords: [coretime, blockspace, parathread, parachain, cores]
 slug: ../learn-guides-coretime-marketplaces
 ---
 
+:::info
+
+If you aren't sure what Agile Coretime is, be sure to read the
+[introduction](./learn-agile-coretime.md),
+[terminology](./learn-agile-coretime.md#agile-coretime-terminology), and
+[FAQ](./learn-agile-coretime.md#agile-coretime-faq).
+
+:::
+
 The tutorials in this document utilize:
 
-- [CoreHub on RegionX](https://app.regionx.tech/), a user interface
-for purchasing and managing Coretime regions.
+- [CoreHub on RegionX](https://app.regionx.tech/), a user interface for purchasing and managing
+  Coretime regions.
 
 - [Lastic](https://test.lastic.xyz/start), a Coretime marketplace user interface.
 
@@ -38,8 +47,8 @@ bottom left). Then, click on the purchase button to sign and broadcast the trans
 ### Managing Cores with RegionX
 
 The Regions dashboard lists all the cores purchased through the connected wallet account along with
-the basic information of the respective core. It allows for partitioning, interlacing, transfers, and
-assigning tasks.
+the basic information of the respective core. It allows for partitioning, interlacing, transfers,
+and assigning tasks.
 
 ![RegionX-regions-dashboard](../assets/coretime/regionx-manage-cores.png)
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -103,12 +103,13 @@ would work as well.
 Registering the genesis state and WASM code of the parachain requires a deposit that is computed
 based on the size (a deposit is paid per byte uploaded):
 
+<!-- prettier-ignore -->
 - **Kusama**:
-  <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/>
-  per byte
+  <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
+  
+  <!-- prettier-ignore -->
 - **Polkadot**:
-  <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/>
-  per byte
+  <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
 
 The deposit used for registering `ParaID` is already counted in for this deposit, the total deposit
 requirement for registering `ParaID`, state and code for `adder-collator` is around 46 KSM on Kusama

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -130,6 +130,15 @@ following command to rapidly sync with the specified relay chain.
 
 ## Run a Parachain with Bulk Coretime
 
+:::info
+
+Note that we have two options: **bulk coretime** and **on-demand coretime**. Bulk coretime is
+purchased via the broker pallet, which is on the respective Coretime system parachain. On-demand
+coretime is ordered via the OnDemandAssignment pallet/module, which is located on the respective
+relay chain.
+
+:::
+
 You can purchase bulk coretime on [Coretime chain](./learn-guides-coretime-marketplaces.md) and
 assign the purchased core to the registered `ParaID`. The snapshot below is from
 [Lastic](https://test.lastic.xyz/) interface.
@@ -150,10 +159,16 @@ After the collator node is fully synced with the relay chain, navigate to
 
 ![coretime-ondemand-assignment](../assets/coretime/coretime-on-demand-assignment.png)
 
-:::info What is onDemandAssignmentProvider.placeOrderAllowDeath?
+:::info
 
-`onDemandAssignmentProvider.placeOrderAllowDeath` will reap the account once the provided funds run
-out, which allows you to pay per block.
+There are two extrinsics which allow you to place orders for on-demand coretime:
+
+- `onDemandAssignmentProvider.placeOrderAllowDeath` will
+  [reap](./learn-accounts.md#existential-deposit-and-reaping) the account once the provided funds
+  run out.
+
+- `onDemandAssignmentProvider.placeOrderKeepAlive` includes a check which will **not** reap the
+  account if the provided funds will run out, ensuring the account is kept alive.
 
 :::
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -7,15 +7,18 @@ keywords: [coretime, blockspace, parathread, parachain, cores]
 slug: ../learn-guides-coretime-parachains
 ---
 
+import RPC from "./../../components/RPC-Connection";
+
 The landscape for parachains on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}
 changes with the rollout of [Agile Coretime](./learn-agile-coretime.md). With
-[auctions](./learn-auction.md) being phased out in favor of direct coretime sales, the existing
-parachains on the relaychain and the prospective parachains are presented with the following
-scenarios:
+[parachain auctions](./learn-auction.md) being phased out in favor of direct
+[coretime](./learn-agile-coretime.md#coretime) sales, the existing parachains on the relaychain and
+the prospective parachains are presented with the following scenarios:
 
-- Migrating from a legacy parachain lease into a bulk coretime model
-- Starting with bulk coretime model from scratch
-- Running a parachain with on-demand coretime purchases ("pay as you go")
+- **Migrating** from a legacy parachain lease into a
+  [bulk coretime](./learn-agile-coretime.md#bulk-coretime) model
+- **Starting** with bulk coretime model from scratch
+- **Running** a parachain with on-demand coretime purchases ("pay as you go")
 
 The parachain lease auctions will stop on-chain with the enactment of the
 [runtime upgrade 1.2.0](https://github.com/polkadot-fellows/runtimes/releases/tag/v1.2.0), and the
@@ -27,41 +30,48 @@ assignment of bulk coretime for a core without going through the regular purchas
 
 :::info
 
-The tutorials below assume that you have already developed the parachain runtime and a fully configured
-parachain collator for the target relay chain using Polkadot-SDK.
+The tutorials below assume that you have already developed the parachain runtime and a fully
+configured parachain collator for the target relay chain using the Polkadot SDK.
 
 :::
 
 For the tutorials below,
 [the adder test parachain](https://github.com/paritytech/polkadot-sdk/tree/6f3d890ed35bfdee3e3f7d59018345635a62d1cd/polkadot/parachain/test-parachains/adder)
-on Polkadot-SDK has been used. To compile the `adder-collator`, run the command below in the
-Polkadot-SDK repository.
+on the Polkadot SDK has been used. To compile the `adder-collator`, run the command below in the
+_root_ of the Polkadot SDK repository.
 
-```
+```sh
+# Ensure the polkadot-sdk is cloned, and you are within the root directory (cd polkadot-sdk)
 cargo build -r -p test-parachain-adder-collator
 ```
 
 After the test parachain collator node is successfully compiled, export its genesis state and the
-code using the following commands. If the export succeeds, these two files should appear in
-the Polkadot-SDK repository.
+code using the following commands. If the export succeeds, these two files should appear in the
+Polkadot-SDK repository.
 
-```
+```sh
 ./target/release/adder-collator export-genesis-state genesis
 ```
 
-```
+```sh
 ./target/release/adder-collator export-genesis-wasm genesis-wasm
 ```
 
 ## Reserve ParaID
 
-The first step is to register a `ParaID` for the on-demand parachain. This can be done through
-Polkadot-JS UI by navigating to Network > Parachains > Parathreads and clicking on ParaID button.
-Ensure that you have sufficient tokens to reserve the displayed `ParaID` successfully.
+The first step is to register a [`ParaID`](../general/glossary.md#paraid) for the parachain. This
+can be done through Polkadot-JS UI by navigating to
+[Network > Parachains > Parathreads](https://polkadot.js.org/apps/#/parachains/parathreads) and
+clicking on ParaID button. Ensure that you have sufficient tokens to reserve the displayed `ParaID`
+successfully.
 
 :::info
 
-Reserving a `ParaID` requires a deposit of 40 KSM on Kusama and 100 DOT on Polkadot.
+Reserving a `ParaID` requires a deposit of
+<RPC network="kusama" path="consts.registrar.paraDeposit" defaultValue={10000000000} filter="humanReadable"/>
+on Kusama and
+<RPC network="polkadot" path="consts.registrar.paraDeposit" defaultValue={10000000000} filter="humanReadable"/>
+on Polkadot.
 
 :::
 
@@ -69,15 +79,24 @@ Reserving a `ParaID` requires a deposit of 40 KSM on Kusama and 100 DOT on Polka
 
 ## Register Parachain State and Code
 
-The next step is to register the parachain's genesis wasm and state, which you should have generated earlier.
+The next step is to register the parachain's genesis wasm and state, which you should have generated
+earlier.
 
 :::info
 
 Registering the state and wasm code of the parachain requires a deposit that is computed based on
-the size. For the `adder-collator` example here, it turns out to be around 46 KSM on Kusama and 116
-DOT on Polkadot. As, the deposit used for registering `ParaID` is already counted in for this
-deposit, the total deposit requirement for registering `ParaID`, state and code for `adder-collator`
-is around 46 KSM on Kusama and 116 DOT on Polkadot.
+the size (a deposit is paid per byte uploaded):
+
+- Kusama:
+  <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={10000000000} filter="humanReadable"/>
+  per byte
+- Polkadot:
+  <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={10000000000} filter="humanReadable"/>
+  per byte
+
+The deposit used for registering `ParaID` is already counted in for this deposit, the total deposit
+requirement for registering `ParaID`, state and code for `adder-collator` is around 46 KSM on Kusama
+and 116 DOT on Polkadot.
 
 :::
 
@@ -98,7 +117,7 @@ sync with the specified relaychain.
 
 ## Run a Parachain with Bulk Coretime
 
-Now, you can purchase bulk coretime on [Coretime chain](./learn-guides-coretime-marketplaces.md) and
+You can purchase bulk coretime on [Coretime chain](./learn-guides-coretime-marketplaces.md) and
 assign the purchased core to the registered `ParaID`. The snapshot below is from
 [Lastic](https://test.lastic.xyz/) interface.
 
@@ -111,19 +130,26 @@ intervals, gradually incrementing the state by `2`.
 
 ## Run a Parachain with On-demand Coretime
 
-After the collator node is fully synced with the relay chain, navigate to Developer > Extrinsics on
-the relay chain and issue `onDemandAssignmentProvider.placeOrderAllowDeath` extrinsic from the
-account that registered the `ParaID` by specifying sufficient `maxAmount`for the transaction to go
-through successfully.
+After the collator node is fully synced with the relay chain, navigate to
+[Developer > Extrinsics](https://polkadot.js.org/apps/#/extrinsics) on the relay chain and issue
+`onDemandAssignmentProvider.placeOrderAllowDeath` extrinsic from the account that registered the
+`ParaID` by specifying sufficient `maxAmount`for the transaction to go through successfully.
 
 ![coretime-ondemand-assignment](../assets/coretime/coretime-on-demand-assignment.png)
+
+:::info What is onDemandAssignmentProvider.placeOrderAllowDeath?
+
+`onDemandAssignmentProvider.placeOrderAllowDeath` will reap the account once the provided funds run
+out, which allows you to pay per block.
+
+:::
 
 With each successful on-demand extrinsic, the parachain head changes (you may have to zoom out on
 the browser for parachain head details to show up on Polkadot-JS UI).
 
 ![coretime-ondemand-parahead](../assets/coretime/coretime-on-demand-parahead.png)
 
-The successful collation can also be verified in the parachain collator logs. It can be
-noticed that with each parachain block, the state of `adder-collator` is incremented by `2`.
+The successful collation can also be verified in the parachain collator logs. It can be noticed that
+with each parachain block, the state of `adder-collator` is incremented by `2`.
 
 ![coretime-new-collation](../assets/coretime/coretime-create-new-collation.png)

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -48,10 +48,12 @@ SDK.
 For the tutorials below,
 [the adder test parachain](https://github.com/paritytech/polkadot-sdk/tree/6f3d890ed35bfdee3e3f7d59018345635a62d1cd/polkadot/parachain/test-parachains/adder)
 on the Polkadot SDK has been used. To compile the `adder-collator`, run the command below in the
-_root_ of the Polkadot SDK repository.
+_root_ of the Polkadot SDK repository. You must have [Rust](https://www.rust-lang.org/tools/install)
+and its associated tooling installed before following along.
+
+Ensure the Polkadot SDK is cloned, and you are within the root directory (`cd polkadot-sdk`)
 
 ```sh
-# Ensure the polkadot-sdk is cloned, and you are within the root directory (cd polkadot-sdk)
 cargo build -r -p test-parachain-adder-collator
 ```
 
@@ -104,12 +106,10 @@ Registering the genesis state and WASM code of the parachain requires a deposit 
 based on the size (a deposit is paid per byte uploaded):
 
 <!-- prettier-ignore -->
-- **Kusama**:
-  <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
-  
-  <!-- prettier-ignore -->
-- **Polkadot**:
-  <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
+- **Kusama**: <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
+
+<!-- prettier-ignore -->
+- **Polkadot**: <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
 
 The deposit used for registering `ParaID` is already counted in for this deposit, the total deposit
 requirement for registering `ParaID`, state and code for `adder-collator` is around 46 KSM on Kusama

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -9,6 +9,15 @@ slug: ../learn-guides-coretime-parachains
 
 import RPC from "./../../components/RPC-Connection";
 
+:::info
+
+If you aren't sure what Agile Coretime is, be sure to read the
+[introduction](./learn-agile-coretime.md),
+[terminology](./learn-agile-coretime.md#agile-coretime-terminology), and
+[FAQ](./learn-agile-coretime.md#agile-coretime-faq).
+
+:::
+
 The landscape for parachains on {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }}
 changes with the rollout of [Agile Coretime](./learn-agile-coretime.md). With
 [parachain auctions](./learn-auction.md) being phased out in favor of direct

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -69,24 +69,23 @@ Polkadot-SDK repository.
 
 ## Reserve ParaID
 
+:::info
+
+Reserving a `ParaID` requires a deposit of:
+
+<!-- prettier-ignore -->
+- <RPC network="kusama" path="consts.registrar.paraDeposit" defaultValue={0} filter="humanReadable"/> on Kusama
+
+<!-- prettier-ignore -->
+- <RPC network="polkadot" path="consts.registrar.paraDeposit" defaultValue={0} filter="humanReadable"/> on Polkadot
+
+:::
+
 The first step is to register a [`ParaID`](../general/glossary.md#paraid) for the parachain. This
 can be done through Polkadot-JS UI by navigating to
 [Network > Parachains > Parathreads](https://polkadot.js.org/apps/#/parachains/parathreads) and
 clicking on ParaID button. Ensure that you have sufficient tokens to reserve the displayed `ParaID`
 successfully.
-
-<!-- prettier-ignore -->
-:::info
-
-Reserving a `ParaID` requires a deposit of:
-
-- <RPC network="kusama" path="consts.registrar.paraDeposit" defaultValue={0} filter="humanReadable"/>
-  on Kusama
-
-- <RPC network="polkadot" path="consts.registrar.paraDeposit" defaultValue={0} filter="humanReadable"/>
-  on Polkadot
-
-:::
 
 ![coretime-reserve-paraID](../assets/coretime/coretime-reserve-paraID.png)
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -31,7 +31,8 @@ assignment of bulk coretime for a core without going through the regular purchas
 :::info
 
 The tutorials below assume that you have already developed the parachain runtime and a fully
-configured parachain collator for the target relay chain using the Polkadot SDK.
+configured parachain [collator](./learn-collator.md) for the target relay chain using the Polkadot
+SDK.
 
 :::
 
@@ -80,12 +81,15 @@ on Polkadot.
 ## Register Parachain State and Code
 
 The next step is to register the parachain's genesis wasm and state, which you should have generated
-earlier.
+earlier. Note that for this example, we are using `adder-collator`, but in theory a custom runtime
+compiled from a
+[template](https://github.com/paritytech/polkadot-sdk/tree/88a2f360238787bf5256cfdd14b40c08f519b38e/templates/parachain)
+would work as well.
 
 :::info
 
-Registering the state and wasm code of the parachain requires a deposit that is computed based on
-the size (a deposit is paid per byte uploaded):
+Registering the genesis state and WASM code of the parachain requires a deposit that is computed
+based on the size (a deposit is paid per byte uploaded):
 
 - Kusama:
   <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={10000000000} filter="humanReadable"/>
@@ -108,8 +112,8 @@ After successful registration, the parachain starts onboarding as a parathread.
 
 ## Run Parachain Collator
 
-While the parachain is onboarding, start syncing the collator using the following command to rapidly
-sync with the specified relaychain.
+While the parachain is onboarding, start syncing the [collator](./learn-collator.md) using the
+following command to rapidly sync with the specified relay chain.
 
 ```
 ./target/release/adder-collator --parachain-id= $ParaID --chain=rococo --sync fast-unsafe

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -75,13 +75,16 @@ can be done through Polkadot-JS UI by navigating to
 clicking on ParaID button. Ensure that you have sufficient tokens to reserve the displayed `ParaID`
 successfully.
 
+<!-- prettier-ignore -->
 :::info
 
-Reserving a `ParaID` requires a deposit of
-<RPC network="kusama" path="consts.registrar.paraDeposit" defaultValue={10000000000} filter="humanReadable"/>
-on Kusama and
-<RPC network="polkadot" path="consts.registrar.paraDeposit" defaultValue={10000000000} filter="humanReadable"/>
-on Polkadot.
+Reserving a `ParaID` requires a deposit of:
+
+- <RPC network="kusama" path="consts.registrar.paraDeposit" defaultValue={0} filter="humanReadable"/>
+  on Kusama
+
+- <RPC network="polkadot" path="consts.registrar.paraDeposit" defaultValue={0} filter="humanReadable"/>
+  on Polkadot
 
 :::
 
@@ -95,16 +98,17 @@ compiled from a
 [template](https://github.com/paritytech/polkadot-sdk/tree/88a2f360238787bf5256cfdd14b40c08f519b38e/templates/parachain)
 would work as well.
 
+<!-- prettier-ignore -->
 :::info
 
 Registering the genesis state and WASM code of the parachain requires a deposit that is computed
 based on the size (a deposit is paid per byte uploaded):
 
-- Kusama:
-  <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={10000000000} filter="humanReadable"/>
+- **Kusama**:
+  <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/>
   per byte
-- Polkadot:
-  <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={10000000000} filter="humanReadable"/>
+- **Polkadot**:
+  <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/>
   per byte
 
 The deposit used for registering `ParaID` is already counted in for this deposit, the total deposit
@@ -133,8 +137,8 @@ following command to rapidly sync with the specified relay chain.
 :::info
 
 Note that we have two options: **bulk coretime** and **on-demand coretime**. Bulk coretime is
-purchased via the broker pallet, which is on the respective Coretime system parachain. On-demand
-coretime is ordered via the OnDemandAssignment pallet/module, which is located on the respective
+purchased via the `broker` pallet, which is on the respective Coretime system parachain. On-demand
+coretime is ordered via the `OnDemandAssignment` pallet/module, which is located on the respective
 relay chain.
 
 :::


### PR DESCRIPTION
This PR addresses the following points from issue #5793

--- 

- [x] Add relevant cross-linking to other Wiki docs with definitions of keywords used
- [x]  Accessible explanations for new learners/new comers to the ecosystem
- [x]  Fetch on-chain constants/values wherever applicable
- [x] Provide more technical clarity around on the implications between on-demand versus bulk