### PR TITLE
Message Box Wiki

### DIFF
--- a/components/MessageBox.css
+++ b/components/MessageBox.css
@@ -1,0 +1,27 @@
+/* src/css/messageBox.css */
+
+.message-box {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: hwb(80 20% 20%);
+    z-index: 1000; /* Set a high z-index value */
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    max-width: 300px; /* Adjust width as needed */
+  }
+  
+  .close-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+  
+  .message-content {
+    /* Add any additional styling for your message content */
+  }

--- a/components/MessageBox.css
+++ b/components/MessageBox.css
@@ -22,6 +22,6 @@
     cursor: pointer;
   }
   
-  .message-content {
-    /* Add any additional styling for your message content */
+  .messageContent {
+    margin-top: 10px;
   }

--- a/components/MessageBox.css
+++ b/components/MessageBox.css
@@ -3,14 +3,14 @@
 .message-box {
     position: fixed;
     bottom: 20px;
-    right: 20px;
-    background-color: hwb(80 20% 20%);
+    right: 10px;
+    background-color: hwb(0 80% 2%);
     z-index: 1000; /* Set a high z-index value */
     border: 1px solid #ccc;
     border-radius: 10px;
     padding: 20px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    max-width: 300px; /* Adjust width as needed */
+    max-width: 270px; /* Adjust width as needed */
   }
   
   .close-button {
@@ -20,7 +20,7 @@
     background: none;
     border: none;
     cursor: pointer;
-  }
+  } 
   
   .messageContent {
     margin-top: 10px;

--- a/components/MessageBox.jsx
+++ b/components/MessageBox.jsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+const MessageBox = ({ message }) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <div className="message-box">
+          <button className="close-button" onClick={handleClose}>
+            &#10006; {/* Unicode character for "x" */}
+          </button>
+          <div className="message-content">
+            <p>{message}</p> {/* Display the message text */}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default MessageBox;

--- a/components/MessageBox.jsx
+++ b/components/MessageBox.jsx
@@ -7,6 +7,11 @@ const MessageBox = ({ message }) => {
     setIsOpen(false);
   };
 
+  // Function to convert markdown links to HTML links
+  const renderMarkdownLinks = (text) => {
+    return text.replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>');
+  };
+
   return (
     <>
       {isOpen && (
@@ -14,9 +19,10 @@ const MessageBox = ({ message }) => {
           <button className="close-button" onClick={handleClose}>
             &#10006; {/* Unicode character for "x" */}
           </button>
-          <div className="message-content">
-            <p>{message}</p> {/* Display the message text */}
-          </div>
+          <div
+            className="message-content"
+            dangerouslySetInnerHTML={{ __html: renderMarkdownLinks(message) }} // Render HTML content
+          ></div>
         </div>
       )}
     </>

--- a/docs/maintain/archive/maintain-guides-democracy.md
+++ b/docs/maintain/archive/maintain-guides-democracy.md
@@ -7,13 +7,11 @@ keywords: [democracy, council, action, proposal]
 slug: ../maintain-guides-democracy
 ---
 
-<div className="sticky" style={{ zIndex: 1 }}> 
-<br />
+import MessageBox from "../../../components/MessageBox"; import
+"../../../components/MessageBox.css";
 
-The content on this page is archived. For up-to-date information about governance, see the
-[Polkadot OpenGov page](../../learn/learn-polkadot-opengov.md).
-
-</div>
+<MessageBox message="The content on this page is archived. For up-to-date information about governance, see the
+[Polkadot OpenGov page](../../learn/learn-polkadot-opengov.md)." />
 
 The public referenda chamber is one of the three bodies of on-chain governance as it's instantiated
 in Polkadot and Kusama. The other two bodies are the


### PR DESCRIPTION
Add a removable sticky msg box that can be added on the bottom right corner of pages (archive, PJS guides)

![Screenshot 2024-04-25 at 18 33 04](https://github.com/w3f/polkadot-wiki/assets/110459737/794ff0bc-1452-4ec5-ac63-29ca78c94264)

