### PR TITLE
Update learn-crowdloans.md

### DIFF
--- a/docs/learn/learn-crowdloans.md
+++ b/docs/learn/learn-crowdloans.md
@@ -10,7 +10,7 @@ slug: ../learn-crowdloans
 import MessageBox from "../../components/MessageBox"; import "../../components/MessageBox.css";
 import RPC from "./../../components/RPC-Connection";
 
-<MessageBox message="Crowdloans will be deprecated right after [Agile Coretime](./learn-agile-coretime.md) is activated on the network. As an alternative for fundraising in a decentralized, transparent, and regulatory compliant manner within the ecosystem, check out the [Polimec parachain](https://www.polimec.org/)." />
+<MessageBox message="Crowdloans will be deprecated right after [Agile Coretime](./learn-agile-coretime.md) is activated on the network. For fundraising in a decentralized, transparent, and regulatory compliant manner within the ecosystem, check out the [Polimec parachain](https://www.polimec.org/)." />
 
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} allows parachains to source tokens
 for their parachain bids in a decentralized crowdloan.


### PR DESCRIPTION
There is no alternative for crowdloans, which help secure a slot/coretime for parachains permissionlessly with the accounts contributing to them in full control of their tokens. Rephrasing it.