### PR TITLE
Fix for formatting errors from PR#5925 (Data Dashboards Page)

### DIFF
--- a/docs/general/parity-data-dashboards.md
+++ b/docs/general/parity-data-dashboards.md
@@ -13,13 +13,11 @@ The Parity Data Team has made publicly available a [website](https://dashboards.
 that displays a number of dashboards relating to Polkadot Ecosystem On-Chain data. The graphs
 provided are grouped into the following sections:
 
-- [Stablecoins](https://dashboards.data.paritytech.io/stablecoins.html),
-- [Treasury Related Activity](https://dashboards.data.paritytech.io/treasuries.html),
-- [Staking](https://dashboards.data.paritytech.io/staking.html) and aggregated
-- [Ecosystem-wide](https://dashboards.data.paritytech.io/parachains.html) metrics. There is also a
-- [Monthly Report](https://dashboards.data.paritytech.io/eoyr.html) which provides a monthly updated
-  version of
-  [The Polkadot in Numbers: Annual Report 2023](https://dashboards.data.paritytech.io/reports/2023/index.html).
+- [Stablecoins](https://dashboards.data.paritytech.io/stablecoins.html) - metrics around stablecoins in Polkadot AssetHub. 
+- [Treasury](https://dashboards.data.paritytech.io/treasuries.html) - metrics around treasuries in the ecosystem. 
+- [Staking](https://dashboards.data.paritytech.io/staking.html) - metrics pertaining to staking, nomination pools and more. 
+- [Ecosystem](https://dashboards.data.paritytech.io/parachains.html) - high level activity metrics for Relay Chains and Parachains. 
+- [Monthly Report](https://dashboards.data.paritytech.io/eoyr.html) - an updated version of the [Polkadot in Numbers: Annual Report 2023](https://dashboards.data.paritytech.io/reports/2023/index.html).
 
 ## Notes on How to Use the Interactive Charts
 
@@ -27,10 +25,12 @@ The [Ecosystem Tab](https://dashboards.data.paritytech.io/parachains.html) shows
 universally applicable metrics (Active Accounts, Unique Accounts, Transactions, Events) across both
 Polkadot & Kusama Relay/Parachains. Users can select whether they want to view:
 
-1. Polkadot or Kusama
-2. Daily or monthly figures
-3. Substrate Only, EVM Only or Substrate + EVM numbers. The default view is set to Polkadot,
-   Monthly, Substrate + EVM.
+- Polkadot or Kusama
+- Daily or monthly figures
+- Substrate Only, EVM Only or Substrate + EVM numbers. 
+
+The default view is set to Polkadot,Monthly, Substrate + EVM.
+
 
 ![Default Selection](../assets/parity-data-dashboards/ecosystem-chart-default-selection.png)
 


### PR DESCRIPTION
Made edits to parity-data-dashboards.md file after [Hotfix: Format Parity Data Page #5925](https://github.com/w3f/polkadot-wiki/pull/5925). 

Corrected bullet point lists as requested. 

@CrackTheCode016 can you please merge when you are able to? Current format of[ parity data dashboards page on wiki](https://wiki.polkadot.network/docs/parity-data-dashboards) is not ideal. 

Thanks for all your help