### PR TITLE
Coretime Guides Rework (Omninode Considerations)

### DIFF
--- a/docs/build/build-guides-coretime-start.md
+++ b/docs/build/build-guides-coretime-start.md
@@ -20,7 +20,7 @@ Polkadot. These guides are **not** production ready due to the moving nature of 
 
 ## Using the Polkadot SDK
 
-The Polkadot SDK used to be overarching **three** repositories:
+The Polkadot SDK is comprised of **three** important repositories:
 
 - [**Polkadot**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#polkadot) -
   Which for a time, included both the client implementation and runtime, until the runtime was moved
@@ -37,9 +37,9 @@ The Polkadot SDK used to be overarching **three** repositories:
 
 :::info What is a task?
 
-You might see the term "task" referenced in place of "parachain". In most cases, it refers to a
+You might see the term "task" referenced often in place of "parachain". In most cases, it refers to a
 process utilizing the relay chain's compute. This could be a parachain or any other computational
-process, provided that it adheres to the Polkadot protocol.
+process, provided that it adheres to the Polkadot protocol interface.
 
 The full definition can be found [here](../learn/learn-agile-coretime.md#task).
 
@@ -107,8 +107,7 @@ PC-->DEP
 Make sure you have everything you need for your target system
 [here.](./build-guides-install-deps.md).
 
-Be sure you also install the `polkadot-parachain` and `chain-spec-builder` binaries, as they will be
-used to start and run your chain!
+Be sure you also install the `polkadot-parachain` and `chain-spec-builder` binaries, as they needed to start and run your chain!
 
 ### Deployment Example - Adder Collator
 

--- a/docs/build/build-guides-coretime-start.md
+++ b/docs/build/build-guides-coretime-start.md
@@ -20,8 +20,7 @@ Polkadot. These guides are **not** production ready due to the moving nature of 
 
 ## Using the Polkadot SDK
 
-At first glance, the Polkadot SDK can be rather overwhelming, and in a way it is - it packs a lot of
-tech into one place. The Polkadot SDK used to be overarching **three** repositories:
+The Polkadot SDK used to be overarching **three** repositories:
 
 - [**Polkadot**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#polkadot) -
   Which for a time, included both the client implementation and runtime, until the runtime was moved
@@ -38,9 +37,9 @@ tech into one place. The Polkadot SDK used to be overarching **three** repositor
 
 :::info What is a task?
 
-You might see the term "task" referenced quite a bit, but in most cases, it refers to a process
-utilizing Polkadot's compute. This could be a parachain or any other computational process, provided
-that it adheres to the Polkadot protocol.
+You might see the term "task" referenced in place of "parachain". In most cases, it refers to a
+process utilizing the relay chain's compute. This could be a parachain or any other computational
+process, provided that it adheres to the Polkadot protocol.
 
 The full definition can be found [here](../learn/learn-agile-coretime.md#task).
 
@@ -106,7 +105,10 @@ PC-->DEP
 ### Install dependencies
 
 Make sure you have everything you need for your target system
-[here.](./build-guides-install-deps.md)
+[here.](./build-guides-install-deps.md).
+
+Be sure you also install the `polkadot-parachain` and `chain-spec-builder` binaries, as they will be
+used to start and run your chain!
 
 ### Deployment Example - Adder Collator
 

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -418,3 +418,13 @@ active toolchain
 nightly-x86_64-unknown-linux-gnu (overridden by +toolchain on the command line)
 rustc 1.63.0-nightly (e7144
 ```
+
+## Install `polkadot-parachain` and `chain-spec-builder`
+
+```sh
+cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.10.0 --force polkadot-parachain-bin
+```
+
+```sh
+cargo install staging-chain-spec-builder
+```

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -427,7 +427,7 @@ parachains (an
 It can be installed as follows:
 
 ```sh
-cargo install polkadot-parachain-bin
+cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.15.1 --force polkadot-parachain-bin
 ```
 
 `chain-spec-builder` is how you will generate chain specifications for your network. It requires a

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -431,7 +431,7 @@ cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1
 cargo install staging-chain-spec-builder
 ```
 
-## Installing the "Omninode" & Chain Spec Builder
+## Installing the "Omninode"
 
 The `polkadot-parachain` binary can be used as a generic node implementation for any given runtime.
 
@@ -441,13 +441,4 @@ Install it using this command:
 
 ```sh
 cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.10.0 --force polkadot-parachain-bin
-```
-
-There is also a dedicated tool for generating chain specs from a given WebAssembly blob called
-`chain-spec-builder`.
-
-Install it using this command:
-
-```sh
-cargo install staging-chain-spec-builder
 ```

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -430,9 +430,8 @@ It can be installed as follows:
 cargo install polkadot-parachain-bin
 ```
 
-The `chain-spec-builder` is how you will generate chain specifications from different presets. Each
-preset represents different type of your network, such as development, testnet, and live networks.
-It requires a `wasm` runtime bundle to generate the chain specification from.
+`chain-spec-builder` is how you will generate chain specifications for your network. It requires a
+`wasm` runtime bundle to generate the chain specification from.
 
 It can be installed as follows:
 

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -430,3 +430,24 @@ cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1
 ```sh
 cargo install staging-chain-spec-builder
 ```
+
+## Installing the "Omninode" & Chain Spec Builder
+
+The `polkadot-parachain` binary can be used as a generic node implementation for any given runtime.
+
+Install it using this command:
+
+> You can change `--tag` to the specific release of your choice
+
+```sh
+cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.10.0 --force polkadot-parachain-bin
+```
+
+There is also a dedicated tool for generating chain specs from a given WebAssembly blob called
+`chain-spec-builder`.
+
+Install it using this command:
+
+```sh
+cargo install staging-chain-spec-builder
+```

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -426,10 +426,8 @@ parachains (an
 ["omninode beta"](https://forum.polkadot.network/t/polkadot-parachain-omni-node-gathering-ideas-and-feedback/7823)).
 It can be installed as follows:
 
-> You can change `--tag` to the specific release of your choice
-
 ```sh
-cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.13.0 --force polkadot-parachain-bin
+cargo install polkadot-parachain-bin
 ```
 
 The `chain-spec-builder` is how you will generate chain specifications from different presets. Each

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -421,6 +421,8 @@ rustc 1.63.0-nightly (e7144
 
 ## Install `polkadot-parachain` and `chain-spec-builder`
 
+<!-- TODO: finish instructions -->
+
 ```sh
 cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.10.0 --force polkadot-parachain-bin
 ```

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -421,24 +421,12 @@ rustc 1.63.0-nightly (e7144
 
 ## Install `polkadot-parachain` and `chain-spec-builder`
 
-<!-- TODO: finish instructions -->
+> You can change `--tag` to the specific release of your choice
 
 ```sh
-cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.10.0 --force polkadot-parachain-bin
+cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.13.0 --force polkadot-parachain-bin
 ```
 
 ```sh
 cargo install staging-chain-spec-builder
-```
-
-## Installing the "Omninode"
-
-The `polkadot-parachain` binary can be used as a generic node implementation for any given runtime.
-
-Install it using this command:
-
-> You can change `--tag` to the specific release of your choice
-
-```sh
-cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.10.0 --force polkadot-parachain-bin
 ```

--- a/docs/build/build-guides-install-deps.md
+++ b/docs/build/build-guides-install-deps.md
@@ -421,11 +421,24 @@ rustc 1.63.0-nightly (e7144
 
 ## Install `polkadot-parachain` and `chain-spec-builder`
 
+The `polkadot-parachain` can be used a universal collator instance for running most of the
+parachains (an
+["omninode beta"](https://forum.polkadot.network/t/polkadot-parachain-omni-node-gathering-ideas-and-feedback/7823)).
+It can be installed as follows:
+
 > You can change `--tag` to the specific release of your choice
 
 ```sh
 cargo install --git https://github.com/paritytech/polkadot-sdk --tag polkadot-v1.13.0 --force polkadot-parachain-bin
 ```
+
+The `chain-spec-builder` is how you will generate chain specifications from different presets. Each
+preset represents different type of your network, such as development, testnet, and live networks.
+It requires a `wasm` runtime bundle to generate the chain specification from.
+
+It can be installed as follows:
+
+> Note that chain-spec-builder only works with select Polkadot SDK versions (`<v1.13.0`)
 
 ```sh
 cargo install staging-chain-spec-builder

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -13,6 +13,8 @@ This guide is considered a moving document and currently uses the **Rococo** tes
 relay chain can also be used in place of Rococo, as coretime is also enabled there. Polkadot will
 enable agile coretime after it has been thoroughly tested on Kusama.
 
+**This guide assumes Polkadot SDK tag `polkadot-v1.15.1`**
+
 :::
 
 This guide aims to get you up and running with the basics of:
@@ -133,8 +135,11 @@ The patch JSON states that:
   collator with `--alice` later on.
 - `Alice` is the sudo key of our network.
 
-:::info Make sure you replace `YOUR_PARA_ID_HERE` with your reserved ParaId! This should be the same
-as the ID you reserved. :::
+:::info Make sure you replace `YOUR_PARA_ID_HERE` with your reserved ParaId!
+
+This should be the same as the ID you reserved.
+
+:::
 
 ```json
 {
@@ -250,14 +255,11 @@ fields are in place:
 1. **Make** sure that `relay_chain` is set to the target relay chain (`rococo`, in our case)
 2. **Make** sure that `para_id` (right below `relay_chain`) is set to your reserved ParaId
 3. **Make** sure that our `chain_type` is set to `Live`
-4. **Optionally**, change the name and id of your chain (mine is called "SomeChain" for the name,
-   and "some_chain" for the id). My ticker symbol for the default token is called "SOME".
+4. **Optionally**, change the name, id, and token symbol of your chain.
 
 If you fail to do one of these, there is a large chance that your chain may fail to produce blocks.
-Feel free to copy the configuration below and use it to ensure everything is in place for a Rococo
-deployment.
 
-For more information on chain specifications in general,
+For more information on chain specifications,
 [check out the reference document from the Polkadot SDK.](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/chain_spec_genesis/index.html)
 
 ### Generating the Runtime and Genesis

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -9,11 +9,11 @@ slug: ../build-guides-template-basic
 
 :::warning Not a production ready guide.
 
-This guide is considered a moving document and currently uses the **Rococo** testnet. The Kusama
-relay chain can also be used in place of Rococo, as coretime is also enabled there. Polkadot will
+This guide is considered a moving document and currently uses the **Rococo** testnet. This guide is also applicable to the parachains on the Kusama
+relay chain, as coretime is also enabled there. Polkadot will
 enable agile coretime after it has been thoroughly tested on Kusama.
 
-**This guide assumes Polkadot SDK tag `polkadot-v1.15.1`**
+**This instructions on this guide are applicable for the Polkadot SDK repository with tag `polkadot-v1.15.1`**
 
 :::
 
@@ -69,7 +69,7 @@ associated tooling (such as `polkadot-parachain` and `chain-spec-builder`).
 
 We will be using the
 [Polkadot SDK's parachain template](https://github.com/paritytech/polkadot-sdk-parachain-template),
-which is kept in sync with the Polkadot SDK.
+which is mirrored in the templates folder within Polkadot SDK repository.
 
 Clone the repository:
 
@@ -114,8 +114,8 @@ definitely a next step after you get used to deploying your parachain on Rococo!
 
 ### Customizing our chain specification's patch file
 
-The chain specification is a JSON file which describes Substrate-based networks. It usually contains
-the genesis runtime (in hex) under `genesis.runtimeGenesis.code`. Under that, it also contains
+The chain specification is a JSON file that describes Polkadot SDK-based networks. It usually contains
+the genesis runtime (in hex) under `genesis.runtimeGenesis.code` and also contains
 genesis values/state for the pallets included in your runtime.
 
 You can bootstrap your network with some initial values, such as initial collators, balances for
@@ -123,7 +123,7 @@ certain accounts, and more. This is done using a patch file, which the `chain-sp
 uses to create the full chain specification of your network. You should do the following to create
 your `patch.json`:
 
-Feel free to use the patch provided here, which you can look to tweaking to your liking.
+Feel free to use the patch provided here, which you can look to tweak to your liking.
 
 1. Create the file: `touch patch.json`
 2. Paste the below patch JSON.
@@ -267,7 +267,7 @@ For more information on chain specifications,
 With our chain specification successfully generated, we can move to generating the genesis state and
 runtime.
 
-Generate the genesis as follows:
+Generate the genesis following the instructions below:
 
 ```shell
 polkadot-parachain export-genesis-head --chain chain_spec.json genesis

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -198,7 +198,7 @@ our chain specification:
 ```sh
 chain-spec-builder create \
 -v \
--r ../../target/release/wbuild/parachain-template-runtime/parachain_template_runtime.wasm \
+-r ./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.wasm \
 patch patch.json
 ```
 

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -189,8 +189,6 @@ Be sure first to build the node using the following (assuming you're within
 cargo build -p parachain-template-node --release
 ```
 
-<!-- TODO: chain-spec-builder -->
-
 ```shell
 ../../target/release/parachain-template-node export-genesis-state genesis
 ```

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -183,9 +183,13 @@ Once this is in place, you are ready to compile your parachain node.
 Be sure first to build the node using the following (assuming you're within
 `polkadot-sdk/templates/parachain`):
 
+<!-- TODO: ensure a runtime blob is available for interaction, and specify this -->
+
 ```shell
 cargo build -p parachain-template-node --release
 ```
+
+<!-- TODO: chain-spec-builder -->
 
 ```shell
 ../../target/release/parachain-template-node export-genesis-state genesis
@@ -203,12 +207,12 @@ Within `polkadot-sdk/templates/parachain`, you should now have two files:
 ## Running Your Collator
 
 It would help if you now started syncing your collator. Keep in mind that you will need to sync
-Rococo first - this could take some time (12 hours to a day - depending on your download speed), so
-best to get started ASAP. In order to avoid storing the full state of the relay chain, be sure to
-run with the appropriate pruning flags (`blocks-pruning` and `state-pruning`):
+Rococo first - this could take some time depending on your download speed, so it is best to start
+this process ASAP. In order to avoid storing the full state of the relay chain, be sure to run with
+the appropriate pruning flags (`blocks-pruning` and `state-pruning`):
 
 ```shell
-./../target/release/parachain-template-node --collator \
+polkadot-parachain --collator \
 --alice \
 --force-authoring \
 --base-path  <your-base-path-here> \

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -118,7 +118,8 @@ genesis state of your network. You should do the following to create your `patch
 
 Feel free to use the patch provided here, which you can look to tweaking to your liking.
 
-:::info Make sure you replace `YOUR_PARA_ID_HERE` with your reserved ParaId! :::
+:::info Make sure you replace `YOUR_PARA_ID_HERE` with your reserved ParaId! This should be the same
+as the ID you reserved. :::
 
 ```json
 {
@@ -133,7 +134,7 @@ Feel free to use the patch provided here, which you can look to tweaking to your
     "invulnerables": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
   },
   "parachainInfo": {
-    "parachainId": 1000
+    "parachainId": YOUR_PARA_ID_HERE
   },
   "polkadotXcm": {
     "safeXcmVersion": 4
@@ -192,6 +193,7 @@ Next, you'll need to modify a few things in your chain spec, namely by adding th
 to make it parachain-ready:
 
 ```json
+"protocolId": "my-live-protocol",
 "properties": {
    "ss58Format": 42,
    "tokenDecimals": 12,
@@ -210,7 +212,7 @@ Once you finish modifying the file, it should look like this:
   "chainType": "Live",
   "bootNodes": [],
   "telemetryEndpoints": null,
-  "protocolId": null,
+  "protocolId": "my-live-protocol",
   "properties": {
     "ss58Format": 42,
     "tokenDecimals": 12,

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -304,7 +304,7 @@ A Polkadot SDK-based node has two pruning modes:
 - `state-pruning` - Prunes the overall state from a specified height
 
 Both of these flags aid in reducing the amount of disk space taken up by the relay chain. Note that
-`state-pruning` is only be used for the first initial sync for the database.
+`state-pruning` is only used for the first initial sync for the database.
 
 :::
 

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -97,10 +97,11 @@ FRAME and Substrate. All you need to know is the following:
 When we compile our template, we can extract the runtime code as a `.wasm` blob, which is one of the
 key artifacts for our core.
 
-Build the node using the following:
+Build the node using the following (assuming you are located within
+`polkadot-sdk/templates/parachain`):
 
 ```shell
-cargo build -p parachain-template-node --release
+cargo build --release
 ```
 
 For the sake of this example, we won't go into adding or modifying any pallets. However, this is
@@ -109,51 +110,49 @@ definitely a next step after you get used to deploying your parachain on Rococo!
 ### Customizing our chain specification's patch file
 
 You can bootstrap your network with some initial values, such as initial collators, balances, and
-more. Feel free to use the patch provided here, which you can look to tweaking:
+more. This is done using a patch file, which the `chain-spec-builder` tool uses to create the
+genesis state of your network. You should do the following to create your `patch.json`:
 
-> Make sure you replace `YOUR_PARA_ID_HERE` with your reserved ParaId!
+1. Create the file: `touch patch.json`
+2. Paste the below patch JSON.
+
+Feel free to use the patch provided here, which you can look to tweaking to your liking.
+
+:::info Make sure you replace `YOUR_PARA_ID_HERE` with your reserved ParaId! :::
 
 ```json
 {
-    "balances": {
-        "balances": [
-            [
-                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-                1152921504606846976
-            ],
-            [
-                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-                1152921504606846976
-            ]
-        ]
-    },
-    "collatorSelection": {
-        "candidacyBond": 16000000000,
-        "invulnerables": [
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        ]
-    },
-    "parachainInfo": {
-        "parachainId": YOUR_PARA_ID_HERE
-    },
-    "polkadotXcm": {
-        "safeXcmVersion": 4
-    },
+  "balances": {
+    "balances": [
+      ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1152921504606846976],
+      ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty", 1152921504606846976]
+    ]
+  },
+  "collatorSelection": {
+    "candidacyBond": 16000000000,
+    "invulnerables": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+  },
+  "parachainInfo": {
+    "parachainId": 1000
+  },
+  "polkadotXcm": {
+    "safeXcmVersion": 4
+  },
 
-    "session": {
-        "keys": [
-            [
-                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-                {
-                    "aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-                }
-            ],
-        ]
-    },
-    "sudo": {
-        "key": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-    }
+  "session": {
+    "keys": [
+      [
+        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        {
+          "aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+        }
+      ]
+    ]
+  },
+  "sudo": {
+    "key": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+  }
 }
 ```
 

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -9,11 +9,12 @@ slug: ../build-guides-template-basic
 
 :::warning Not a production ready guide.
 
-This guide is considered a moving document and currently uses the **Rococo** testnet. This guide is also applicable to the parachains on the Kusama
-relay chain, as coretime is also enabled there. Polkadot will
-enable agile coretime after it has been thoroughly tested on Kusama.
+This guide is considered a moving document and currently uses the **Rococo** testnet. This guide is
+also applicable to the parachains on the Kusama relay chain, as coretime is also enabled there.
+Polkadot will enable agile coretime after it has been thoroughly tested on Kusama.
 
-**This instructions on this guide are applicable for the Polkadot SDK repository with tag `polkadot-v1.15.1`**
+**This instructions on this guide are applicable for the Polkadot SDK repository with tag
+`polkadot-v1.15.1`**
 
 :::
 
@@ -114,9 +115,9 @@ definitely a next step after you get used to deploying your parachain on Rococo!
 
 ### Customizing our chain specification's patch file
 
-The chain specification is a JSON file that describes Polkadot SDK-based networks. It usually contains
-the genesis runtime (in hex) under `genesis.runtimeGenesis.code` and also contains
-genesis values/state for the pallets included in your runtime.
+The chain specification is a JSON file that describes Polkadot SDK-based networks. It usually
+contains the genesis runtime (in hex) under `genesis.runtimeGenesis.code` and also contains genesis
+values/state for the pallets included in your runtime.
 
 You can bootstrap your network with some initial values, such as initial collators, balances for
 certain accounts, and more. This is done using a patch file, which the `chain-spec-builder` tool
@@ -290,10 +291,23 @@ Within your project folder, you should now have two files:
 > Make sure you have the
 > [`polkadot-parachain`](./build-guides-install-deps.md#installing-the-omninode) binary installed!
 
-You should start syncing your collator. Keep in mind that you will need to sync Rococo first - this
-could take some time depending on your download speed, so it is best to start this process ASAP. In
-order to avoid storing the full state of the relay chain, be sure to run with the appropriate
-pruning flags (`blocks-pruning` and `state-pruning`):
+Keep in mind that you will need to sync Rococo first - this could take some time depending on your
+download speed, so it is best to start this process. In order to avoid storing the full state of the
+relay chain, be sure to run with the appropriate pruning flags (`blocks-pruning` and
+`state-pruning`):
+
+:::info Explaining `blocks-pruning` and `state-pruning`
+
+A Polkadot SDK-based node has two pruning modes:
+
+- `blocks-pruning` - Prunes block bodies (the list of extrinsics in the block) from a specified
+  height (default: `256`)
+- `state-pruning` - Prunes the overall state from a specified height
+
+Both of these flags aid in reducing the amount of disk space taken up by the relay chain. Note that
+`state-pruning` is only be used for the first initial sync for the database.
+
+:::
 
 ```shell
 polkadot-parachain --collator \

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -21,7 +21,7 @@ Polkadot will enable agile coretime after it has been thoroughly tested on Kusam
 This guide aims to get you up and running with the basics of:
 
 - **Compiling** and configuring your first template
-- **Obtaining** coretime (bulk or on-demand)
+- **Obtaining** Coretime (bulk or on-demand)
 - **Deploying** your template on your procured core
 
 ## Getting ROC and Reserving a ParaId
@@ -42,9 +42,9 @@ to upload our parachain's code:
    [Network > Parachains > Parathreads (the tab)](https://polkadot.js.org/apps/#/parachains/parathreads)
 5. [Follow these instructions to reserve a ParaId.](../learn/learn-guides-coretime-parachains#reserve-paraid)
 
-You can also visit the [Accounts](https://polkadot.js.org/apps/#/accounts) tab to view all
-registered accounts and associated balances within the Polkadot.js Extension. Once finished, you
-should see your new ParaId at the bottom of the list within
+Visit the [Accounts](https://polkadot.js.org/apps/#/accounts) tab to view all registered accounts
+and associated balances within the Polkadot.js Extension. Once finished, you should see your new
+ParaId at the bottom of the list within
 [Network > Parachains > Parathreads](https://polkadot.js.org/apps/#/parachains/parathreads) with the
 option to "Deregister" to the right:
 
@@ -65,7 +65,7 @@ Visit [the dependencies' installation](./build-guides-install-deps.md) page befo
 :::
 
 This guide uses release
-[`polkadot-v1.15.0`](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.15.0), for
+[`polkadot-v1.15.1`](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.15.1), for
 associated tooling (such as `polkadot-parachain` and `chain-spec-builder`).
 
 We will be using the
@@ -258,7 +258,7 @@ fields are in place:
 3. **Make** sure that our `chain_type` is set to `Live`
 4. **Optionally**, change the name, id, and token symbol of your chain.
 
-If you fail to do one of these, there is a large chance that your chain may fail to produce blocks.
+If you fail to do one of these, your chain may fail to produce blocks.
 
 For more information on chain specifications,
 [check out the reference document from the Polkadot SDK.](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/chain_spec_genesis/index.html)
@@ -291,10 +291,9 @@ Within your project folder, you should now have two files:
 > Make sure you have the
 > [`polkadot-parachain`](./build-guides-install-deps.md#installing-the-omninode) binary installed!
 
-Keep in mind that you will need to sync Rococo first - this could take some time depending on your
-download speed, so it is best to start this process. In order to avoid storing the full state of the
-relay chain, be sure to run with the appropriate pruning flags (`blocks-pruning` and
-`state-pruning`):
+Before you are able to connect your collator, you must sync the relay chain. Depending on your
+download speed, the time to sync may vary. In order to avoid storing the full state of the relay
+chain, be sure to run with the appropriate pruning flags (`blocks-pruning` and `state-pruning`):
 
 :::info Explaining `blocks-pruning` and `state-pruning`
 

--- a/docs/build/build-guides-template-basic.md
+++ b/docs/build/build-guides-template-basic.md
@@ -58,7 +58,7 @@ We can now move on to working with the template. Some essential prerequisites ar
 
 :::info Install dependencies
 
-Visit [the dependencies installation](./build-guides-install-deps.md) page before starting.
+Visit [the dependencies' installation](./build-guides-install-deps.md) page before starting.
 
 :::
 


### PR DESCRIPTION
_Please note that these only affect the Kusama guides_

**Closes issue #5928**

---

- [x] Add instructions for installing `polkadot-parachain` and `chain-spec-builder`
- [x] Replace using the compiled binary with `polkadot-parachain` as the "omninode"
- [x] Use `chain-spec-builder` as a means for the genesis