### PR TITLE
Added clarification for parathread registration costs

### DIFF
--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -93,6 +93,18 @@ successfully.
 
 ## Register Parachain State and Code
 
+:::warning Deposit is fixed at the maximum amount for registering a parathread!
+
+Due to the reasons [discussed here](https://github.com/paritytech/polkadot-sdk/pull/2372), instead
+of the usual per-byte method of charging for storing validation and genesis code upon registration,
+the cost is fixed to the maximum possible code size (`MAX_CODE_SIZE`).
+
+On **Kusama**, the cost to register a parathread is **~1100 KSM**.
+
+On **Polkadot**, the cost to register a parathread is **~3300**
+
+:::
+
 The next step is to register the parachain's genesis wasm and state, which you should have generated
 earlier. Note that for this example, we are using `adder-collator`, but in theory a custom runtime
 compiled from a
@@ -100,22 +112,22 @@ compiled from a
 would work as well.
 
 <!-- prettier-ignore -->
-:::info
+<!-- :::info
 
 Registering the genesis state and WASM code of the parachain requires a deposit that is computed
-based on the size (a deposit is paid per byte uploaded):
+based on the size (a deposit is paid per byte uploaded): -->
 
 <!-- prettier-ignore -->
-- **Kusama**: <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
+<!-- - **Kusama**: <RPC network="kusama" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte -->
 
 <!-- prettier-ignore -->
-- **Polkadot**: <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte
+<!-- - **Polkadot**: <RPC network="polkadot" path="consts.registrar.dataDepositPerByte" defaultValue={0} filter="humanReadable"/> per byte -->
 
-The deposit used for registering `ParaID` is already counted in for this deposit, the total deposit
+<!-- The deposit used for registering `ParaID` is already counted in for this deposit, the total deposit
 requirement for registering `ParaID`, state and code for `adder-collator` is around 46 KSM on Kusama
 and 116 DOT on Polkadot.
 
-:::
+::: -->
 
 ![coretime-register-parathread](../assets/coretime/coretime-register-parathread.png)
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -93,7 +93,7 @@ successfully.
 
 ## Register Parachain State and Code
 
-:::warning Deposit is fixed at the maximum amount for registering a parathread!
+:::info Deposit requirements for registering a parachain
 
 Due to the reasons [discussed here](https://github.com/paritytech/polkadot-sdk/pull/2372), instead
 of the usual per-byte method of charging for storing validation and genesis code upon registration,

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -104,6 +104,10 @@ On **Kusama**, the deposit required to register a parachain is **~1100 KSM**.
 
 On **Polkadot**, the deposit required to register a parachain is **~3300 DOT**.
 
+It is possible to deregister the parachain and withdraw the deposit if the parachain has not produced 
+any blocks. If the parachain produced blocks, then the parachain can only be deregistered through relay 
+chain governance.
+
 :::
 
 The next step is to register the parachain's genesis wasm and state, which you should have generated

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -102,7 +102,7 @@ size.
 
 On **Kusama**, the deposit required to register a parachain is **~1100 KSM**.
 
-On **Polkadot**, the cost to register a parathread is **~3300 DOT**.
+On **Polkadot**, the deposit required to register a parachain is **~3300 DOT**.
 
 :::
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -100,7 +100,7 @@ of the usual per-byte method of charging for storing validation and genesis code
 the cost is fixed to the maximum possible code size (`MAX_CODE_SIZE`), regardless of the actual
 size.
 
-On **Kusama**, the cost to register a parathread is **~1100 KSM**.
+On **Kusama**, the deposit required to register a parachain is **~1100 KSM**.
 
 On **Polkadot**, the cost to register a parathread is **~3300 DOT**.
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -101,7 +101,7 @@ the cost is fixed to the maximum possible code size (`MAX_CODE_SIZE`).
 
 On **Kusama**, the cost to register a parathread is **~1100 KSM**.
 
-On **Polkadot**, the cost to register a parathread is **~3300**
+On **Polkadot**, the cost to register a parathread is **~3300 DOT**.
 
 :::
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -97,7 +97,8 @@ successfully.
 
 Due to the reasons [discussed here](https://github.com/paritytech/polkadot-sdk/pull/2372), instead
 of the usual per-byte method of charging for storing validation and genesis code upon registration,
-the cost is fixed to the maximum possible code size (`MAX_CODE_SIZE`).
+the cost is fixed to the maximum possible code size (`MAX_CODE_SIZE`), regardless of the actual
+size.
 
 On **Kusama**, the cost to register a parathread is **~1100 KSM**.
 


### PR DESCRIPTION
- Commented out old per-byte calculation
- Added disclaimer, estimate amounts, and reason why the price is set to `max_code_size`

Closes #5959 