### PR TITLE
Add section on the new validator node key requirement

### DIFF
--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -684,6 +684,28 @@ in the field and click "Set Session Key".
 
 Submit this extrinsic and you are now ready to start validating.
 
+### Setting the Node (aka Network) Key
+
+Validators must use a static network key to maintain a stable node identity across restarts.
+Starting with Polkadot version 1.11, a check is performed on startup, and the following error will be printed if a static node key is not set:
+
+```
+Error:
+0: Starting an authority without network key
+This is not a safe operation because other authorities in the network may depend on your node having a stable identity.
+Otherwise these other authorities may not being able to reach you.
+
+If it is the first time running your node you could use one of the following methods:
+1. [Preferred] Separately generate the key with: <NODE_BINARY> key generate-node-key --base-path <YOUR_BASE_PATH>
+2. [Preferred] Separately generate the key with: <NODE_BINARY> key generate-node-key --file <YOUR_PATH_TO_NODE_KEY>
+3. [Preferred] Separately generate the key with: <NODE_BINARY> key generate-node-key --default-base-path
+4. [Unsafe] Pass --unsafe-force-node-key-generation and make sure you remove it for subsequent node restarts"
+```
+
+The recommended solution is to generate a node key and save it to a file using `polkadot key generate-node-key --file <PATH_TO_NODE_KEY>`, then attach it to your node with `--node-key-file <PATH_TO_NODE_KEY>`.
+
+Please see [polkadot-sdk#3852](https://github.com/paritytech/polkadot-sdk/pull/3852) for the rationale behind this change.
+
 ## Validate
 
 To verify that your node is live and synchronized, head to


### PR DESCRIPTION
The requirement was added in https://github.com/paritytech/polkadot-sdk/pull/3852 , we are adding a section on the docs to clarify that this is mandatory.

cc @alexggh