### PR TITLE
Remove Substrate Connect mentions from the "Node Endpoints" section.

### DIFF
--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -47,20 +47,6 @@ async () => {
   // ...
 ```
 
-#### Substrate Connect
-
-[Substrate connect](https://substrate.io/developers/substrate-connect/) builds on Polkadot JS so
-building an app is the same experience as with using a traditional RPC server node. It is a fast,
-secure, and decentralized way to interact with Polkadot, Kusama, and their parachains right in the
-browser.
-
-:::info
-
-Substrate Connect is still under
-[active development](https://github.com/paritytech/substrate-connect).
-
-:::
-
 ### Third Party Providers
 
 There are a number of third-party providers of RPC infrastructure to the Polkadot and Kusama


### PR DESCRIPTION
This PR removed the subsection about Substrate Connect from the "Node Endpoints" section of the wiki.

The rationale behind this delation is:
- the "Node Endpoints" section deals with available node endpoints, whereas Substrate Connect is a light client based solution for a browser extension.
- There is a wiki section where Substrate Connect is properly addressed: https://wiki.polkadot.network/docs/build-light-clients
- Substrate Connect is still under heavy development and may have important changes in a near future. 