### PR TITLE
Small fix to the metadata hash description

### DIFF
--- a/docs/build/build-transaction-construction.md
+++ b/docs/build/build-transaction-construction.md
@@ -27,7 +27,7 @@ Polkadot has some basic transaction information that is common to all transactio
 - Mode: The flag indicating whether to verify the metadata hash or not.
 - Era Period: Optional, the number of blocks after the checkpoint for which a transaction is valid.
   If zero, the transaction is [immortal](build-protocol-info.md#transaction-mortality)
-- MetadataHash: The metadata hash which should match the RUNTIME_METADATA_HASH environment variable.
+- MetadataHash: Optional, the metadata hash which should match the RUNTIME_METADATA_HASH environment variable.
 
 :::caution
 


### PR DESCRIPTION
In my previous PR, I forgot to add the optional tag in the description of the metadata hash.