### PR TITLE
Update learn-nomination-pools.md. Staking proxies can make nomination…

### DIFF
--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -136,17 +136,10 @@ account.
 
 :::
 
-:::tip Use Non-Transfer or Nomination Pools Proxy Accounts to join Nomination Pools
+:::tip Use Proxy Accounts to join Nomination Pools
 
-Only [non-transfer proxies](learn-proxies.md#non-transfer-proxy) and
-[nomination pools proxy](./learn-proxies.md#nomination-pools-proxy) can be used to participate in
-nomination pools. [Staking proxies](learn-proxies.md#staking-proxy) cannot be used as they cannot
-make calls to the nomination pools pallet. (The nomination pools will be supported through a staking
-proxy when the changes made in [this PR](https://github.com/paritytech/polkadot/pull/7448) are
-released on the network.
-
-Thus, depending on how much control you want to give your proxy, you might choose between
-non-transfer > staking > nomination pool proxy, with the latter being only able to sign transactions
+Depending on how much control you want to give your proxy, you might choose between
+any > non-transfer > staking > nomination pool proxy, with the latter being only able to sign transactions
 related to the `NominationPool` pallet.
 
 :::


### PR DESCRIPTION
The [mentioned PR](https://github.com/paritytech/polkadot/pull/7448) was merged, and staking proxy accounts can issue calls to the nomination pools pallet:

https://github.com/polkadot-fellows/runtimes/blob/40f849df87a8a1b79aba4cfb7ce762d868243dca/relay/polkadot/src/lib.rs#L1258-L1263

I also added the proxy type "any" as a possible proxy to issue nomination pool calls.