### PR TITLE
Update Getting Started

### DIFF
--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -195,7 +195,7 @@ Explore Polkadot with a secure and user-friendly wallets listed on the
   you can create your own [nomination pool](../learn/learn-nomination-pools.md).
 
 DOT has utility in Polkadot's OpenGov where you can
-[vote](../learn/learn-polkadot-opengov.md#voting-on-a-referendum) or
+[vote](../learn/learn-polkadot-opengov.md#voting-on-a-referendum),
 [delegate your voting power](../learn/learn-polkadot-opengov.md#multirole-delegation), and place
 deposits for your referenda or referenda proposed by others. DOT can also enable you to participate
 in programs like the [Thousand Validators Programme](../general/thousand-validators.md#polkadot).

--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -194,14 +194,11 @@ Explore Polkadot with a secure and user-friendly wallets listed on the
 - {{ polkadot: __<RPC network="polkadot" path="query.nominationPools.minCreateBond" defaultValue={5000000000000} filter="humanReadable"/>:__ :polkadot }}
   you can create your own [nomination pool](../learn/learn-nomination-pools.md).
 
-DOT has utility in [Polkadot's OpenGov](../learn/learn-polkadot-opengov.md). Bonding DOT is a
-requirement to create proposals, to endorse them and to vote on them when they become referendums.
-Bonding
-{{ polkadot: <RPC network="polkadot" path="consts.treasury.proposalBondMinimum" defaultValue={1000000000000} filter="humanReadable"/> :polkadot }}
-or 5% of requested funding is a requirement to make a
-[treasury proposal](../learn/learn-polkadot-opengov-treasury.md). DOT can also enable you to
-participate in programs like the
-[Thousand Validators Programme](../general/thousand-validators.md#polkadot).
+DOT has utility in Polkadot's OpenGov where you can
+[vote](../learn/learn-polkadot-opengov.md#voting-on-a-referendum) or
+[delegate your voting power](../learn/learn-polkadot-opengov.md#multirole-delegation), and place
+deposits for your referenda or referenda proposed by others. DOT can also enable you to participate
+in programs like the [Thousand Validators Programme](../general/thousand-validators.md#polkadot).
 
 ## Polkadot Gifts
 

--- a/docs/general/kusama/kusama-getting-started.md
+++ b/docs/general/kusama/kusama-getting-started.md
@@ -182,7 +182,7 @@ governance, acquisition of a parachain slot and for enabling several key functio
 KSM has utility in [Kusama's OpenGov](../../learn/learn-polkadot-opengov.md) where you can
 [vote](../../learn/learn-polkadot-opengov.md#voting-on-a-referendum) or
 [delegate your voting power](../../learn/learn-polkadot-opengov.md#multirole-delegation), and place
-deposits for your referenda or referenda proposed by others. DOT can also enable you to participate
+deposits for your referenda or referenda proposed by others. KSM can also enable you to participate
 in programs like the [Thousand Validators Programme](../../general/thousand-validators.md#polkadot).
 
 ### Kusama Gifts

--- a/docs/general/kusama/kusama-getting-started.md
+++ b/docs/general/kusama/kusama-getting-started.md
@@ -180,10 +180,10 @@ governance, acquisition of a parachain slot and for enabling several key functio
   the minimum amount of KSM required to become an active nominator and earn rewards.
 
 KSM has utility in [Kusama's OpenGov](../../learn/learn-polkadot-opengov.md) where you can
-[vote](../../learn/learn-polkadot-opengov.md#voting-on-a-referendum) or
+[vote](../../learn/learn-polkadot-opengov.md#voting-on-a-referendum),
 [delegate your voting power](../../learn/learn-polkadot-opengov.md#multirole-delegation), and place
 deposits for your referenda or referenda proposed by others. KSM can also enable you to participate
-in programs like the [Thousand Validators Programme](../../general/thousand-validators.md#polkadot).
+in programs like the [Thousand Validators Programme](../../general/thousand-validators.md).
 
 ### Kusama Gifts
 

--- a/docs/general/kusama/kusama-getting-started.md
+++ b/docs/general/kusama/kusama-getting-started.md
@@ -179,12 +179,11 @@ governance, acquisition of a parachain slot and for enabling several key functio
 - {{ kusama: __<RPC network="kusama" path="query.staking.minimumActiveStake" defaultValue={0} filter="humanReadable"/>:__ :kusama }}
   the minimum amount of KSM required to become an active nominator and earn rewards.
 
-KSM has utility in [Kusama's OpenGov](../../learn/learn-polkadot-opengov.md). Bonding KSM is a
-requirement to create proposals, to endorse them and to vote on them when they become referendums.
-Bonding
-{{ kusama: <RPC network="kusama" path="consts.treasury.proposalBondMinimum" defaultValue={666666666000} filter="humanReadable"/> :kusama }}
-or 5% of requested funding is a requirement to make a
-[treasury proposal](../../learn/learn-polkadot-opengov-treasury.md).
+KSM has utility in [Kusama's OpenGov](../../learn/learn-polkadot-opengov.md) where you can
+[vote](../../learn/learn-polkadot-opengov.md#voting-on-a-referendum) or
+[delegate your voting power](../../learn/learn-polkadot-opengov.md#multirole-delegation), and place
+deposits for your referenda or referenda proposed by others. DOT can also enable you to participate
+in programs like the [Thousand Validators Programme](../../general/thousand-validators.md#polkadot).
 
 ### Kusama Gifts
 


### PR DESCRIPTION
From https://github.com/w3f/polkadot-wiki/issues/6085

"Remove Gov1 info on Getting Started page and add delegation feature to "What can I do with my DOT" section