### PR TITLE
Update endpoints

### DIFF
--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -20,7 +20,7 @@ tables below list these endpoints.
 
 ### Network Endpoints
 
-Endpoints for all production and test networks are visible on the
+Endpoints for all production and test networks are listed on the
 [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) and can be accessed
 [here](https://github.com/polkadot-js/apps/tree/master/packages/apps-config/src/endpoints).
 Endpoints for Polkadot Relay Chain and Kusama Relay Chain, parachains, and Paseo test network are

--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -21,7 +21,7 @@ tables below list these endpoints.
 ### Network Endpoints
 
 Endpoints for all production and test networks are listed on the
-[Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) and can be accessed
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) which are accessed from
 [here](https://github.com/polkadot-js/apps/tree/master/packages/apps-config/src/endpoints).
 Endpoints for Polkadot Relay Chain and Kusama Relay Chain, parachains, and Paseo test network are
 maintained by the community. System Chains as well as Westend and Rococo test networks "official"

--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -66,6 +66,6 @@ service, and additional metrics.
 :::note
 
 The list of third party RPC endpoints above for Polkadot and Kusama is directly fetched from
-[Polkdot-JS UI](https://polkadot.js.org/apps/#/explorer)
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/explorer)
 
 :::

--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -7,6 +7,8 @@ keywords: [endpoints, network, connect]
 slug: ../maintain-endpoints
 ---
 
+import Tabs from "@theme/Tabs"; import TabItem from "@theme/TabItem";
+
 Ideally, one may run their own node when interacting with the
 [Polkadot network](https://polkadot.network/) via [Polkadot-JS Apps](https://polkadot.js.org/apps/)
 or other UIs and programmatic methods. Another option would be to connect to one of the several
@@ -18,30 +20,64 @@ tables below list these endpoints.
 
 ### Network Endpoints
 
-#### Main Networks
+Endpoints for all production and test networks are visible on the
+[Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) and can be accessed
+[here](https://github.com/polkadot-js/apps/tree/master/packages/apps-config/src/endpoints).
+Endpoints for Polkadot Relay Chain and Kusama Relay Chain, parachains, and Paseo test network are
+maintained by the community. System Chains as well as Westend and Rococo test networks "official"
+endpoints are listed below:
 
-| Network  | URL                          |
-| -------- | ---------------------------- |
-| Polkadot | wss://rpc.polkadot.io        |
-| Kusama   | wss://kusama-rpc.polkadot.io |
+<!-- prettier-ignore -->
+<Tabs groupId="endpoints" values={[ 
+  { label: 'Polkadot System Chains', value: 'psc' }, 
+  { label: 'Kusama System Chains', value: 'ksc' }, 
+  { label: 'Test Networks', value: 'tn' } 
+]}>
 
-#### Test Networks
+  <TabItem value="psc">
 
-| Network | URL                           |
+| Network      | WSS Endpoint                               |
+| ------------ | ------------------------------------------ |
+| Asset Hub    | wss://polkadot-asset-hub-rpc.polkadot.io   |
+| Bridge Hub   | wss://polkadot-bridge-hub-rpc.polkadot.io  |
+| Collectives  | wss://polkadot-collectives-rpc.polkadot.io |
+| People Chain | wss://polkadot-people-rpc.polkadot.io      |
+
+  </TabItem>
+
+  <TabItem value="ksc">
+
+| Network      | WSS Endpoint                             |
+| ------------ | ---------------------------------------- |
+| Asset Hub    | wss://kusama-asset-hub-rpc.polkadot.io   |
+| Bridge Hub   | wss://kusama-bridge-hub-rpc.polkadot.io  |
+| Collectives  | wss://kusama-collectives-rpc.polkadot.io |
+| People Chain | wss://kusama-people-rpc.polkadot.io      |
+
+  </TabItem>
+
+  <TabItem value="tn">
+
+| Network | WSS Endpoint                  |
 | ------- | ----------------------------- |
 | Westend | wss://westend-rpc.polkadot.io |
 | Rococo  | wss://rococo-rpc.polkadot.io  |
 
+  </TabItem>
+
+</Tabs>
+
 #### Example usage with Polkadot-JS API
 
-To connect to the Parity node, use the endpoint in your JavaScript apps like so:
+To connect to the Parity node for the Polkadot Asset Hub, use the endpoint in your JavaScript apps
+like so:
 
 ```javascript {5}
 // Using the Polkadot Mainnet Endpoint
 const { ApiPromise, WsProvider } = require('@polkadot/api');
 async () => {
   // Construct a provider with the endpoint URL
-  const provider = new WsProvider('wss://rpc.polkadot.io/');
+  const provider = new WsProvider('wss://polkadot-asset-hub-rpc.polkadot.io');
   // Create an API instance for Polkadot
   const api = await ApiPromise.create({ provider });
   // ...

--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -25,7 +25,7 @@ Endpoints for all production and test networks are listed on the
 [here](https://github.com/polkadot-js/apps/tree/master/packages/apps-config/src/endpoints).
 Endpoints for Polkadot Relay Chain and Kusama Relay Chain, parachains, and Paseo test network are
 maintained by the community. System Chains as well as Westend and Rococo test network endpoints maintained by Parity Technologies
-endpoints are listed below:
+are listed below:
 
 <!-- prettier-ignore -->
 <Tabs groupId="endpoints" values={[ 

--- a/docs/maintain/maintain-endpoints.md
+++ b/docs/maintain/maintain-endpoints.md
@@ -24,7 +24,7 @@ Endpoints for all production and test networks are listed on the
 [Polkadot-JS UI](https://polkadot.js.org/apps/#/accounts) which are accessed from
 [here](https://github.com/polkadot-js/apps/tree/master/packages/apps-config/src/endpoints).
 Endpoints for Polkadot Relay Chain and Kusama Relay Chain, parachains, and Paseo test network are
-maintained by the community. System Chains as well as Westend and Rococo test networks "official"
+maintained by the community. System Chains as well as Westend and Rococo test network endpoints maintained by Parity Technologies
 endpoints are listed below:
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
See https://github.com/w3f/polkadot-wiki/issues/6085

Task "Node endpoints are outdated for Polkadot and Kusama. System chains node end points need to be listed."