### PR TITLE
Update build-data.md

### DIFF
--- a/docs/build/build-data.md
+++ b/docs/build/build-data.md
@@ -52,15 +52,9 @@ subgraphs using [GraphQL](https://graphql.org/).
 
 ## Analytics platform
 
-### Dolpha Analytics
+### DIN
 
-[Dolpha Analytics](https://dolpha.com/) is an on-chain data analytics and insights platform for the
-Polkadot and Kusama ecosystems. Dolpha empowers casual and power users to get a pulse on the
-ecosystems, perform due diligence, surface signals, and make informed data-driven decisions.
-
-### Web3Go
-
-[Web3GO](https://web3go.xyz/) is a Polkadot-based open data analytics platform that provides
+[DIN](https://din.lol/)(formally named Web3Go) is a Polkadot-based open data analytics platform that provides
 infrastructure and tooling to help users visualize, curate, share, and analyze on-chain data.
 
 ### Covalent


### PR DESCRIPTION
- The analytics panel offered by Dolpha has been discontinued more than 1 year ago after its proposal to the treasury was rejected.

- Web3Go has undergone a complete rebranding and is now known as DIN. You can confirm this by seeing that from the original domain of the Web3Go portal a redirection is made to the DIN landing page.