### PR TITLE
Add parachain / solochain section to Runtime Upgrades page

### DIFF
--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -8,7 +8,9 @@ slug: ../learn-runtime-upgrades
 ---
 
 Runtime upgrades allow {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} to change the
-logic of the chain without the need for a hard fork.
+logic of a Substrate-based chain without the need for a hard fork.
+
+:::info Substrate is part of the Polkadot SDK :::
 
 ## Forkless Upgrades
 
@@ -20,15 +22,16 @@ thousands) of nodes in the network that need to upgrade their software. Thus, ha
 inefficient, and error-prone due to the levels of offline coordination required and, therefore, the
 propensity to bundle many upgrades into one large-scale event.
 
-By using Wasm in Substrate (the framework powering Polkadot, Kusama, and many connecting chains),
-parachains are given the ability to upgrade their runtime (a chain's "business logic") without hard
-forking.
+The usage of [WebAssembly](./learn-wasm.md) in the Polkadot SDK (the framework powering Polkadot,
+Kusama, and its respective parachains/rollups), gives any relay chains, parachains, and any other
+chains built with the Polkadot SDK the ability to upgrade their runtime (a chain's "business logic")
+without hard forking.
 
 Rather than encoding the runtime in the nodes,
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} nodes contain a WebAssembly
 [execution host](learn-polkadot-host). They maintain consensus on a very low-level and
 well-established instruction set. Upgrades can be small, isolated, and very specific by deploying
-Wasm on-chain and having nodes auto-enact the new logic at a particular block height.
+WebAssembly on-chain and having nodes auto-enact the new logic at a particular block height.
 
 The {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} runtime is stored on the
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} blockchain itself.
@@ -36,12 +39,27 @@ The {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} runtime is st
 the logic stored on-chain and removes the coordination challenge of requiring thousands of node
 operators to upgrade in advance of a given block number. Polkadot stakeholders propose and approve
 upgrades through the [on-chain governance](./learn-polkadot-opengov.md) system, which also enacts
-them autonomously.
+them autonomously once voted through.
 
-As a result of storing the Runtime as part of the state, the Runtime code itself becomes state
-sensitive, and calls to Runtime can change the Runtime code itself. Therefore, the Polkadot Host
-must always ensure it provides the Runtime corresponding to the state in which the entry point has
+As a result of storing the runtime as part of the state, the runtime code itself becomes state
+sensitive, and calls to runtime can change the runtime code itself. Therefore, the Polkadot Host
+must always ensure it provides the runtime corresponding to the state in which the entry point has
 been called.
+
+### Forkless Upgrades - Parachains & Solo Chains
+
+The architecture for parachains and solo chains is the same as the relay chain, with the runtime
+code being stored on-chain. Solo chains, which are blockchains which are not secured by / following
+the relay chain's consensus, are able to be update with whatever governance that solo chain has
+implemented. This could either be a governance system like [OpenGov](./learn-polkadot-opengov.md),
+or a simple sudo/multisig setup.
+
+Parachains must notify the relay chain whenever a new upgrade is to be enacted. This is done using
+two key extrinsics:
+
+- The first notifies the relay chain that an upgrade is to take place, and thus a new state
+  transition function is going to be introduced for that parachain to be validated with.
+- The second enacts the upgrade, assuming it has been approved.
 
 ## Client Releases
 

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -10,7 +10,12 @@ slug: ../learn-runtime-upgrades
 Runtime upgrades allow {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} to change the
 logic of a Substrate-based chain without the need for a hard fork.
 
-:::info Substrate is part of the Polkadot SDK :::
+:::info Substrate is part of the Polkadot SDK
+
+Substrate is one of the core parts of the Polkadot SDK, containing libraries used to build
+blockchains.
+
+:::
 
 ## Forkless Upgrades
 

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -28,9 +28,9 @@ inefficient, and error-prone due to the levels of offline coordination required 
 propensity to bundle many upgrades into one large-scale event.
 
 The usage of [WebAssembly](./learn-wasm.md) in the Polkadot SDK (the framework powering Polkadot,
-Kusama, and its respective parachains/rollups), gives any relay chains, parachains, and any other
-chains built with the Polkadot SDK the ability to upgrade their runtime (a chain's "business logic")
-without hard forking.
+Kusama and their respective parachains), give the relay chain, its parachains, as well as any other standalone solo
+chains built with the Polkadot SDK the ability to upgrade their runtime (the chain's "business logic")
+without a hard fork of the respective network.
 
 Rather than encoding the runtime in the nodes,
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} nodes contain a WebAssembly

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -12,7 +12,7 @@ logic of a Substrate-based chain without the need for a hard fork.
 
 :::info Substrate is part of the Polkadot SDK
 
-Substrate is one of the core parts of the Polkadot SDK, containing libraries used to build
+Substrate is one of the core components of the Polkadot SDK, containing libraries used to build
 blockchains.
 
 :::

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -55,9 +55,7 @@ been called.
 
 The node architectural design for parachains and solo chains is similar to that of the relay chain, with the runtime
 code being a Wasm blob that is stored in chain state. Solo chains built with Polkadot SDK, which are blockchains that have a native consensus mechanism that is independent of
-the relay chain's consensus, are able to be update with whatever governance that solo chain has
-implemented. This could either be a governance system like [OpenGov](./learn-polkadot-opengov.md),
-or a simple sudo/multisig setup.
+the relay chain's consensus, can be updated through an on-chain governance system like [OpenGov](./learn-polkadot-opengov.md) or a simple sudo/multisig setup.
 
 Parachains must notify the relay chain whenever a new upgrade is to be enacted. This is done using
 two key extrinsics:

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -53,7 +53,7 @@ been called.
 
 ### Forkless Upgrades - Parachains & Solo Chains
 
-The architecture for parachains and solo chains is the same as the relay chain, with the runtime
+The node architectural design for parachains and solo chains is similar to that of the relay chain, with the runtime
 code being stored on-chain. Solo chains, which are blockchains which are not secured by / following
 the relay chain's consensus, are able to be update with whatever governance that solo chain has
 implemented. This could either be a governance system like [OpenGov](./learn-polkadot-opengov.md),

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -54,7 +54,7 @@ been called.
 ### Forkless Upgrades - Parachains & Solo Chains
 
 The node architectural design for parachains and solo chains is similar to that of the relay chain, with the runtime
-code being stored on-chain. Solo chains, which are blockchains which are not secured by / following
+code being a Wasm blob that is stored in chain state. Solo chains built with Polkadot SDK, which are blockchains that have a native consensus mechanism that is independent of
 the relay chain's consensus, are able to be update with whatever governance that solo chain has
 implemented. This could either be a governance system like [OpenGov](./learn-polkadot-opengov.md),
 or a simple sudo/multisig setup.

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -7,15 +7,9 @@ keywords: [runtime, upgrades, releases, forkless]
 slug: ../learn-runtime-upgrades
 ---
 
-Runtime upgrades allow {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} to change the
-logic of a Substrate-based chain without the need for a hard fork.
-
-:::info Substrate is part of the Polkadot SDK
-
-Substrate is one of the core components of the Polkadot SDK, containing libraries used to build
-blockchains.
-
-:::
+Runtime upgrades allow the {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} relay
+chain, parachains, and solo blockchains built with the Polkadot SDK to change their core business
+logic (referred to as the **runtime**) without the need for a hard fork.
 
 ## Forkless Upgrades
 
@@ -28,9 +22,9 @@ inefficient, and error-prone due to the levels of offline coordination required 
 propensity to bundle many upgrades into one large-scale event.
 
 The usage of [WebAssembly](./learn-wasm.md) in the Polkadot SDK (the framework powering Polkadot,
-Kusama and their respective parachains), give the relay chain, its parachains, as well as any other standalone solo
-chains built with the Polkadot SDK the ability to upgrade their runtime (the chain's "business logic")
-without a hard fork of the respective network.
+Kusama and their respective parachains), give the relay chain, its parachains, as well as any other
+standalone solo chains built with the Polkadot SDK the ability to upgrade their runtime (the chain's
+"business logic") without a hard fork of the respective network.
 
 Rather than encoding the runtime in the nodes,
 {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} nodes contain a WebAssembly
@@ -53,16 +47,20 @@ been called.
 
 ### Forkless Upgrades - Parachains & Solo Chains
 
-The node architectural design for parachains and solo chains is similar to that of the relay chain, with the runtime
-code being a Wasm blob that is stored in chain state. Solo chains built with Polkadot SDK, which are blockchains that have a native consensus mechanism that is independent of
-the relay chain's consensus, can be updated through an on-chain governance system like [OpenGov](./learn-polkadot-opengov.md) or a simple sudo/multisig setup.
+The node architectural design for parachains and solo chains is similar to that of the relay chain,
+with the runtime code being a Wasm blob that is stored in chain state. Solo chains built with
+Polkadot SDK, which are blockchains that have a native consensus mechanism that is independent of
+the relay chain's consensus, can be updated through an on-chain governance system like
+[OpenGov](./learn-polkadot-opengov.md) or a simple sudo/multisig setup.
 
 Parachains must notify the relay chain whenever a new upgrade is to be enacted. This is done using
 two key extrinsics:
 
-- The first notifies the relay chain that an upgrade is to take place, and thus a new state
-  transition function is going to be introduced for that parachain to be validated with.
-- The second enacts the upgrade, assuming it has been approved.
+- [`system.authorizeUpgrade`](https://paritytech.github.io/polkadot-sdk/master/frame_system/pallet/struct.Pallet.html#method.authorize_upgrade) -
+  notifies the relay chain that an upgrade is to take place, and thus a new state transition
+  function is going to be introduced for that parachain to be validated with.
+- [`system.applyAuthorizedUpgrade`](https://paritytech.github.io/polkadot-sdk/master/frame_system/pallet/struct.Pallet.html#method.apply_authorized_upgrade) -
+  enacts the upgrade, assuming it has been approved.
 
 ## Client Releases
 

--- a/docs/learn/learn-runtime-upgrades.md
+++ b/docs/learn/learn-runtime-upgrades.md
@@ -44,7 +44,7 @@ The {{ polkadot: Polkadot :polkadot }}{{ kusama: Kusama :kusama }} runtime is st
 the logic stored on-chain and removes the coordination challenge of requiring thousands of node
 operators to upgrade in advance of a given block number. Polkadot stakeholders propose and approve
 upgrades through the [on-chain governance](./learn-polkadot-opengov.md) system, which also enacts
-them autonomously once voted through.
+them autonomously once the runtime upgrade referendum is approved through on-chain voting.
 
 As a result of storing the runtime as part of the state, the runtime code itself becomes state
 sensitive, and calls to runtime can change the runtime code itself. Therefore, the Polkadot Host


### PR DESCRIPTION
Addresses mega issue #6085: 

**Runtime Upgrades page only references Polkadot. No info on Parachain Runtime upgrades.**

---

Adds **high-level information** relating to runtime upgrades.  A good follow-up would be a guide on performing runtime upgrades for the mentioned cases, or pointing to a reliable guide.  