### PR TITLE
Remove Child Bounty delay payout info

### DIFF
--- a/docs/general/chain-state-values.md
+++ b/docs/general/chain-state-values.md
@@ -79,10 +79,6 @@ The deposit to submit a bounty on Polkadot is <RPC network="polkadot" path="cons
 
 A Polkadot bounty has a predetermined duration of <RPC network="polkadot" path="consts.bounties.bountyUpdatePeriod" defaultValue={1296000} filter="blocksToDays"/> days.
 
-#### Child Bounty Payout Delay
-
-The waiting time before claiming a Polkadot child bounty reward is <RPC network="polkadot" path="consts.bounties.bountyDepositPayoutDelay" defaultValue={115200} filter="blocksToDays"/> days.
-
 #### Conviction Voting Lock Period
 
 One conviction voting lock period on Polkadot equals <RPC network="polkadot" path="consts.convictionVoting.voteLockingPeriod" defaultValue={100800} filter="blocksToDays"/> days.
@@ -262,10 +258,6 @@ The deposit to submit a bounty on Kusama is <RPC network="kusama" path="consts.b
 #### Bounty Duration
 
 A Kusama bounty has a predetermined duration of <RPC network="kusama" path="consts.bounties.bountyUpdatePeriod" defaultValue={1296000} filter="blocksToDays"/> days.
-
-#### Child Bounty Payout Delay
-
-The waiting time before claiming a Kusama child bounty reward is <RPC network="kusama" path="consts.bounties.bountyDepositPayoutDelay" defaultValue={57600} filter="blocksToDays"/> days.
 
 #### Conviction Voting Lock Period
 

--- a/docs/learn/learn-guides-bounties.md
+++ b/docs/learn/learn-guides-bounties.md
@@ -182,10 +182,9 @@ bounty 17 refers to the Community Events Bounty, which has 183 child bounties.
 
 ![polkassembly-child-bounties](../assets/polkassembly-child-bounties.png)
 
-[After the child bounty delay elapsed](../general/chain-state-values.md#child-bounty-payout-delay),
-follow the guidelines in the video tutorial below to learn how to claim a child bounty reward. Note
-that the extrinsic to claim the child bounty reward is permissionless, and anyone can initiate the
-claim on behalf of the beneficiary.
+After the child bounty has been rewarded, follow the guidelines in the video tutorial below to learn
+how to claim a child bounty reward. Note that the extrinsic to claim the child bounty reward is
+permissionless, and anyone can initiate the claim on behalf of the beneficiary.
 
 <div className="row">
   <div className="col text--center">


### PR DESCRIPTION
Now there is not delay anymore. People can claim the reward right after the child bounty is awarded.