### PR TITLE
Add Advanced Coretime Guides / Pages to Polkadot Wiki

### DIFF
--- a/docs/build/build-guides-coretime-start.md
+++ b/docs/build/build-guides-coretime-start.md
@@ -11,13 +11,6 @@ slug: ../build-guides-coretime-start
 
 :::
 
-:::warning Not a production ready guide.
-
-Agile coretime is only for the Kusama and testnet networks at the moment, and is not yet deployed on
-Polkadot. These guides are **not** production ready due to the moving nature of these features.
-
-:::
-
 ## Using the Polkadot SDK
 
 The Polkadot SDK is comprised of **three** important repositories:

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -551,6 +551,23 @@ module.exports = {
                     "learn/learn-agile-coretime",
                     "learn/learn-guides-coretime-marketplaces",
                     "learn/learn-guides-coretime-parachains",
+                    {
+                      type: "category",
+                      label: "Advanced Coretime Guides",
+                      description: "More Advanced and Technical Coretime Guides",
+                      link: {
+                        type: 'generated-index',
+                        title: "Advanced Coretime Guides",
+                        description: "Concepts, Implementation and Tutorials on Agile Coretime.",
+                        slug: '/learn-agile-coretime-getting-started',
+                      },
+                      items: [
+                        "build/build-guides-install-deps",
+                        "build/build-guides-coretime-start",
+                        "build/build-guides-template-basic",
+                        "build/build-guides-coretime-troubleshoot"
+                      ]
+                    }
                   ],
                 },
                 {


### PR DESCRIPTION
Adds the following section / guides from the Kusama Guide to the Polkadot Wiki: https://guide.kusama.network/docs/learn-agile-coretime-getting-started