### PR TITLE
Edit Coretime Guides

### DIFF
--- a/docs/build/build-guides-coretime-start.md
+++ b/docs/build/build-guides-coretime-start.md
@@ -7,7 +7,7 @@ keywords: [coretime, blockspace, parathread, parachain, cores]
 slug: ../build-guides-coretime-start
 ---
 
-:::warning This section is under construction and moving! (Expect Chaos)
+:::warning This section is under construction.
 
 :::
 

--- a/docs/build/build-guides-coretime-start.md
+++ b/docs/build/build-guides-coretime-start.md
@@ -20,14 +20,14 @@ import Tabs from "@theme/Tabs"; import DocCardList from '@theme/DocCardList';
 The Polkadot SDK is comprised of **three** important repositories:
 
 - [**Polkadot**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#polkadot) -
-  Which for a time, included both the client implementation and runtime, until the runtime was moved
-  to the Polkadot Fellows organization.
+  This included both client implementation and runtime until the runtime was moved to the Polkadot
+  Fellows organization.
 - [**Substrate**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#substrate) -
-  The underlying, core primitives and libraries for building blockchains (any blockchain, not just
+  The underlying core primitives and libraries for building blockchains (any blockchain, not just
   one for Polkadot). Much of Polkadot is built with Substrate.
 - [**Cumulus**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#cumulus) -
-  A set of libraries and tools which pertain specifically with connecting blockchains to Polkadot,
-  known as parachains.
+  A set of libraries and tools pertaining specifically to connecting blockchains to Polkadot, known
+  as parachains.
 
 > For an in-depth dive into the monorepo, it is highly recommended that you look into the
 > [Polkadot SDK Docs, which explains everything.](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html)
@@ -110,7 +110,7 @@ to start and run your chain!
 ### Deployment Example - Adder Collator
 
 Try out the above by deploying the
-[adder collator, a very simple "counter" parachain implementation](../learn/learn-guides-coretime-parachains.md).
+[adder collator, a straightforward "counter" parachain implementation](../learn/learn-guides-coretime-parachains.md).
 
 ## OpenZeppelin Templates & Guides
 

--- a/docs/build/build-guides-coretime-start.md
+++ b/docs/build/build-guides-coretime-start.md
@@ -7,9 +7,13 @@ keywords: [coretime, blockspace, parathread, parachain, cores]
 slug: ../build-guides-coretime-start
 ---
 
+import Tabs from "@theme/Tabs"; import DocCardList from '@theme/DocCardList';
+
 :::warning This section is under construction.
 
 :::
+
+<DocCardList />
 
 ## Using the Polkadot SDK
 
@@ -20,7 +24,7 @@ The Polkadot SDK is comprised of **three** important repositories:
   to the Polkadot Fellows organization.
 - [**Substrate**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#substrate) -
   The underlying, core primitives and libraries for building blockchains (any blockchain, not just
-  one for Polkadot). Much of Polkadot is built with Substrate!
+  one for Polkadot). Much of Polkadot is built with Substrate.
 - [**Cumulus**](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html#cumulus) -
   A set of libraries and tools which pertain specifically with connecting blockchains to Polkadot,
   known as parachains.
@@ -98,7 +102,7 @@ PC-->DEP
 ### Install dependencies
 
 Make sure you have everything you need for your target system
-[here.](./build-guides-install-deps.md).
+[here](./build-guides-install-deps.md).
 
 Be sure you also install the `polkadot-parachain` and `chain-spec-builder` binaries, as they needed
 to start and run your chain!
@@ -106,7 +110,7 @@ to start and run your chain!
 ### Deployment Example - Adder Collator
 
 Try out the above by deploying the
-[adder collator, a very simple "counter" parachain implementation.](../learn/learn-guides-coretime-parachains.md).
+[adder collator, a very simple "counter" parachain implementation](../learn/learn-guides-coretime-parachains.md).
 
 ## OpenZeppelin Templates & Guides
 

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -560,14 +560,11 @@ module.exports = {
                       label: "Coretime Guides",
                       description: "Technical Coretime Guides",
                       link: {
-                        type: 'generated-index',
-                        title: "Coretime Guides",
-                        description: "Concepts, Implementation and Tutorials on Agile Coretime.",
-                        slug: '/learn-agile-coretime-getting-started',
+                        type: 'doc',
+                        id: 'build/build-guides-coretime-start',
                       },
                       items: [
                         "build/build-guides-install-deps",
-                        "build/build-guides-coretime-start",
                         "build/build-guides-template-basic",
                         "build/build-guides-coretime-troubleshoot"
                       ]

--- a/polkadot-wiki/sidebars.js
+++ b/polkadot-wiki/sidebars.js
@@ -557,11 +557,11 @@ module.exports = {
                     "learn/learn-guides-coretime-parachains",
                     {
                       type: "category",
-                      label: "Advanced Coretime Guides",
-                      description: "More Advanced and Technical Coretime Guides",
+                      label: "Coretime Guides",
+                      description: "Technical Coretime Guides",
                       link: {
                         type: 'generated-index',
-                        title: "Advanced Coretime Guides",
+                        title: "Coretime Guides",
                         description: "Concepts, Implementation and Tutorials on Agile Coretime.",
                         slug: '/learn-agile-coretime-getting-started',
                       },


### PR DESCRIPTION
Some minor changes:

- removed "advanced" as Coretime is already in the Advanced section
- removed "expect chaos" as this, I feel, creates anxiety when reading the guide.
- added page with mermaid diagram as intro with `doc` instead of `generated index`
- grammar checks

To consider:

We have now two pages explaining similar things
- Coretime for parachains
- Parachain template guide (that does not include any coretime ref in the name)
-> I suggest to merge the first into the second @CrackTheCode016

Those pages in the coretime guides section have the `build` slug, and if they are planned to stay in the learn section, it would be more appropriate to change it to `learn`.