### PR TITLE
Updated secondary slot algo doc

### DIFF
--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -83,10 +83,10 @@ build in some capacity until finalization kicks in and amputates a fork. See
 ### No Validators in Slot
 
 When no validators have rolled low enough in the randomness lottery to qualify for block production,
-a slot can remain seemingly blockless. Polkadot runs a [secondary validator selection algorithm](https://spec.polkadot.network/sect-block-production#defn-babe-secondary-slots) in the 
+a slot can remain seemingly blockless. Polkadot protocol runs a [secondary validator selection algorithm](https://spec.polkadot.network/sect-block-production#defn-babe-secondary-slots) in the 
 background. The validators selected through this predictable algorithm always produce 
 blocks. These _secondary_ blocks are ignored if the same slot
-also produces a primary block from a [VRF-selected](./learn-cryptography.md#randomness) validator.
+has a primary block produced from a [VRF-selected](./learn-cryptography.md#randomness) validator.
 Thus, a slot can have either a _primary_ or a _secondary_ block, and no slots are ever skipped.
 
 For more details on BABE, please see the

--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -83,9 +83,9 @@ build in some capacity until finalization kicks in and amputates a fork. See
 ### No Validators in Slot
 
 When no validators have rolled low enough in the randomness lottery to qualify for block production,
-a slot can remain seemingly blockless. We avoid this by running a secondary, round-robin style
-validator selection algorithm in the background. The validators selected to produce blocks through
-this algorithm always produce blocks. Still, these _secondary_ blocks are ignored if the same slot
+a slot can remain seemingly blockless. We run a secondary validator selection algorithm in the 
+background to prevent this. The validators selected through this predictable algorithm always produce 
+blocks. Still, these _secondary_ blocks are ignored if the same slot
 also produces a primary block from a [VRF-selected](./learn-cryptography.md#randomness) validator.
 Thus, a slot can have either a _primary_ or a _secondary_ block, and no slots are ever skipped.
 

--- a/docs/learn/learn-consensus.md
+++ b/docs/learn/learn-consensus.md
@@ -83,9 +83,9 @@ build in some capacity until finalization kicks in and amputates a fork. See
 ### No Validators in Slot
 
 When no validators have rolled low enough in the randomness lottery to qualify for block production,
-a slot can remain seemingly blockless. We run a secondary validator selection algorithm in the 
-background to prevent this. The validators selected through this predictable algorithm always produce 
-blocks. Still, these _secondary_ blocks are ignored if the same slot
+a slot can remain seemingly blockless. Polkadot runs a [secondary validator selection algorithm](https://spec.polkadot.network/sect-block-production#defn-babe-secondary-slots) in the 
+background. The validators selected through this predictable algorithm always produce 
+blocks. These _secondary_ blocks are ignored if the same slot
 also produces a primary block from a [VRF-selected](./learn-cryptography.md#randomness) validator.
 Thus, a slot can have either a _primary_ or a _secondary_ block, and no slots are ever skipped.
 


### PR DESCRIPTION
ref: https://substrate.stackexchange.com/questions/11943/why-was-babe-secondary-slot-assignment-not-implemented-in-a-round-robin-style/