### PR TITLE
Update Rococo related docs following shutdown

### DIFF
--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -133,6 +133,10 @@ Polkadot's native token DOT.
 | Dot (PAS)       | 10             | 10<sup>10</sup> Planck | 1.0000000000 PAS  |
 | Million (MPAS)  | 16             | 10<sup>16</sup> Planck | 1,000,000.00 PAS  |
 
+Users can also obtain PAS by posting
+`!drip <PASEO_ADDRESS>` in the Matrix chatroom
+[#paseo_faucet:matrix.org](https://matrix.to/#/#paseo_faucet:matrix.org).
+
 ### Getting Tokens on the Westend Testnet
 
 Polkadot's testnet is called [Westend](../maintain/maintain-networks.md#westend-test-network).
@@ -163,16 +167,6 @@ On the Westend network, you can also earn WNDs as rewards by
 | MicroWND (uWND) | 6              | 10<sup>6</sup> Planck  | 0.000001000000 WND |
 | MilliWND (mWND) | 9              | 10<sup>9</sup> Planck  | 0.001000000000 WND |
 | WND             | 12             | 10<sup>12</sup> Planck | 1.000000000000 WND |
-
-### Getting Tokens on the Rococo Testnet
-
-Rococo is a parachain testnet. ROC tokens are given directly to teams working on parachains or
-exploring the [cross consensus](learn-xcm.md) message-passing aspects of this testnet. Besides the
-[official faucet](https://faucet.polkadot.io/rococo), users can obtain ROC by posting
-`!drip <ROCOCO_ADDRESS>` in the Matrix chatroom
-[#rococo-faucet:matrix.org](https://matrix.to/#/#rococo-faucet:matrix.org) or through the web-based
-[Rococo faucet](https://faucet.polkadot.io/rococo). Learn more about Rococo on its
-[dedicated wiki section](../build/build-parachains.md##testing-a-parachains:-rococo-testnet).
 
 ### Faucets support
 

--- a/docs/maintain/maintain-networks.md
+++ b/docs/maintain/maintain-networks.md
@@ -86,25 +86,15 @@ to Westend Asset Hub.
 
 ### Rococo Test Network
 
-[Rococo](https://substrate.io/developers/rococo-network/) is a test network built for parachains.
-The native token of this network (ROC) holds no economic value.
+Rococo used to be a Polkadot test network for parachains. The network was shut down following its replacement by Paseo.
 
-Run the Polkadot binary and specify `rococo` as the chain:
+### Paseo Test Network
+[Paseo](https://github.com/paseo-network/) is a test network built for parachains.
+The native token of this network (PAS) holds no economic value.
 
-```bash
-polkadot --chain=rococo
-```
+#### Paseo Faucet
 
-and you will connect and start syncing to Rococo.
-
-Check that your node is connected by viewing it on
-[Rococo Telemetry](https://telemetry.polkadot.io/#list/0x6408de7737c59c238890533af25896a2c20608d8b380bb01029acb392781063e)
-(you can set a custom node name by specifying `--name "my-custom-node-name"`).
-
-#### Rococo Faucet
-
-Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-rococo-testnet) to get
-ROCs tokens.
+Follow the instruction [here](../learn/learn-DOT.md#getting-tokens-on-the-paseo-testnet) to get PAS tokens.
 
 ### Wococo Test Network (inactive)
 


### PR DESCRIPTION
Rococo is scheduled to be shut down in 1 week from now (October 14th 2024), see https://forum.polkadot.network/t/rococo-to-be-deprecated-in-october/8702/4

This PR should be merged on this date.