### PR TITLE
Fix broken script name to start a new node

### DIFF
--- a/docs/maintain/maintain-sync.md
+++ b/docs/maintain/maintain-sync.md
@@ -171,7 +171,7 @@ value: 'linux-package'} ]}>
   ```bash
   git clone https://github.com/paritytech/polkadot-sdk polkadot-sdk
   cd polkadot-sdk
-  ./scripts/init.sh
+  ./scripts/getting-started.sh
   cargo build --release
   ```
 - Start your node:


### PR DESCRIPTION
`init.sh` does no longer exist: the new script to start a node is called `getting-started.sh`.