### PR TITLE
fix: update links to FAQ on how-to-validate-polkadot & how-to-validate-kusama pages

### DIFF
--- a/docs/maintain/kusama/maintain-guides-how-to-validate-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-how-to-validate-kusama.md
@@ -49,7 +49,7 @@ Controller accounts are deprecated. For more information, see
 :::
 
 You can have a rough estimate on that by using the methods listed
-[here](../../general/faq.md/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
+[here](../../general/faq/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
 To be elected into the set, you need a minimum stake behind your validator. This stake can come from
 yourself or from [nominators](../../learn/learn-nominator.md). This means that as a minimum, you
 will need enough KSM to set up Stash and staking proxy [accounts](../../learn/learn-cryptography.md)

--- a/docs/maintain/kusama/maintain-guides-how-to-validate-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-how-to-validate-kusama.md
@@ -49,7 +49,7 @@ Controller accounts are deprecated. For more information, see
 :::
 
 You can have a rough estimate on that by using the methods listed
-[here](../../general/faq/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
+[here](../../general/faq.md#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
 To be elected into the set, you need a minimum stake behind your validator. This stake can come from
 yourself or from [nominators](../../learn/learn-nominator.md). This means that as a minimum, you
 will need enough KSM to set up Stash and staking proxy [accounts](../../learn/learn-cryptography.md)

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -47,7 +47,7 @@ experience.
 ### How many DOT do I need to become an active Validator?
 
 You can have a rough estimate on that by using the methods listed
-[here](../general/faq/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
+[here](../general/faq.md#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
 To be elected into the set, you need a minimum stake behind your validator. This stake can come from
 yourself or from [nominators](../learn/learn-nominator.md). This means that as a minimum, you will
 need enough DOT to set up stash (and optionally a staking

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -47,7 +47,7 @@ experience.
 ### How many DOT do I need to become an active Validator?
 
 You can have a rough estimate on that by using the methods listed
-[here](../general/faq.md/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
+[here](../general/faq/#what-is-the-minimum-stake-necessary-to-be-elected-as-an-active-validator).
 To be elected into the set, you need a minimum stake behind your validator. This stake can come from
 yourself or from [nominators](../learn/learn-nominator.md). This means that as a minimum, you will
 need enough DOT to set up stash (and optionally a staking


### PR DESCRIPTION
Dear All,

upon going through the wiki, I found out the links to be failing:
![Screenshot 2024-12-17 at 01 33 25](https://github.com/user-attachments/assets/3d98c2ae-48bd-42d1-bb72-b1ac07a65ce6)
and it seems to be a minor issue with the unnecessary '.md' addition. Without it, the links should be working in both cases—when used from GitHub and on the production/live server.