### PR TITLE
Update mkdocs.yml - Disable Social Cards

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,9 +40,6 @@ theme:
 plugins:
   - search
   - open-in-new-tab
-  - social:
-      cards_layout_options:
-        logo: assets/wiki-logo.svg
   - macros:
       module_name: macros/rpc
 


### PR DESCRIPTION
The social cards customizability is minimal for the free tier. A subscription is required to have access to full features. Temporarily disabling it till a decision is reached within the team.