### PR TITLE
Remove inactive wallets

### DIFF
--- a/docs/general/wallets-and-extensions.md
+++ b/docs/general/wallets-and-extensions.md
@@ -39,11 +39,8 @@ them also allow interaction with air-gapped wallets and hardware devices.
 
 | Wallet                                                                                     | Browsers                                                                                                                                                                                                                                                                                                                                                                                                          | Staking and Nomination Pools | NFTs    | Crowdloans | Ledger support | Governance | Other features                               |
 | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------- | ---------- | -------------- | ---------- | -------------------------------------------- |
-| [Enkrypt](https://www.enkrypt.com/?mtm_campaign=Polkadot%20Wiki%20-%20Supported%20Wallets) | Brave, Chrome, Edge, Firefox, Opera, Safari                                                                                                                                                                                                                                                                                                                                                                       | No, No                       | **Yes** | No         | **Yes**        | No         | [Enkrypt Features](#enkrypt)                 |
-| [PolkaGate](https://polkagate.xyz/)                                                        | [Brave](https://chrome.google.com/webstore/detail/polkagate-the-gateway-to/ginchbkmljhldofnbjabmeophlhdldgp), [Chrome](https://chrome.google.com/webstore/detail/polkagate-the-gateway-to/ginchbkmljhldofnbjabmeophlhdldgp), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/polkagate), [Edge](https://chrome.google.com/webstore/detail/polkagate-the-gateway-to/ginchbkmljhldofnbjabmeophlhdldgp)     | **Yes**, **Yes**             | **Yes** | **Yes**    | **Yes**        | **Yes**    | [PolkaGate features](#polkagate)             |
 | [SubWallet](https://subwallet.app/)                                                        | [Brave](https://chrome.google.com/webstore/detail/subwallet-polkadot-extens/onhogfjeacnfoofkfgppdlbmlmnplgbn), [Chrome](https://chrome.google.com/webstore/detail/subwallet-polkadot-extens/onhogfjeacnfoofkfgppdlbmlmnplgbn), [Edge](https://chrome.google.com/webstore/detail/subwallet-polkadot-extens/onhogfjeacnfoofkfgppdlbmlmnplgbn), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/subwallet/) | **Yes**, **Yes**             | **Yes** | **Yes**    | **Yes**        | No         | [SubWallet features](#subwallet)             |
 | [Talisman](https://www.talisman.xyz/)                                                      | Brave, Chrome, Edge, Firefox                                                                                                                                                                                                                                                                                                                                                                                      | **Yes**, **Yes**             | **Yes** | **Yes**    | **Yes**        | No         | [Talisman features](#talisman)               |
-| [Fearless Wallet](https://fearlesswallet.io/)                                              | [Brave](https://chrome.google.com/webstore/detail/fearless-wallet/nhlnehondigmgckngjomcpcefcdplmgc), [Chrome](https://chrome.google.com/webstore/detail/fearless-wallet/nhlnehondigmgckngjomcpcefcdplmgc)                                                                                                                                                                                                         | No, No                       | **Yes** | No         | No             | No         | [Fearless Wallet Features](#fearless-wallet) |
 
 !!! info "Ledger support only for chromium-based browsers"
     Currently, all browser extensions support Ledger devices only on chromium-based browsers (i.e.
@@ -60,9 +57,7 @@ wallets through Bluetooth connectivity.
 
 | Wallet                                        | Platforms                                                                                              | Staking and Nomination Pools | NFTs    | Crowdloans | Ledger support | Governance | Proxy Accounts | Other features                               |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- | ------- | ---------- | -------------- | ---------- | -------------- | -------------------------------------------- |
-| [Fearless Wallet](https://fearlesswallet.io/) | iOS, Android                                                                                           | **Yes**, **Yes**             | No      | **Yes**    | No             | No         | No             | [Fearless Wallet Features](#fearless-wallet) |
 | [Nova Wallet](https://novawallet.io/)\*       | iOS, Android                                                                                           | **Yes**, **Yes**             | **Yes** | **Yes**    | **Yes**        | **Yes**    | **Yes**        | [Nova Wallet features](#nova-wallet)         |
-| [Polkawallet](https://polkawallet.io/)        | iOS, Android                                                                                           | **Yes**, **Yes**             | No      | **Yes**    | No             | **Yes**    | No             | [Polkawallet features](#polkawallet)         |
 | [SubWallet](https://subwallet.app/)           | [iOS](https://apps.apple.com/us/app/subwallet-polkadot-wallet/id1633050285), [Android](https://bit.ly/3DE2Dlg) | **Yes**, **Yes**             | **Yes** | **Yes**    | No             | No         | No             | [SubWallet features](#subwallet)             |
 
 !!! caution "Note about Nova wallet"
@@ -89,26 +84,9 @@ in the Polkadot ecosystem without having to download any new applications.
 | ----------------------------------------- | -------------------- | -------------- | -------------------------------- | -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Telenova](https://t.me/telenova_app_bot) | Mobile, Desktop, Web | **Yes**        | **Yes**                          | **Yes**                    | **Yes**       | [Telenova Features](https://medium.com/novasama-technologies/meet-telenova-your-newbie-friendly-polkadot-wallet-built-into-telegram-5d9e9570d334) |
 
-## Enkrypt
 
-A multichain crypto wallet - Bitcoin, Ethereum, Polkadot, Kusama and a few parachains.
-Non-custodial, private, hardware wallet support (Ledger and Trezor). Private and open source. Hold,
-send, and receive tokens and NFTs. Swap tokens and bridge assets between chains. Manage multiple
-accounts on multiple networks. Connect to web3 apps. Recipient of a development grant from Web3
-Foundation.
 
-## Fearless Wallet
 
-The Fearless DeFi Wallet for the Future. Simply, intuitively, and fearlessly interact with
-[Web3](web3-and-polkadot.md). Currently supports Staking, Crowdloans, Parachain Accounts,
-Nomination Pools Native Staking, dApp Signer on desktop through your mobile phone (experimental),
-Chromium-based browser extension. Safety features such as Scam Address Warning and Network Failure
-Warnings help fearlessly navigate [web3](web3-and-polkadot.md). Formerly funded and supported by
-Kusama Treasury [[1](https://kusama.polkassembly.io/treasury/23),
-[2](https://kusama.polkassembly.io/treasury/34), [3](https://kusama.polkassembly.io/treasury/74),
-[4](https://kusama.polkassembly.io/treasury/102), [5](https://kusama.polkassembly.io/treasury/178)],
-and the SORA community [[1](https://sora.subscan.io/referenda/193?tab=votes)], developed by
-SORAMITSU. Stay Fearless!
 
 ## Nova Wallet
 
@@ -120,26 +98,6 @@ Metamask/EVM Integration and crowdloans. Nova Wallet received funding from Kusam
 [[1](https://kusama.polkassembly.io/treasury/122),
 [2](https://kusama.polkassembly.io/treasury/158)], as well as funding from the Polkadot Treasury
 [[1](https://polkadot.polkassembly.io/motion/314)].
-
-## PolkaGate
-
-The PolkaGate extension, funded by the Kusama Treasury
-[[1](https://kusama.polkassembly.io/treasury/205),
-[2](https://kusama.polkassembly.io/referenda/124)] is a feature-rich wallet for the Polkadot and
-Kusama ecosystems. It simplifies account management with export, import, derivation tools, Ledger
-integration, and watch-only accounts. Key features include governance participation, vote
-delegation, identity management, proxy management, pool staking, solo staking, crowdloans, and
-parachain account handling. Additional tools include NFT support, phishing detection, spam address
-warnings, light clients, and optimized remote node selection. PolkaGate also tracks balances in
-multiple currencies, manages transaction histories, and generates QR codes for addresses—offering a
-seamless and secure blockchain experience.
-
-## Polkawallet
-
-Polkawallet provides cross-chain asset one-stop management, convenient staking, governance, and
-multiple DeFi services; the private key is self-owned. Polkawallet received funding from Kusama
-Treasury [[1](https://kusama.polkassembly.io/treasury/32),
-[2](https://kusama.polkassembly.io/treasury/41)].
 
 ## SubWallet
 


### PR DESCRIPTION
In my opinion, we should remove all the wallets that are no longer actively releasing new developments and align the wallet with ecosystem updates. Or at least we set them at lower positions. I know that it is ordered by alphabet, but from a user perspective, stuff listed at top positions means they are highlighted and recommended.