### PR TITLE
Add tooltips to Wiki

### DIFF
--- a/includes/definitions.md
+++ b/includes/definitions.md
@@ -1,0 +1,80 @@
+*[Active Nomination]: A validator selected by a nominator to validate and earn rewards.
+*[Alexander]: The fourth and now defunct PoC-4 testnet for Polkadot.
+*[Asset Hub]: A parachain for asset management.
+*[Attestation]: A validator's message on parachain block validity.
+*[Auction (Parachain)]: A method for parachains to access Polkadot by bidding for coretime.
+*[Aura]: A round-robin block authoring mechanism.
+*[Authority]: A role in blockchain consensus mechanisms.
+*[Availability Cores]: Slots assigned to process parachains.
+*[BABE]: Polkadot's block production mechanism.
+*[Bitfield Array]: Single-bit values indicating parachain candidate availability.
+*[Block]: A data structure representing a blockchain state transition.
+*[Blockspace]: The capacity of a blockchain to finalize operations.
+*[Block Explorer]: A tool for exploring blockchain blocks.
+*[Blocks Nominations]: A state where a validator stops accepting nominations.
+*[BLS]: A signature scheme enabling signature aggregation.
+*[Bonding]: Freezing tokens for staking rewards.
+*[Bounty]: Treasury funding managed by curators.
+*[Bridge]: A parachain enabling interaction with external blockchains.
+*[Byzantine Fault Tolerance]: A system's ability to handle ambiguous faults.
+*[Capacity]: The maximum nominators signaling intent to nominate a validator.
+*[Candidate]: A parachain block submitted for finalization.
+*[Collations]: Proposed parachain blocks with state transition proofs.
+*[Collator]: A node producing parachain state transition proofs.
+*[Collectives]: A parachain hosting on-chain collectives like the Fellowship.
+*[Commission]: A validator's rate deducted from rewards.
+*[Common Good (Parachain)]: See System Parachains.
+*[Community Queue]: A queue for individual proposals awaiting referenda.
+*[Consensus]: The process of agreeing on blockchain data values.
+*[Coretime]: Time allocated for using a core.
+*[Crowdloan]: A mechanism for sourcing tokens to bid for relay chain cores.
+*[Curator]: An entity verifying bounty completion.
+*[DOT]: Polkadot's native token for governance, staking, and bonding.
+*[Duty Roster]: Tasks assigned to validators, shuffled per parachain.
+*[Epoch]: A time duration in the BABE protocol.
+*[Era]: A period of sessions for recalculating validator sets and rewards.
+*[Equivocation]: Conflicting information provided by a validator.
+*[External Queue]: A queue for Council-originated proposals.
+*[Extrinsic]: External state changes invoked on the blockchain.
+*[Finality]: A block property ensuring it cannot be reverted.
+*[Finality Gadget]: A mechanism ensuring block finality.
+*[Frame]: Substrate-provided pallets for building runtimes.
+*[Genesis]: The origin block or initial state of a blockchain.
+*[Governance]: The process of stakeholder voting on network changes.
+*[GRANDPA Finality Gadget]: A mechanism for asynchronous and safe block finality.
+*[Hard Fork]: A permanent blockchain split due to consensus rule changes.
+*[Inactive Nomination]: A validator nominated but not validating this era.
+*[Injected Account]: An account accessed via Polkadot UI but managed externally.
+*[Interoperability]: The ability of systems to exchange information.
+*[KSM]: Kusama's native token.
+*[Kusama]: Polkadot's canary network for early releases.
+*[Lease Period]: The duration a parachain is connected to the relay chain.
+*[LIBP2P]: A library for encrypted peer-to-peer communications.
+*[Mainnet]: The primary blockchain network.
+*[Message]: Data sent between parachains in XCMP.
+*[Motion]: A decision or referendum considered by the Council.
+*[Nominated Proof of Stake (NPoS)]: A staking system where nominators back validators.
+*[On-chain Governance]: Governance controlled transparently on the blockchain.
+*[Parachain]: A blockchain running parallel to the relay chain.
+*[Parity Technologies]: The company behind Substrate, Kusama, and Polkadot.
+*[Polkadot]: A multi-chain network enabling cross-chain communication.
+*[Polkadot Alliance]: An on-chain collective promoting development standards.
+*[Preimage]: A hash-linked submission storing extrinsic or data details.
+*[Proof of Stake (PoS)]: A consensus system selecting participants based on staked tokens.
+*[Proof of Validity]: A proof verifying parachain state transitions.
+*[Proposal]: A potential network change to be voted on.
+*[Referendum]: A vote on whether to accept a proposal.
+*[Runtime]: The state transition function defining blockchain state changes.
+*[Session]: A period with a constant validator set.
+*[Shared Security]: A model securing all chains equally via the relay chain.
+*[Slashing]: Punishment for validator misbehavior by removing staked DOT.
+*[Staking]: Bonding tokens to secure the network and earn rewards.
+*[Substrate]: A framework for building blockchains, used by Polkadot.
+*[System Parachains]: Parachains forming part of Polkadot's core protocol.
+*[Teleport]: Sending assets between chains by burning and minting.
+*[Testnet]: An experimental network for testing before mainnet deployment.
+*[Validator]: A node securing the relay chain by staking and validating.
+*[Web3 Foundation]: A foundation supporting decentralized web technologies.
+*[WebAssembly]: A virtual machine instruction format for Polkadot runtimes.
+*[Westend]: A testnet for testing Polkadot's relay chain.
+

--- a/includes/definitions.md
+++ b/includes/definitions.md
@@ -2,12 +2,11 @@
 *[Alexander]: The fourth and now defunct PoC-4 testnet for Polkadot.
 *[Asset Hub]: A system chain for asset management and more.
 *[Attestation]: A validator's message on parachain block validity.
-*[Auction (Parachain)]: A method for parachains to access Polkadot by bidding for coretime.
+*[Auction (Parachain)]: An old method for parachains to access Polkadot by bidding for a parachain slot.
 *[Aura]: A round-robin block authoring mechanism.
 *[Authority]: A role in blockchain consensus mechanisms.
 *[Availability Cores]: Entry points to Polkadot's security and interoperability. Time on a core is guaranteed by purchasing coretime.
 *[BABE]: Polkadot's block production mechanism.
-*[Bitfield Array]: Single-bit values indicating parachain candidate availability.
 *[Block]: A data structure representing a blockchain state transition.
 *[Blockspace]: Umbrella term to define the resource created and often sold by a blockchain network.
 *[Block Explorer]: A tool for exploring blockchain data through visualization and summaries.
@@ -24,7 +23,6 @@
 *[Collectives]: A parachain hosting on-chain collectives like the Polkadot Technical Fellowship.
 *[Commission]: A validator's rate deducted from rewards to cover operational costs and other expenses.
 *[Common Good (Parachain)]: An old term used to define system chains like the Polkadot Asset Hub.
-*[Community Queue]: A queue for individual proposals awaiting referenda.
 *[Consensus]: The process of agreeing on blockchain data values.
 *[Coretime]: Time allocated for using a Polkadot's virtual core.
 *[Crowdloan]: A mechanism for sourcing tokens to bid for relay chain cores.
@@ -34,14 +32,13 @@
 *[Epoch]: A time duration in the BABE protocol.
 *[Era]: A period of sessions for recalculating validator sets and rewards.
 *[Equivocation]: Conflicting information provided by a validator.
-*[External Queue]: A queue for Council-originated proposals.
 *[Extrinsic]: External state changes invoked on the blockchain.
 *[Finality]: A block property ensuring it cannot be reverted.
 *[Finality Gadget]: A mechanism ensuring block finality.
-*[Frame]: Substrate-provided pallets for building runtimes.
+*[FRAME]: Polkadot SDK-provided pallets (modules) for building runtimes.
 *[Genesis]: The origin block or initial state of a blockchain.
 *[Governance]: The process of stakeholder voting on network changes and other organizational matters.
-*[GRANDPA Finality Gadget]: A mechanism for asynchronous and safe block finality.
+*[GRANDPA]: A mechanism for asynchronous and safe block finality. Verifies chains rather than individual blocks.
 *[Hard Fork]: A permanent blockchain split due to consensus rule changes.
 *[Inactive Nomination]: A validator that is nominated but not validating and producing blocks in the current era.
 *[Injected Account]: A specific term used to tag an account accessed via the Polkadot-JS UI but managed externally (for example, via a browser extension).
@@ -69,7 +66,8 @@
 *[Shared Security]: A model securing all chains equally via the relay chain.
 *[Slashing]: Punishment for validator misbehavior by removing staked DOT.
 *[Staking]: Bonding tokens to secure the network and earn rewards.
-*[Substrate]: A framework for building blockchains, used by Polkadot.
+*[Substrate]: A framework for building blockchains, used by Polkadot (mostly referred to as the Polkadot SDK).
+*[Polkadot SDK]: A framework for building blockchains, both rollups and solo chains, used by Polkadot.
 *[System Parachains]: Parachains forming part of Polkadot's core protocol.
 *[Teleport]: Sending assets between chains by burning and minting.
 *[Testnet]: An experimental network for testing before mainnet deployment.

--- a/includes/definitions.md
+++ b/includes/definitions.md
@@ -1,32 +1,32 @@
-*[Active Nomination]: A validator selected by a nominator to validate and earn rewards.
+*[Active Nomination]: A validator that produces blocks in the current era and earns staking rewards.
 *[Alexander]: The fourth and now defunct PoC-4 testnet for Polkadot.
-*[Asset Hub]: A parachain for asset management.
+*[Asset Hub]: A system chain for asset management and more.
 *[Attestation]: A validator's message on parachain block validity.
 *[Auction (Parachain)]: A method for parachains to access Polkadot by bidding for coretime.
 *[Aura]: A round-robin block authoring mechanism.
 *[Authority]: A role in blockchain consensus mechanisms.
-*[Availability Cores]: Slots assigned to process parachains.
+*[Availability Cores]: Entry points to Polkadot's security and interoperability. Time on a core is guaranteed by purchasing coretime.
 *[BABE]: Polkadot's block production mechanism.
 *[Bitfield Array]: Single-bit values indicating parachain candidate availability.
 *[Block]: A data structure representing a blockchain state transition.
-*[Blockspace]: The capacity of a blockchain to finalize operations.
-*[Block Explorer]: A tool for exploring blockchain blocks.
+*[Blockspace]: Umbrella term to define the resource created and often sold by a blockchain network.
+*[Block Explorer]: A tool for exploring blockchain data through visualization and summaries.
 *[Blocks Nominations]: A state where a validator stops accepting nominations.
 *[BLS]: A signature scheme enabling signature aggregation.
-*[Bonding]: Freezing tokens for staking rewards.
+*[Bonding]: Freezing tokens for staking and other on-chain activities.
 *[Bounty]: Treasury funding managed by curators.
 *[Bridge]: A parachain enabling interaction with external blockchains.
 *[Byzantine Fault Tolerance]: A system's ability to handle ambiguous faults.
 *[Capacity]: The maximum nominators signaling intent to nominate a validator.
 *[Candidate]: A parachain block submitted for finalization.
 *[Collations]: Proposed parachain blocks with state transition proofs.
-*[Collator]: A node producing parachain state transition proofs.
-*[Collectives]: A parachain hosting on-chain collectives like the Fellowship.
-*[Commission]: A validator's rate deducted from rewards.
-*[Common Good (Parachain)]: See System Parachains.
+*[Collator]: A node producing parachain blocks.
+*[Collectives]: A parachain hosting on-chain collectives like the Polkadot Technical Fellowship.
+*[Commission]: A validator's rate deducted from rewards to cover operational costs and other expenses.
+*[Common Good (Parachain)]: An old term used to define system chains like the Polkadot Asset Hub.
 *[Community Queue]: A queue for individual proposals awaiting referenda.
 *[Consensus]: The process of agreeing on blockchain data values.
-*[Coretime]: Time allocated for using a core.
+*[Coretime]: Time allocated for using a Polkadot's virtual core.
 *[Crowdloan]: A mechanism for sourcing tokens to bid for relay chain cores.
 *[Curator]: An entity verifying bounty completion.
 *[DOT]: Polkadot's native token for governance, staking, and bonding.
@@ -40,24 +40,24 @@
 *[Finality Gadget]: A mechanism ensuring block finality.
 *[Frame]: Substrate-provided pallets for building runtimes.
 *[Genesis]: The origin block or initial state of a blockchain.
-*[Governance]: The process of stakeholder voting on network changes.
+*[Governance]: The process of stakeholder voting on network changes and other organizational matters.
 *[GRANDPA Finality Gadget]: A mechanism for asynchronous and safe block finality.
 *[Hard Fork]: A permanent blockchain split due to consensus rule changes.
-*[Inactive Nomination]: A validator nominated but not validating this era.
-*[Injected Account]: An account accessed via Polkadot UI but managed externally.
-*[Interoperability]: The ability of systems to exchange information.
+*[Inactive Nomination]: A validator that is nominated but not validating and producing blocks in the current era.
+*[Injected Account]: A specific term used to tag an account accessed via the Polkadot-JS UI but managed externally (for example, via a browser extension).
+*[Interoperability]: The ability of systems to exchange information. In the blockchain context, interoperability enables systems with different consensus to communicate safely.
 *[KSM]: Kusama's native token.
-*[Kusama]: Polkadot's canary network for early releases.
+*[Kusama]: Polkadot's canary network for early releases and experimentation in general.
 *[Lease Period]: The duration a parachain is connected to the relay chain.
 *[LIBP2P]: A library for encrypted peer-to-peer communications.
 *[Mainnet]: The primary blockchain network.
-*[Message]: Data sent between parachains in XCMP.
+*[Message]: Data sent between parachains using the XCM format.
 *[Motion]: A decision or referendum considered by the Council.
 *[Nominated Proof of Stake (NPoS)]: A staking system where nominators back validators.
 *[On-chain Governance]: Governance controlled transparently on the blockchain.
-*[Parachain]: A blockchain running parallel to the relay chain.
-*[Parity Technologies]: The company behind Substrate, Kusama, and Polkadot.
-*[Polkadot]: A multi-chain network enabling cross-chain communication.
+*[Parachain]: A layer-one blockchain running on a Polkadot virtual core (in parallel to the relay chain).
+*[Parity Technologies]: The company that was commissioned to launch Polkadot, and that is currently behind the Polkadot SDK.
+*[Polkadot]: A service provider for secure and resilient computation and blockchain interoperability.
 *[Polkadot Alliance]: An on-chain collective promoting development standards.
 *[Preimage]: A hash-linked submission storing extrinsic or data details.
 *[Proof of Stake (PoS)]: A consensus system selecting participants based on staked tokens.
@@ -74,7 +74,7 @@
 *[Teleport]: Sending assets between chains by burning and minting.
 *[Testnet]: An experimental network for testing before mainnet deployment.
 *[Validator]: A node securing the relay chain by staking and validating.
-*[Web3 Foundation]: A foundation supporting decentralized web technologies.
-*[WebAssembly]: A virtual machine instruction format for Polkadot runtimes.
+*[Web3 Foundation]: A foundation fostering and supporting web3 technologies.
+*[WebAssembly]: A virtual machine instruction format that is used for Polkadot runtimes.
 *[Westend]: A testnet for testing Polkadot's relay chain.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,9 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.snippets
+  - pymdownx.snippets:
+        auto_append:
+            - includes/definitions.md
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
This PR adds hoverable tooltips for certain definitions/keywords in the Wiki. We need to define which terms to add/remove, but this list is a starting point.

Closes issue #5225 