### PR TITLE
Removal of common tooltip terms

### DIFF
--- a/includes/definitions.md
+++ b/includes/definitions.md
@@ -1,32 +1,25 @@
 *[active issuance]: The total issuance - inactive issuance. Active tokens can participate in governance.
 *[Active Nomination]: A validator that produces blocks in the current era and earns staking rewards.
 *[Adaptive Quorum Biasing]: A system used in Governance V1 to alter the effective supermajority required to make it easier or more difficult for a proposal to pass, depending on turnout and origin (Council or public); that has been replaced with the approval and support system in OpenGov.
-*[Alexander]: The fourth and now defunct PoC-4 testnet for Polkadot.
 *[Alternating Voting Timetable]: A system to vote on Council and public referenda in Governance V1.
 *[Asset Hub]: A system chain for asset management and more.
 *[Attestation]: A validator's message on parachain block validity.
 *[Auction (Parachain)]: An old method for parachains to access Polkadot by bidding for a parachain slot.
 *[Aura]: A round-robin block authoring mechanism.
-*[Authority]: A role in blockchain consensus mechanisms.
 *[Availability Cores]: Entry points to Polkadot's security and interoperability. Time on a core is guaranteed by purchasing coretime.
 *[BABE]: Polkadot's block production mechanism.
-*[Block]: A data structure representing a blockchain state transition.
 *[Blockspace]: Umbrella term to define the resource created and often sold by a blockchain network.
-*[Block Explorer]: A tool for exploring blockchain data through visualization and summaries.
 *[Blocks Nominations]: A state where a validator stops accepting nominations.
 *[BLS]: A signature scheme enabling signature aggregation.
 *[Bonding]: Freezing tokens for staking and other on-chain activities.
 *[Bounty]: Treasury funding managed by curators.
 *[Bridge]: A parachain enabling interaction with external blockchains.
-*[Byzantine Fault Tolerance]: A system's ability to handle ambiguous faults.
-*[Capacity]: The maximum nominators signaling intent to nominate a validator.
 *[Candidate]: A parachain block submitted for finalization.
 *[Collations]: Proposed parachain blocks with state transition proofs.
 *[Collator]: A node producing parachain blocks.
 *[Collectives]: A parachain hosting on-chain collectives like the Polkadot Technical Fellowship.
 *[Commission]: A validator's rate deducted from rewards to cover operational costs and other expenses.
 *[Common Good (Parachain)]: An old term used to define system chains like the Polkadot Asset Hub.
-*[Consensus]: The process of agreeing on blockchain data values.
 *[Coretime]: Time allocated for using a Polkadot's virtual core.
 *[Council]: Together with the Technical Committee, it was one of the two chambers in the Polkadot Governance V1 model. It was an approval-voted, elected executive "government" to manage parameters, admin, and spending proposals.
 *[Council Referendum]: A referendum initiated by the Council in Governance V1.
@@ -39,7 +32,6 @@
 *[Era]: A period of sessions for recalculating validator sets and rewards.
 *[Equivocation]: Conflicting information provided by a validator.
 *[Extrinsic]: External state changes invoked on the blockchain.
-*[Finality]: A block property ensuring it cannot be reverted.
 *[Finality Gadget]: A mechanism ensuring block finality.
 *[FRAME]: Polkadot SDK-provided pallets (modules) for building runtimes.
 *[Genesis]: The origin block or initial state of a blockchain.
@@ -50,21 +42,13 @@
 *[inactive issuance]: Includes tokens locked in deposits, which cannot participate in governance.
 *[Inactive Nomination]: A validator that is nominated but not validating and producing blocks in the current era.
 *[Injected Account]: A specific term used to tag an account accessed via the Polkadot-JS UI but managed externally (for example, via a browser extension).
-*[Interoperability]: The ability of systems to exchange information. In the blockchain context, interoperability enables systems with different consensus to communicate safely.
-*[KSM]: Kusama's native token.
-*[Kusama]: Polkadot's canary network for early releases and experimentation in general.
 *[Lease Period]: The duration a parachain is connected to the relay chain.
-*[LIBP2P]: A library for encrypted peer-to-peer communications.
 *[Mainnet]: The primary blockchain network.
-*[Message]: Data sent between parachains using the XCM format.
 *[Motion]: A decision or referendum considered by the Council.
 *[Nominated Proof of Stake (NPoS)]: A staking system where nominators back validators.
 *[On-chain Governance]: Governance controlled transparently on the blockchain.
 *[Parachain]: A layer-one blockchain running on a Polkadot virtual core (in parallel to the relay chain).
 *[Parity Technologies]: The company that was commissioned to launch Polkadot, and that is currently behind the Polkadot SDK.
-*[Paseo]: A testnet that mirrors Polkadot's runtime.
-*[Polkadot]: A service provider for secure and resilient computation and blockchain interoperability.
-*[Polkadot Alliance]: An on-chain collective promoting development standards.
 *[Preimage]: A hash-linked submission storing extrinsic or data details.
 *[Proof of Stake (PoS)]: A consensus system selecting participants based on staked tokens.
 *[Proof of Validity]: A proof verifying parachain state transitions.
@@ -82,11 +66,5 @@
 *[System Parachains]: Parachains forming part of Polkadot's core protocol.
 *[Technical Committee]: Together with the Council, it was one of the two chambers in the Polkadot Governance V1 model. It was a technocratic committee to manage upgrade timelines.
 *[Teleport]: Sending assets between chains by burning and minting.
-*[Testnet]: An experimental network for testing before mainnet deployment.
 *[Thousand Validators Program]: Previous iteration of the currently run Decentralized Nodes Program.
 *[total issuance]: The total number of tokens in existence.
-*[Validator]: A node securing the relay chain by staking and validating.
-*[Web3 Foundation]: A foundation fostering and supporting web3 technologies.
-*[WebAssembly]: A virtual machine instruction format that is used for Polkadot runtimes.
-*[Westend]: A testnet for testing Polkadot's relay chain.
-


### PR DESCRIPTION
Removing repetitive terms and sticking to nuanced ones to clean up pages.