### PR TITLE
Fix dark mode white flash and theme switching issues

### DIFF
--- a/material-overrides/js/dynamic-logo.js
+++ b/material-overrides/js/dynamic-logo.js
@@ -42,55 +42,20 @@
                window.location.pathname.endsWith('/') && window.location.pathname.split('/').length <= 2;
     }
 
-    // Get the current theme
+    // Get the current theme - CSS-first approach
     function getCurrentTheme() {
-        const htmlElement = document.documentElement;
-        const bodyElement = document.body;
-        
-        // Check multiple possible locations for theme information
-        const htmlScheme = htmlElement.getAttribute('data-md-color-scheme');
-        const bodyScheme = bodyElement.getAttribute('data-md-color-scheme');
-        const htmlClasses = htmlElement.className;
-        const bodyClasses = bodyElement.className;
-        
-        // Check for checked palette input
-        const checkedInput = document.querySelector('input[name="__palette"]:checked');
-        const checkedScheme = checkedInput ? checkedInput.getAttribute('data-md-color-scheme') : null;
-        
-        
-        // Determine theme from multiple sources
-        let scheme = htmlScheme || bodyScheme || checkedScheme || 'default';
-        
-        // Fallback: check CSS custom properties
-        if (scheme === 'default' || !scheme) {
-            const computedStyle = getComputedStyle(htmlElement);
-            const bgColor = computedStyle.getPropertyValue('--md-default-bg-color').trim();
-            
-            // If background is dark, we're probably in dark mode
-            if (bgColor && (bgColor === '#1a1a1a' || bgColor.includes('1a1a1a'))) {
-                scheme = 'slate';
-            }
+        // Priority 1: Use CSS Theme system if available
+        if (window.CSSTheme && window.CSSTheme.getCurrentTheme) {
+            return window.CSSTheme.getCurrentTheme();
         }
         
-        // Additional fallback: check body background color
-        if (scheme === 'default' || !scheme) {
-            const bodyStyle = getComputedStyle(bodyElement);
-            const bodyBg = bodyStyle.backgroundColor;
-            
-            // Parse RGB values to detect dark backgrounds
-            if (bodyBg.includes('rgb')) {
-                const rgbMatch = bodyBg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
-                if (rgbMatch) {
-                    const [, r, g, b] = rgbMatch.map(Number);
-                    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-                    
-                    if (brightness < 128) {
-                        scheme = 'slate';
-                    }
-                }
-            }
-        }
-        return scheme === 'slate' ? 'dark' : 'light';
+        // Priority 2: Check DOM for Material's data attribute
+        const htmlScheme = document.documentElement.getAttribute('data-md-color-scheme');
+        if (htmlScheme === 'slate') return 'dark';
+        if (htmlScheme === 'default') return 'light';
+        
+        // Priority 3: Fallback to light theme
+        return 'light';
     }
 
     // Update the logo based on current theme
@@ -179,12 +144,17 @@
         });
     }
 
-    // Initialize logo switcher
+    // Initialize logo switcher - CSS-first approach
     function init() {
-        // Set initial logo quickly
-        setTimeout(updateLogo, 50);
+        // Update logo immediately
+        updateLogo();
         
-        // Watch for theme changes
+        // Listen for CSS theme changes
+        document.addEventListener('cssthemechange', function(event) {
+            setTimeout(updateLogo, 10);
+        });
+        
+        // Also watch for direct DOM changes (backup)
         watchThemeChanges();
         
         // Watch for new logo elements being added to DOM

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -17,6 +17,90 @@
 {% block styles %}
 	{{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/polkadot.css' | url }}">
+  
+  <style id="css-first-flash-prevention">
+    /* CSS-FIRST FLASH PREVENTION - Temporary styles */
+    /* These styles prevent white flash but will be removed to allow Material theme switching */
+    
+    /* Apply dark theme by default for non-homepage pages ONLY if not force-light */
+    html:not(.homepage):not(.force-light):not(.css-ready) {
+      background: #1a1a1a !important;
+    }
+    
+    html:not(.homepage):not(.force-light):not(.css-ready) body {
+      background: #1a1a1a !important;
+      color: #c6cfdb !important;
+    }
+    
+    /* Fix specific navigation elements that flash white - ONLY for dark mode */
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-nav__title,
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-nav__item,
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-nav__link,
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-header,
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-sidebar,
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-content,
+    html:not(.homepage):not(.force-light):not(.css-ready) .md-footer {
+      background: #1a1a1a !important;
+      color: #c6cfdb !important;
+    }
+    
+    /* Homepage should always be light */
+    html.homepage {
+      background: white !important;
+    }
+    
+    html.homepage body {
+      background: white !important;
+      color: rgba(0,0,0,0.87) !important;
+    }
+    
+    /* Override for light mode users - also temporary */
+    html.force-light:not(.css-ready) {
+      background: white !important;
+    }
+    
+    html.force-light:not(.css-ready) body {
+      background: white !important;
+      color: rgba(0,0,0,0.87) !important;
+    }
+  </style>
+  
+  <script>
+    /* CSS-FIRST: Immediate theme detection in <head> */
+    (function() {
+      // Mark homepage immediately
+      if (window.location.pathname === '/' || window.location.pathname === '/index.html') {
+        document.documentElement.classList.add('homepage');
+        return;
+      }
+      
+      // For non-homepage, check if we should use light mode instead
+      var shouldUseLightMode = false;
+      
+      try {
+        // Quick localStorage check for light mode preference
+        var keys = ["/.__palette", window.location.pathname + ".__palette"];
+        for (var i = 0; i < keys.length; i++) {
+          var stored = localStorage.getItem(keys[i]);
+          if (stored) {
+            var data = JSON.parse(stored);
+            if (data && data.index === 0) {
+              shouldUseLightMode = true;
+              break;
+            }
+          }
+        }
+      } catch (e) {}
+      
+      // Apply the appropriate class and scheme
+      if (shouldUseLightMode) {
+        document.documentElement.classList.add('force-light');
+        document.documentElement.setAttribute('data-md-color-scheme', 'default');
+      } else {
+        document.documentElement.setAttribute('data-md-color-scheme', 'slate');
+      }
+    })();
+  </script>
 {% endblock %}
 
 {% block fonts %}
@@ -87,4 +171,67 @@
       {% endblock %}
     </article>
   </div>
-{%- endblock -%} 
+{%- endblock -%}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    // CSS-FIRST THEME COORDINATION
+    // CSS handles flash prevention, JS handles theme switching
+    
+    (function() {
+      'use strict';
+      
+      // Skip homepage - it has its own theme logic
+      var isHomepage = window.location.pathname === '/' || window.location.pathname === '/index.html';
+      if (isHomepage) return;
+      
+      // Get current theme from DOM
+      function getCurrentTheme() {
+        var scheme = document.documentElement.getAttribute('data-md-color-scheme');
+        return scheme === 'slate' ? 'dark' : 'light';
+      }
+      
+      var currentTheme = getCurrentTheme();
+      
+      // Remove temporary flash prevention CSS after Material loads
+      setTimeout(function() {
+        document.documentElement.classList.add('css-ready');
+        var flashPreventionCSS = document.getElementById('css-first-flash-prevention');
+        if (flashPreventionCSS) {
+          flashPreventionCSS.remove();
+        }
+      }, 300);
+      
+      // Check if we just reloaded from a theme switch
+      var justReloaded = sessionStorage.getItem('theme-switch-reload');
+      if (justReloaded) {
+        sessionStorage.removeItem('theme-switch-reload');
+      }
+      
+      // Listen for palette form changes and reload page for clean theme state
+      document.addEventListener('change', function(e) {
+        if (e.target && e.target.name === '__palette') {
+          sessionStorage.setItem('theme-switch-reload', 'true');
+          window.location.reload();
+        }
+      });
+      
+      // Listen for clicks on palette labels  
+      document.addEventListener('click', function(e) {
+        if (e.target && e.target.getAttribute('for') && e.target.getAttribute('for').includes('__palette')) {
+          sessionStorage.setItem('theme-switch-reload', 'true');
+          window.location.reload();
+        }
+      });
+      
+      // Make available globally
+      window.CSSTheme = {
+        currentTheme: currentTheme,
+        getCurrentTheme: getCurrentTheme
+      };
+      
+      
+    })();
+  </script>
+{% endblock %} 

--- a/material-overrides/partials/logo.html
+++ b/material-overrides/partials/logo.html
@@ -1,8 +1,40 @@
 {#-
-  Custom logo partial with dynamic theme support
+  Custom logo partial with CSS-first theme support
 -#}
 {% if config.theme.logo %}
-  <img src="{{ config.theme.logo | url }}" alt="logo" class="theme-logo">
+  <script>
+    (function() {
+      // CSS-first logo detection - works with initial CSS theme
+      function getInitialLogo() {
+        // Homepage always uses light logo
+        if (window.location.pathname === '/' || window.location.pathname === '/index.html') {
+          return '{{ config.theme.logo | url }}';
+        }
+        
+        // Check for force-light class (light mode override)
+        if (document.documentElement.classList.contains('force-light')) {
+          return '{{ config.theme.logo | url }}';
+        }
+        
+        // Check for homepage class
+        if (document.documentElement.classList.contains('homepage')) {
+          return '{{ config.theme.logo | url }}';
+        }
+        
+        // Default to dark logo for non-homepage (CSS-first sets dark by default)
+        var segments = window.location.pathname.split('/').filter(s => s.length > 0);
+        var depth = segments.length > 0 ? segments.length : 0;
+        var prefix = depth > 0 ? '../'.repeat(depth) : '';
+        return prefix + 'assets/images/logo-white.png';
+      }
+      
+      var logoSrc = getInitialLogo();
+      document.write('<img src="' + logoSrc + '" alt="logo" class="theme-logo">');
+    })();
+  </script>
+  <noscript>
+    <img src="{{ config.theme.logo | url }}" alt="logo" class="theme-logo">
+  </noscript>
 {% else %}
   {% set icon = config.theme.icon.logo or "material/library" %}
   {% include ".icons/" ~ icon ~ ".svg" %}


### PR DESCRIPTION
Issue #6811 
- Implemented CSS first approach (Previously, the site would load in light mode by default, then JS would override to dark mode)
- Removed overriding and instead added separate CSS injections (Theme switch function now reloads page to start with a clean state to avoid interference. )
- New Pages opened in respective themes have smoother transition (Without flashes)