### PR TITLE
docs: remove duplicate info section from learn accounts page

### DIFF
--- a/docs/learn/learn-accounts.md
+++ b/docs/learn/learn-accounts.md
@@ -4,7 +4,7 @@ description: Learn about Polkadot accounts, their structure, identity, and how t
 ---
 
 !!!info "User friendly wallets"
-Create your Polkadot accounts with any of the secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
+    Create your Polkadot accounts with any of the secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
 
 This document covers the basics of accounts in the Polkadot ecosystem. See the
 [Advanced Account](./learn-account-advanced.md) page for more information about accounts such as
@@ -108,17 +108,16 @@ the unified address format include the following:
   of the Polkadot network.
 
 !!!info Exchanges and Legacy Formats
-Some exchanges may require the legacy format for deposits or withdrawals during the transition.
-Parachain upgrades are happening progressively, and exchanges may take time to fully integrate the
-new format.
+    Some exchanges may require the legacy format for deposits or withdrawals during the transition.
+    Parachain upgrades are happening progressively, and exchanges may take time to fully integrate the
+    new format.
 
-    To assist, a feature for copying legacy addresses is being implemented to ensure a seamless
-    experience during this interim period.
+    To assist, a feature for copying legacy addresses is being implemented to ensure a seamless experience during this interim period.
 
 ## Existential Deposit and Reaping
 
 !!!info
-Visit [**this support page**](https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit-) for more information about existential deposit.
+    Visit [**this support page**](https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit-) for more information about existential deposit.
 
 When you generate an account (address), you only generate a _key_ that lets you access it. The
 account does not exist yet on-chain. For that, it needs the
@@ -135,7 +134,7 @@ before any other transaction logic, accounts with balances _equal to_ the existe
 construct a valid transaction. Additional funds will need to be added to cover the transaction fees.
 
 !!!info "The existential deposit can be different on parachains"
-Having an Existential Deposit (ED) on the relay chain account does not guarantee the liveness of the same account on its system chains or parachains. Parachains typically define ED for an account in their native tokens but can also configure it with tokens that are deemed sufficient. For example, the Existential Deposit on Polkadot Asset Hub can be in DOT or sufficient assets like USDC or USDT.
+    Having an Existential Deposit (ED) on the relay chain account does not guarantee the liveness of the same account on its system chains or parachains. Parachains typically define ED for an account in their native tokens but can also configure it with tokens that are deemed sufficient. For example, the Existential Deposit on Polkadot Asset Hub can be in DOT or sufficient assets like USDC or USDT.
 
 Here's another way to think about existential deposits. Ever notice those `Thumbs.db` files on
 Windows or `.DS_Store` files on Mac? Those are junk; they serve no specific purpose other than
@@ -149,4 +148,4 @@ but gets put back when it has the existential deposit.
 ---
 
 !!!info "Polkadot-JS Guides"
-If you are an advanced user, see the [Polkadot-JS guides about accounts](./learn-guides-accounts.md).
+    If you are an advanced user, see the [Polkadot-JS guides about accounts](./learn-guides-accounts.md).

--- a/docs/learn/learn-accounts.md
+++ b/docs/learn/learn-accounts.md
@@ -1,11 +1,10 @@
 ---
 title: Polkadot Accounts
 description: Learn about Polkadot accounts, their structure, identity, and how to manage them effectively.
-
 ---
 
 !!!info "User friendly wallets"
-    Create your Polkadot accounts with any of the secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
+Create your Polkadot accounts with any of the secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/).
 
 This document covers the basics of accounts in the Polkadot ecosystem. See the
 [Advanced Account](./learn-account-advanced.md) page for more information about accounts such as
@@ -109,23 +108,9 @@ the unified address format include the following:
   of the Polkadot network.
 
 !!!info Exchanges and Legacy Formats
-    Some exchanges may require the legacy format for deposits or withdrawals during the transition.
-    Parachain upgrades are happening progressively, and exchanges may take time to fully integrate the
-    new format.
-
-    To assist, a feature for copying legacy addresses is being implemented to ensure a seamless
-    experience during this interim period.
-
-    - Simplified User Experience: A single address format reduces complexity, making Polkadot more
-      accessible.
-    - Consistency Across Ecosystem: No more dealing with multiple formats for different parachains.
-    - Improved Ecosystem Usability: A unified experience enhances the overall robustness and usability
-      of the Polkadot network.
-
-!!!info Exchanges and Legacy Formats
-    Some exchanges may require the legacy format for deposits or withdrawals during the transition.
-    Parachain upgrades are happening progressively, and exchanges may take time to fully integrate the
-    new format.
+Some exchanges may require the legacy format for deposits or withdrawals during the transition.
+Parachain upgrades are happening progressively, and exchanges may take time to fully integrate the
+new format.
 
     To assist, a feature for copying legacy addresses is being implemented to ensure a seamless
     experience during this interim period.
@@ -133,7 +118,7 @@ the unified address format include the following:
 ## Existential Deposit and Reaping
 
 !!!info
-    Visit [**this support page**](https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit-) for more information about existential deposit.
+Visit [**this support page**](https://support.polkadot.network/support/solutions/articles/65000168651-what-is-the-existential-deposit-) for more information about existential deposit.
 
 When you generate an account (address), you only generate a _key_ that lets you access it. The
 account does not exist yet on-chain. For that, it needs the
@@ -150,7 +135,7 @@ before any other transaction logic, accounts with balances _equal to_ the existe
 construct a valid transaction. Additional funds will need to be added to cover the transaction fees.
 
 !!!info "The existential deposit can be different on parachains"
-    Having an Existential Deposit (ED) on the relay chain account does not guarantee the liveness of the same account on its system chains or parachains. Parachains typically define ED for an account in their native tokens but can also configure it with tokens that are deemed sufficient. For example, the Existential Deposit on Polkadot Asset Hub can be in DOT or sufficient assets like USDC or USDT.
+Having an Existential Deposit (ED) on the relay chain account does not guarantee the liveness of the same account on its system chains or parachains. Parachains typically define ED for an account in their native tokens but can also configure it with tokens that are deemed sufficient. For example, the Existential Deposit on Polkadot Asset Hub can be in DOT or sufficient assets like USDC or USDT.
 
 Here's another way to think about existential deposits. Ever notice those `Thumbs.db` files on
 Windows or `.DS_Store` files on Mac? Those are junk; they serve no specific purpose other than
@@ -164,4 +149,4 @@ but gets put back when it has the existential deposit.
 ---
 
 !!!info "Polkadot-JS Guides"
-    If you are an advanced user, see the [Polkadot-JS guides about accounts](./learn-guides-accounts.md).
+If you are an advanced user, see the [Polkadot-JS guides about accounts](./learn-guides-accounts.md).


### PR DESCRIPTION
This PR removes a duplicated section in the Learn → Accounts page of the Polkadot Wiki.

The benefits list and the !!!info Exchanges and Legacy Formats block were repeated. This duplication could confuse readers.

### Changes:
- Removed the repeated list of benefits for the unified address format.
- Kept a single !!!info Exchanges and Legacy Formats block to maintain clarity.