### PR TITLE
chore(eth-compare): improve reading

### DIFF
--- a/docs/learn/learn-comparison-ethereum.md
+++ b/docs/learn/learn-comparison-ethereum.md
@@ -23,7 +23,7 @@ Both protocols have fundamentally different goals:
 - Ethereum is a general-purpose blockchain based on the Ethereum Virtual Machine (EVM). Ethereum is
   not specialized nor optimized for any particular application. Instead, its primary focus is the
   Ethereum Virtual Machine for executing smart contracts. Ethereum achieves scalability via
-  [**rollups**](./learn-comparisons-rollups.md#rollup-comparison) are secondary protocols that utilize Ethereum
+  [**rollups**](./learn-comparisons-rollups.md#rollup-comparison), that are secondary protocols that utilize Ethereum
   as a settlement layer.
 
 - Polkadot is a multi-chain protocol that provides shared security and secure interoperability for


### PR DESCRIPTION
This pull request makes a minor wording update to the Ethereum section in the `learn-comparison-ethereum.md` documentation. The change clarifies the description of rollups as secondary protocols that utilize Ethereum as a settlement layer.