### PR TITLE
Remove 'Answered by Gav' section from FAQ

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -257,15 +257,4 @@ On-demand parachains are still secured by the relay chain but don't need to hold
 produce a block when it's economically feasible for them. For more information, please refer to the
 [parachains page](../learn/learn-parachains.md#parachains-vs-on-demand-parachains).
 
-## Answered by Gav series
 
-The "Answered by Gav" series is a collection of posts uploaded to Reddit of questions that have been
-asked in the Polkadot Watercooler Riot channel and answered by Polkadot founder Gavin Wood.
-
-- [Reason for using asynchronous rather than synchronous communication? Difference in terms of TPS?](https://www.reddit.com/r/dot/comments/b87d96/answered_by_gav_reason_for_using_asynchronous/)
-- [How exactly do validators in an ETH parachain keep moving around and how is communication between zones trustless?](https://www.reddit.com/r/dot/comments/b87awr/answered_by_gav_how_exactly_do_validators_in_an/)
-- [What are the main issues with Bitcoin integration and will it ever be possible? Same problem with other POW chains? Is Polkadot only going to work with POS chains? How is it trust-less in comparison to Cosmos though?](https://www.reddit.com/r/dot/comments/b87bua/answered_by_gav_what_are_the_main_issues_with/)
-- [What are the current thoughts around governance especially since projects have to be voted in to receive the parachains security?](https://www.reddit.com/r/dot/comments/b87cjz/answered_by_gav_what_are_the_current_thoughts/)
-- [Also is there any detailed overview of how exactly a token transfer from ETH could be exchanged with another chain's currency?](https://www.reddit.com/r/dot/comments/b87ds8/answered_by_gav_also_is_there_any_detailed/)
-- [Can I run multiple Validators with the same Session Key?](https://www.reddit.com/r/dot/comments/bcqrx9/answered_by_gav_can_i_run_multiple_validators/)
-- [How to tackle the concentration risk of Validators in data centers?](https://www.reddit.com/r/dot/comments/bcqwit/answered_by_gav_how_to_tackle_the_concentration/)


### PR DESCRIPTION
r/dot has been deprecated and "Answered by Gav" series is not accessible anymore. Moreover, the questions were outdated / irrelevant now

closes #6890