### PR TITLE
Remove announcement block from main.html

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -1,17 +1,5 @@
 {% extends "base.html" %}
  
-{% block announce %}
-<div class="announcement-bar">
-   <span class="announcement-text">
-    The Asset Hub Migration for Polkadot happened on November 4th 2025.
-  </span>
-  <a class="announcement-link" href="https://support.polkadot.network/support/solutions/articles/65000190561-polkadot-asset-hub-migration-what-you-must-know/" target="_blank" rel="noopener noreferrer">
-    Learn more
-  </a>
-</div>
-{{ super() }}
-{% endblock %}
-
 {% block styles %}
 	{{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/polkadot.css' | url }}">


### PR DESCRIPTION
Removed the announcement block regarding the Asset Hub Migration.