### PR TITLE
Fix chain-state values post AHM

### DIFF
--- a/docs/general/chain-state-values.md
+++ b/docs/general/chain-state-values.md
@@ -21,7 +21,7 @@ description: Explore chain constants and storage values for Polkadot, Kusama, an
 
     #### Active Validator Count
 
-    The number of Polkadot validators in the active set is {{ rpc("polkadot-assethub", "Staking", "ValidatorCount", 297, false, false) }}.
+    The current number of Polkadot validators in the active set is {{ rpc("polkadot-assethub", "Staking", "ValidatorCount", 297, false, false) }}.
 
     #### Block Hash Count
 

--- a/docs/general/chain-state-values.md
+++ b/docs/general/chain-state-values.md
@@ -3,138 +3,141 @@ title: Chain State Values
 description: Explore chain constants and storage values for Polkadot, Kusama, and their system chains.
 ---
 
+!!!info "Asset Hub Migration"
+    Following the Asset Hub Migration, balances and staking operations are now managed on Asset Hub. The values below are queried from Asset Hub for both Polkadot and Kusama networks.
+
 <!-- prettier-ignore-start -->
 
 === "Polkadot"
 
     !!!info "What to do with DOT"
-        - __{{ rpc("polkadot", "Balances", "ExistentialDeposit", 0, is_constant=true, readable="human_readable") }} :__ the minimum balance required to have an active account on Polkadot Network. If your account balance drops below the minimum, your account will be reaped. Learn more about [Accounts](../learn/learn-accounts.md) and the [Existential Deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) requirement.
-        - __{{ rpc("polkadot", "NominationPools", "MinJoinBond", 0, is_constant=false, readable="human_readable") }} :__ the minimum contribution required to join a [nomination pool](../learn/learn-nomination-pools.md) and earn staking rewards for contributing to the security of the network. Learn more about [nomination pools](../learn/learn-nomination-pools.md).
+        - __{{ rpc("polkadot-assethub", "Balances", "ExistentialDeposit", 0, is_constant=true, readable="human_readable") }} :__ the minimum balance required to have an active account on Polkadot Network. If your account balance drops below the minimum, your account will be reaped. Learn more about [Accounts](../learn/learn-accounts.md) and the [Existential Deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) requirement.
+        - __{{ rpc("polkadot-assethub", "NominationPools", "MinJoinBond", 0, is_constant=false, readable="human_readable") }} :__ the minimum contribution required to join a [nomination pool](../learn/learn-nomination-pools.md) and earn staking rewards for contributing to the security of the network. Learn more about [nomination pools](../learn/learn-nomination-pools.md).
         - __{{ rpc("polkadot-people", "Identity", "BasicDeposit", 0, is_constant=true, readable="human_readable") }} :__ register an [on-chain identity](../learn/learn-identity.md)
-        - __{{ rpc("polkadot", "Proxy", "ProxyDepositBase", 0, is_constant=true, readable="human_readable") }} :__ create a [proxy account](../learn/learn-proxies.md).
-        - __{{ rpc("polkadot", "Staking", "MinNominatorBond", 0, is_constant=false, readable="human_readable") }} :__ the minimum stake required to submit your intent to directly nominate validators.
-        - __{{ rpc("polkadot", "Staking", "MinimumActiveStake", 0, is_constant=false, readable="human_readable") }} :__ the minimum amount of DOT required to become an active nominator and earn rewards, i.e. the minimum active bond. To increase the chance of earning staking rewards, your stake should not be less than the minimum stake among the active nominators, which is a dynamic threshold. If you have lesser DOT than the minimum active nomination, please consider contributing to [nomination pools](../learn/learn-nomination-pools.md). Learn more about [becoming a nominator](../learn/learn-nominator.md).
-        - __{{ rpc("polkadot", "NominationPools", "MinCreateBond", 0, is_constant=false, readable="human_readable") }} :__ you can create your own [nomination pool](../learn/learn-nomination-pools.md).
+        - __{{ rpc("polkadot-assethub", "Proxy", "ProxyDepositBase", 0, is_constant=true, readable="human_readable") }} :__ create a [proxy account](../learn/learn-proxies.md).
+        - __{{ rpc("polkadot-assethub", "Staking", "MinNominatorBond", 0, is_constant=false, readable="human_readable") }} :__ the minimum stake required to submit your intent to directly nominate validators.
+        - __{{ rpc("polkadot-assethub", "Staking", "MinimumActiveStake", 0, is_constant=false, readable="human_readable") }} :__ the minimum amount of DOT required to become an active nominator and earn rewards, i.e. the minimum active bond. To increase the chance of earning staking rewards, your stake should not be less than the minimum stake among the active nominators, which is a dynamic threshold. If you have lesser DOT than the minimum active nomination, please consider contributing to [nomination pools](../learn/learn-nomination-pools.md). Learn more about [becoming a nominator](../learn/learn-nominator.md).
+        - __{{ rpc("polkadot-assethub", "NominationPools", "MinCreateBond", 0, is_constant=false, readable="human_readable") }} :__ you can create your own [nomination pool](../learn/learn-nomination-pools.md).
 
     #### Active Validator Count
 
-    The number of Polkadot validators in the active set is {{ rpc("polkadot", "Staking", "ValidatorCount", 297, false, false) }}.
+    The number of Polkadot validators in the active set is {{ rpc("polkadot-assethub", "Staking", "ValidatorCount", 297, false, false) }}.
 
     #### Block Hash Count
 
-    On Polkadot, the maximum number of block hashes retained on-chain at any given time is {{ rpc("polkadot", "System", "BlockHashCount", 4096, true, false) }} (which maps to seven hours given 6-second block times).
+    On Polkadot Asset Hub, the maximum number of block hashes retained on-chain at any given time is {{ rpc("polkadot-assethub", "System", "BlockHashCount", 4096, true, false) }} (which maps to seven hours given 6-second block times).
 
     #### Bounty Curator Deposit
 
-    On Polkadot, the bounty curator deposit is calculated by multiplying the curator fee by the bounty curator deposit multiplier set to {{ rpc("polkadot", "Bounties", "CuratorDepositMultiplier", 500000, true, readable="percentage") }}. The deposit can range between a minimum of {{ rpc("polkadot", "Bounties", "CuratorDepositMin", 100000000000, true, readable="human_readable") }}  and a maximum of {{ rpc("polkadot", "Bounties", "CuratorDepositMax", 2000000000000, true, readable="human_readable") }}
+    On Polkadot, the bounty curator deposit is calculated by multiplying the curator fee by the bounty curator deposit multiplier set to {{ rpc("polkadot-assethub", "Bounties", "CuratorDepositMultiplier", 500000, true, readable="percentage") }}. The deposit can range between a minimum of {{ rpc("polkadot-assethub", "Bounties", "CuratorDepositMin", 100000000000, true, readable="human_readable") }}  and a maximum of {{ rpc("polkadot-assethub", "Bounties", "CuratorDepositMax", 2000000000000, true, readable="human_readable") }}
 
     #### Bounty Deposit
 
-    The deposit to submit a bounty on Polkadot is {{ rpc("polkadot", "Bounties", "BountyDepositBase", 10000000000, true, readable="human_readable") }}
+    The deposit to submit a bounty on Polkadot is {{ rpc("polkadot-assethub", "Bounties", "BountyDepositBase", 10000000000, true, readable="human_readable") }}
 
     #### Bounty Duration
 
-    A Polkadot bounty has a predetermined duration of {{ rpc("polkadot", "Bounties", "BountyUpdatePeriod", 1296000, true, readable="blocks_to_days") }} days.
+    A Polkadot bounty has a predetermined duration of {{ rpc("polkadot-assethub", "Bounties", "BountyUpdatePeriod", 1296000, true, readable="blocks_to_days") }} days.
 
     #### Conviction Voting Lock Period
 
-    One conviction voting lock period on Polkadot equals {{ rpc("polkadot", "ConvictionVoting", "VoteLockingPeriod", 100800, true, readable="blocks_to_days") }} days.
+    One conviction voting lock period on Polkadot equals {{ rpc("polkadot-assethub", "ConvictionVoting", "VoteLockingPeriod", 100800, true, readable="blocks_to_days") }} days.
 
     #### Existential Deposit
 
-    The minimum number of tokens to keep an account alive on the Polkadot relay chain is {{ rpc("polkadot", "Balances", "ExistentialDeposit", 333000000, true, readable="human_readable") }}
+    The minimum number of tokens to keep an account alive on Polkadot Asset Hub is {{ rpc("polkadot-assethub", "Balances", "ExistentialDeposit", 333000000, true, readable="human_readable") }}
 
     #### Inactive Issuance
 
-    Polkadot's inactive issuance is {{ rpc("polkadot", "Balances", "InactiveIssuance", 20115636146084858300, is_constant=false, readable="precise_dot") }} in the era {{ rpc("polkadot", "Staking", "CurrentEra", 1553, is_constant=false) }}.
+    Polkadot's inactive issuance is {{ rpc("polkadot-assethub", "Balances", "InactiveIssuance", 20115636146084858300, is_constant=false, readable="precise_dot") }} in the era {{ rpc("polkadot-assethub", "Staking", "CurrentEra", 1553, is_constant=false) }}.
 
     #### Index Deposit
 
-    The deposit to reserve an index on Polkadot is {{ rpc("polkadot", "Indices", "Deposit", 100000000000, is_constant=true, readable="human_readable") }}
+    The deposit to reserve an index on Polkadot is {{ rpc("polkadot-assethub", "Indices", "Deposit", 100000000000, is_constant=true, readable="human_readable") }}
 
     #### Maximum Number of Nominators
 
-    The maximum number of nominators on Polkadot is uncapped and the current value is {{ rpc("polkadot", "Staking", "CounterForNominators", 36793, is_constant=false) }}.
+    The maximum number of nominators on Polkadot is uncapped and the current value is {{ rpc("polkadot-assethub", "Staking", "CounterForNominators", 36793, is_constant=false) }}.
 
     #### Maximum Number of Proxies per Account
 
-    The maximum number of proxies per Polkadot account is {{ rpc("polkadot", "Proxy", "MaxProxies", 32, is_constant=true) }}. You can have the same proxy for multiple accounts.
+    The maximum number of proxies per Polkadot account is {{ rpc("polkadot-assethub", "Proxy", "MaxProxies", 32, is_constant=true) }}. You can have the same proxy for multiple accounts.
 
     #### Maximum Votes per Nominator
 
-    A nominator on Polkadot can select up to {{ rpc("polkadot", "ElectionProviderMultiPhase", "MinerMaxVotesPerVoter", 16, is_constant=true) }} validators.
+    A nominator on Polkadot can select up to {{ rpc("polkadot-assethub", "ElectionProviderMultiPhase", "MinerMaxVotesPerVoter", 16, is_constant=true) }} validators.
 
     #### Minimum Active Bond
 
-    The minimum amount of tokens to nominate on Polkadot is {{ rpc("polkadot", "Staking", "MinimumActiveStake", 5521439075539, is_constant=false, readable="human_readable") }} 
+    The minimum amount of tokens to nominate on Polkadot is {{ rpc("polkadot-assethub", "Staking", "MinimumActiveStake", 5521439075539, is_constant=false, readable="human_readable") }} 
 
     #### Minimum Bond to Create a Nomination Pool
 
-    The minimum bond to create a Polkadot nomination pool is {{ rpc("polkadot", "NominationPools", "MinCreateBond", 5000000000000, is_constant=false,readable="human_readable") }}.
+    The minimum bond to create a Polkadot nomination pool is {{ rpc("polkadot-assethub", "NominationPools", "MinCreateBond", 5000000000000, is_constant=false,readable="human_readable") }}.
 
     #### Minimum Bond to Join a Nomination Pool
 
-    The minimum bond to join a Polkadot nomination pool is {{ rpc("polkadot", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable") }}
+    The minimum bond to join a Polkadot nomination pool is {{ rpc("polkadot-assethub", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable") }}
 
     #### Minimum Bond to Participate in Staking
 
-    The minimum bond to nominate on Polkadot is {{ rpc("polkadot", "Staking", "MinNominatorBond", 2500000000000, is_constant=false, readable="human_readable") }}  while the minimum amount to join a pool is {{ rpc("polkadot", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable") }}
+    The minimum bond to nominate on Polkadot is {{ rpc("polkadot-assethub", "Staking", "MinNominatorBond", 2500000000000, is_constant=false, readable="human_readable") }}  while the minimum amount to join a pool is {{ rpc("polkadot-assethub", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable") }}
 
     #### Minimum Validator Bond
 
-    To start a validator instance on Polkadot, the minimum bond required is {{ rpc("polkadot", "Staking", "MinValidatorBond", 0, is_constant=false, readable="human_readable") }}
+    To start a validator instance on Polkadot, the minimum bond required is {{ rpc("polkadot-assethub", "Staking", "MinValidatorBond", 0, is_constant=false, readable="human_readable") }}
 
     #### Minimum Validator Commission
 
-    The minimum commission a Polkadot Validator can set is {{ rpc("polkadot", "Staking", "MinCommission", 0, is_constant=false, readable="percentage") }}. [This does not guarantee entry into the active set and earning rewards](https://docs.polkadot.com/infrastructure/running-a-validator/#running-a-validator).
+    The minimum commission a Polkadot Validator can set is {{ rpc("polkadot-assethub", "Staking", "MinCommission", 0, is_constant=false, readable="percentage") }}. [This does not guarantee entry into the active set and earning rewards](https://docs.polkadot.com/infrastructure/running-a-validator/#running-a-validator).
 
     #### Multisig Deposit Base
 
-    The multisig deposit base on Polkadot is {{ rpc("polkadot", "Multisig", "DepositBase", 200880000000, is_constant=true, readable="human_readable") }}
+    The multisig deposit base on Polkadot is {{ rpc("polkadot-assethub", "Multisig", "DepositBase", 200880000000, is_constant=true, readable="human_readable") }}
 
     #### Multisig Deposit Factor
 
-    The multisig deposit factor on Polkadot is {{ rpc("polkadot", "Multisig", "DepositFactor", 320000000, is_constant=true, readable="human_readable") }}
+    The multisig deposit factor on Polkadot is {{ rpc("polkadot-assethub", "Multisig", "DepositFactor", 320000000, is_constant=true, readable="human_readable") }}
 
     #### Nomination Pool Max Commission
 
-    The maximum commission that can be set for a Polkadot nomination pool is {{ rpc("polkadot", "NominationPools", "GlobalMaxCommission", 100000000, is_constant=false, readable="percentage") }}.
+    The maximum commission that can be set for a Polkadot nomination pool is {{ rpc("polkadot-assethub", "NominationPools", "GlobalMaxCommission", 100000000, is_constant=false, readable="percentage") }}.
 
     #### Nomination Pool Members
 
-    There are currently {{ rpc("polkadot", "NominationPools", "CounterForPoolMembers", 0, is_constant=false) }} members in {{ rpc("polkadot", "NominationPools", "LastPoolId", 0, is_constant=false) }} Polkadot nomination pools. There is no limit to the number of pools or pool members per pool.
+    There are currently {{ rpc("polkadot-assethub", "NominationPools", "CounterForPoolMembers", 0, is_constant=false) }} members in {{ rpc("polkadot-assethub", "NominationPools", "LastPoolId", 0, is_constant=false) }} Polkadot nomination pools. There is no limit to the number of pools or pool members per pool.
 
     #### OpenGov Referendum Timeout
 
-    A Polkadot referendum is timeout for not submitting the Decision Deposit within {{ rpc("polkadot", "Referenda", "UndecidingTimeout", 0, is_constant=true, readable="blocks_to_days") }} days since its creation.
+    A Polkadot referendum is timeout for not submitting the Decision Deposit within {{ rpc("polkadot-assethub", "Referenda", "UndecidingTimeout", 0, is_constant=true, readable="blocks_to_days") }} days since its creation.
 
     #### OpenGov Submission Deposit
 
-    A deposit of {{ rpc("polkadot", "Referenda", "SubmissionDeposit", 0, is_constant=true, readable="human_readable") }} is needed to submit a referendum on Polkadot.
+    A deposit of {{ rpc("polkadot-assethub", "Referenda", "SubmissionDeposit", 0, is_constant=true, readable="human_readable") }} is needed to submit a referendum on Polkadot.
 
     #### Parachain ID Registration Deposit
 
-    Reserving a `ParaID` on Polkadot requires a deposit of {{ rpc("polkadot", "Registrar", "ParaDeposit", 0, is_constant=true, readable="human_readable") }}
+    Reserving a `ParaID` on Polkadot requires a deposit of {{ rpc("polkadot-assethub", "Registrar", "ParaDeposit", 0, is_constant=true, readable="human_readable") }}
 
     #### Parachain Genesis State Registration Deposit
 
-    Registering the genesis state and Wasm code of a Polkadot parachain requires a deposit {{ rpc("polkadot", "Registrar", "DataDepositPerByte", 0, is_constant=true,  readable="human_readable") }} per byte.
+    Registering the genesis state and Wasm code of a Polkadot parachain requires a deposit {{ rpc("polkadot-assethub", "Registrar", "DataDepositPerByte", 0, is_constant=true,  readable="human_readable") }} per byte.
 
     #### Proxy Deposits
 
-    The creation of proxies on Polkadot requires a **proxy deposit base** of {{ rpc("polkadot", "Proxy", "ProxyDepositBase", 0, is_constant=true,  readable="human_readable") }} and a **proxy deposit factor** of {{ rpc("polkadot", "Proxy", "ProxyDepositFactor", 0, is_constant=true,  readable="human_readable") }} that is multiplied by the number of proxies under the same proxied account.
+    The creation of proxies on Polkadot requires a **proxy deposit base** of {{ rpc("polkadot-assethub", "Proxy", "ProxyDepositBase", 0, is_constant=true,  readable="human_readable") }} and a **proxy deposit factor** of {{ rpc("polkadot-assethub", "Proxy", "ProxyDepositFactor", 0, is_constant=true,  readable="human_readable") }} that is multiplied by the number of proxies under the same proxied account.
 
-    In case of time-delayed proxies, there is an **announcement deposit base** of {{ rpc("polkadot", "Proxy", "AnnouncementDepositBase", 0, is_constant=true,  readable="human_readable") }} for announcing a call and an **announcement deposit factor** of {{ rpc("polkadot", "Proxy", "AnnouncementDepositFactor", 0, is_constant=true, readable="human_readable") }} for each proxy call.
+    In case of time-delayed proxies, there is an **announcement deposit base** of {{ rpc("polkadot-assethub", "Proxy", "AnnouncementDepositBase", 0, is_constant=true,  readable="human_readable") }} for announcing a call and an **announcement deposit factor** of {{ rpc("polkadot-assethub", "Proxy", "AnnouncementDepositFactor", 0, is_constant=true, readable="human_readable") }} for each proxy call.
 
     #### Staking Miner Deposit and Reward
 
-    Staking miners on Polkadot are required to reserve a deposit to submit their solutions. The deposit is the sum of a **signed deposit base** of {{ rpc("polkadot", "ElectionProviderMultiPhase", "SignedDepositBase", 0, is_constant=true, readable="human_readable") }}, a **signed deposit per byte** of {{ rpc("polkadot", "ElectionProviderMultiPhase", "SignedDepositByte", 0, is_constant=true, readable="human_readable") }} (a solution weighing 200KB would yield 200 x 0.0000097656 = 0.00195312 DOT), and a **signed deposit weight** set to 0.
+    Staking miners on Polkadot are required to reserve a deposit to submit their solutions. The deposit is the sum of a **signed deposit base** of {{ rpc("polkadot-assethub", "ElectionProviderMultiPhase", "SignedDepositBase", 0, is_constant=true, readable="human_readable") }}, a **signed deposit per byte** of {{ rpc("polkadot-assethub", "ElectionProviderMultiPhase", "SignedDepositByte", 0, is_constant=true, readable="human_readable") }} (a solution weighing 200KB would yield 200 x 0.0000097656 = 0.00195312 DOT), and a **signed deposit weight** set to 0.
 
-    The **signed reward base** on Polkadot is {{ rpc("polkadot", "ElectionProviderMultiPhase", "SignedRewardBase", 0, is_constant=true, readable="human_readable") }} which is a fixed amount.
+    The **signed reward base** on Polkadot is {{ rpc("polkadot-assethub", "ElectionProviderMultiPhase", "SignedRewardBase", 0, is_constant=true, readable="human_readable") }} which is a fixed amount.
 
     #### Staking Miner Max Submissions
 
-    The maximum number of submissions for a staking miner on Polkadot is {{ rpc("polkadot", "ElectionProviderMultiPhase", "SignedMaxSubmissions", 0, is_constant=true) }}.
+    The maximum number of submissions for a staking miner on Polkadot is {{ rpc("polkadot-assethub", "ElectionProviderMultiPhase", "SignedMaxSubmissions", 0, is_constant=true) }}.
 
     #### Staking Reward Retention
 
@@ -145,152 +148,152 @@ description: Explore chain constants and storage values for Polkadot, Kusama, an
 
     #### Total Issuance
 
-    Polkadot's total issuance is {{ rpc("polkadot", "Balances", "TotalIssuance", 0, is_constant=false, readable="precise_dot") }} in the era {{ rpc("polkadot", "Staking", "CurrentEra", 0, is_constant=false) }}.
+    Polkadot's total issuance is {{ rpc("polkadot-assethub", "Balances", "TotalIssuance", 0, is_constant=false, readable="precise_dot") }} in the era {{ rpc("polkadot-assethub", "Staking", "CurrentEra", 0, is_constant=false) }}.
 
     #### Treasury Burn Factor
 
-    At the end of every spending period on Polkadot, {{ rpc("polkadot", "Treasury", "Burn", 0, is_constant=true, readable="percentage") }} of the available funds are burned.
+    At the end of every spending period on Polkadot, {{ rpc("polkadot-assethub", "Treasury", "Burn", 0, is_constant=true, readable="percentage") }} of the available funds are burned.
 
     #### Treasury Spending Period
 
-    The spending period on Polkadot is currently {{ rpc("polkadot", "Treasury", "SpendPeriod", 0, is_constant=true, readable="blocks_to_days") }} days.
+    The spending period on Polkadot is currently {{ rpc("polkadot-assethub", "Treasury", "SpendPeriod", 0, is_constant=true, readable="blocks_to_days") }} days.
 
     #### Unbonding Duration
 
-    The unbonding duration on Polkadot is set to {{ rpc("polkadot", "Staking", "BondingDuration", 0, is_constant=true) }} days. This is
+    The unbonding duration on Polkadot is set to {{ rpc("polkadot-assethub", "Staking", "BondingDuration", 0, is_constant=true) }} days. This is
     calculated by taking the **bonding duration** (in eras), multiplying it by the **length of a single
     era** (in hours), and dividing by the **hours in a day** (24). Example: 28 × 24 ÷ 24 = 28 days.
 
 === "Kusama"
 
     !!!info "What to do with KSM"
-        - __{{ rpc("kusama", "Balances", "ExistentialDeposit", 0, is_constant=true, readable="precise_ksm") }} :__ the minimum balance required to have an active account on Kusama Network. If your account balance drops below the minimum, your account will be reaped. Learn more about [Accounts](../learn/learn-accounts.md) and the [Existential Deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) requirement.
-        - __{{ rpc("kusama", "NominationPools", "MinJoinBond", 0, is_constant=false, readable="precise_ksm") }} :__ the minimum contribution required to join a [nomination pool](../learn/learn-nomination-pools.md) and earn staking rewards for contributing to the security of the network. Learn more about [nomination pools](../learn/learn-nomination-pools.md).
+        - __{{ rpc("kusama-assethub", "Balances", "ExistentialDeposit", 0, is_constant=true, readable="precise_ksm") }} :__ the minimum balance required to have an active account on Kusama Network. If your account balance drops below the minimum, your account will be reaped. Learn more about [Accounts](../learn/learn-accounts.md) and the [Existential Deposit](../learn/learn-accounts.md#existential-deposit-and-reaping) requirement.
+        - __{{ rpc("kusama-assethub", "NominationPools", "MinJoinBond", 0, is_constant=false, readable="precise_ksm") }} :__ the minimum contribution required to join a [nomination pool](../learn/learn-nomination-pools.md) and earn staking rewards for contributing to the security of the network. Learn more about [nomination pools](../learn/learn-nomination-pools.md).
         - __{{ rpc("kusama-people", "Identity", "BasicDeposit", 0, is_constant=true, readable="precise_ksm") }} :__ register an [on-chain identity](../learn/learn-identity.md)
-        - __{{ rpc("kusama", "Proxy", "ProxyDepositBase", 0, is_constant=true, readable="human_readable_kusama") }} :__ create a [proxy account](../learn/learn-proxies.md).
-        - __{{ rpc("kusama", "Staking", "MinNominatorBond", 0, is_constant=false, readable="human_readable_kusama") }} :__ the minimum stake required to submit your intent to directly nominate validators.
-        - __{{ rpc("kusama", "Staking", "MinimumActiveStake", 0, is_constant=false, readable="human_readable_kusama") }} :__ the minimum amount required to become an active nominator and earn rewards, i.e. the minimum active bond. To increase the chance of earning staking rewards, your stake should not be less than the minimum stake among the active nominators, which is a dynamic threshold. If you have lesser KSM than the minimum active nomination, please consider contributing to [nomination pools](../learn/learn-nomination-pools.md). Learn more about [becoming a nominator](../learn/learn-nominator.md).
-        - __{{ rpc("kusama", "NominationPools", "MinCreateBond", 0, is_constant=false, readable="human_readable_kusama") }} :__ you can create your own [nomination pool](../learn/learn-nomination-pools.md).
+        - __{{ rpc("kusama-assethub", "Proxy", "ProxyDepositBase", 0, is_constant=true, readable="human_readable_kusama") }} :__ create a [proxy account](../learn/learn-proxies.md).
+        - __{{ rpc("kusama-assethub", "Staking", "MinNominatorBond", 0, is_constant=false, readable="human_readable_kusama") }} :__ the minimum stake required to submit your intent to directly nominate validators.
+        - __{{ rpc("kusama-assethub", "Staking", "MinimumActiveStake", 0, is_constant=false, readable="human_readable_kusama") }} :__ the minimum amount required to become an active nominator and earn rewards, i.e. the minimum active bond. To increase the chance of earning staking rewards, your stake should not be less than the minimum stake among the active nominators, which is a dynamic threshold. If you have lesser KSM than the minimum active nomination, please consider contributing to [nomination pools](../learn/learn-nomination-pools.md). Learn more about [becoming a nominator](../learn/learn-nominator.md).
+        - __{{ rpc("kusama-assethub", "NominationPools", "MinCreateBond", 0, is_constant=false, readable="human_readable_kusama") }} :__ you can create your own [nomination pool](../learn/learn-nomination-pools.md).
 
     #### Active Validator Count
 
-    The number of Kusama validators in the active set is {{ rpc("kusama", "Staking", "ValidatorCount", 297, false, false) }}.
+    The number of Kusama validators in the active set is {{ rpc("kusama-assethub", "Staking", "ValidatorCount", 297, false, false) }}.
 
     #### Block Hash Count
 
-    On Kusama, the maximum number of block hashes retained on-chain at any given time is {{ rpc("kusama", "System", "BlockHashCount", 4096, true, false) }}(which maps to seven hours given 6-second block times).
+    On Kusama Asset Hub, the maximum number of block hashes retained on-chain at any given time is {{ rpc("kusama-assethub", "System", "BlockHashCount", 4096, true, false) }}(which maps to seven hours given 6-second block times).
 
     #### Bounty Curator Deposit
 
-    On Kusama, the bounty curator deposit is calculated by multiplying the curator fee by the bounty curator deposit multiplier set to {{ rpc("kusama", "Bounties", "CuratorDepositMultiplier", 500000, true, readable="percentage") }}. The deposit can range between a minimum of {{ rpc("kusama", "Bounties", "CuratorDepositMin", 100000000000, true, readable="human_readable_kusama") }}  and a maximum of {{ rpc("kusama", "Bounties", "CuratorDepositMax", 2000000000000, true, readable="human_readable_kusama") }}
+    On Kusama, the bounty curator deposit is calculated by multiplying the curator fee by the bounty curator deposit multiplier set to {{ rpc("kusama-assethub", "Bounties", "CuratorDepositMultiplier", 500000, true, readable="percentage") }}. The deposit can range between a minimum of {{ rpc("kusama-assethub", "Bounties", "CuratorDepositMin", 100000000000, true, readable="human_readable_kusama") }}  and a maximum of {{ rpc("kusama-assethub", "Bounties", "CuratorDepositMax", 2000000000000, true, readable="human_readable_kusama") }}
 
     #### Bounty Deposit
 
-    The deposit to submit a bounty on Kusama is {{ rpc("kusama", "Bounties", "BountyDepositBase", 10000000000, true, readable="human_readable_kusama") }} .
+    The deposit to submit a bounty on Kusama is {{ rpc("kusama-assethub", "Bounties", "BountyDepositBase", 10000000000, true, readable="human_readable_kusama") }} .
 
     #### Bounty Duration
 
-    A Kusama bounty has a predetermined duration of {{ rpc("kusama", "Bounties", "BountyUpdatePeriod", 1296000, true, readable="blocks_to_days") }} days.
+    A Kusama bounty has a predetermined duration of {{ rpc("kusama-assethub", "Bounties", "BountyUpdatePeriod", 1296000, true, readable="blocks_to_days") }} days.
 
     #### Conviction Voting Lock Period
 
-    One conviction voting lock period on Kusama equals {{ rpc("kusama", "ConvictionVoting", "VoteLockingPeriod", 100800, true, readable="blocks_to_days") }} days.
+    One conviction voting lock period on Kusama equals {{ rpc("kusama-assethub", "ConvictionVoting", "VoteLockingPeriod", 100800, true, readable="blocks_to_days") }} days.
 
     #### Existential Deposit
 
-    The minimum number of tokens to keep an account alive on the Kusama relay chain is {{ rpc("kusama", "Balances", "ExistentialDeposit", 333000000, true, readable="human_readable_kusama") }}.
+    The minimum number of tokens to keep an account alive on Kusama Asset Hub is {{ rpc("kusama-assethub", "Balances", "ExistentialDeposit", 333000000, true, readable="human_readable_kusama") }}.
 
     #### Inactive Issuance
 
-    Kusama's inactive issuance is {{ rpc("kusama", "Balances", "InactiveIssuance", 20115636146084858300, is_constant=false, readable="precise_ksm") }} in the era {{ rpc("kusama", "Staking", "CurrentEra", 1553, is_constant=false) }}.
+    Kusama's inactive issuance is {{ rpc("kusama-assethub", "Balances", "InactiveIssuance", 20115636146084858300, is_constant=false, readable="precise_ksm") }} in the era {{ rpc("kusama-assethub", "Staking", "CurrentEra", 1553, is_constant=false) }}.
 
     #### Index Deposit
 
-    The deposit to reserve an index on Kusama is {{ rpc("kusama", "Indices", "Deposit", 100000000000, is_constant=true, readable="human_readable_kusama") }}
+    The deposit to reserve an index on Kusama is {{ rpc("kusama-assethub", "Indices", "Deposit", 100000000000, is_constant=true, readable="human_readable_kusama") }}
 
     #### Maximum Number of Nominators
 
-    The maximum number of nominators on Kusama is uncapped and the current value is {{ rpc("kusama", "Staking", "CounterForNominators", 36793, is_constant=false) }}.
+    The maximum number of nominators on Kusama is uncapped and the current value is {{ rpc("kusama-assethub", "Staking", "CounterForNominators", 36793, is_constant=false) }}.
 
     #### Maximum Number of Proxies per Account
 
-    The maximum number of proxies per Kusama account is {{ rpc("kusama", "Proxy", "MaxProxies", 32, is_constant=true) }}. You can have the same proxy for multiple accounts.
+    The maximum number of proxies per Kusama account is {{ rpc("kusama-assethub", "Proxy", "MaxProxies", 32, is_constant=true) }}. You can have the same proxy for multiple accounts.
 
     #### Maximum Votes per Nominator
 
-    A nominator on Kusama can select up to {{ rpc("kusama", "ElectionProviderMultiPhase", "MinerMaxVotesPerVoter", 16, is_constant=true) }} validators.
+    A nominator on Kusama can select up to {{ rpc("kusama-assethub", "ElectionProviderMultiPhase", "MinerMaxVotesPerVoter", 16, is_constant=true) }} validators.
 
     #### Minimum Active Bond
 
-    The minimum amount of tokens to nominate on Kusama is {{ rpc("kusama", "Staking", "MinimumActiveStake", 5521439075539, is_constant=false, readable="human_readable_kusama") }} 
+    The minimum amount of tokens to nominate on Kusama is {{ rpc("kusama-assethub", "Staking", "MinimumActiveStake", 5521439075539, is_constant=false, readable="human_readable_kusama") }} 
 
     #### Minimum Bond to Create a Nomination Pool
 
-    The minimum bond to create a Kusama nomination pool is {{ rpc("kusama", "NominationPools", "MinCreateBond", 5000000000000, is_constant=false, readable="human_readable_kusama") }}.
+    The minimum bond to create a Kusama nomination pool is {{ rpc("kusama-assethub", "NominationPools", "MinCreateBond", 5000000000000, is_constant=false, readable="human_readable_kusama") }}.
 
     #### Minimum Bond to Join a Nomination Pool
 
-    The minimum bond to join a Kusama nomination pool is {{ rpc("kusama", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable_kusama") }}.
+    The minimum bond to join a Kusama nomination pool is {{ rpc("kusama-assethub", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable_kusama") }}.
 
     #### Minimum Bond to Participate in Staking
 
-    The minimum bond to nominate on Kusama is {{ rpc("kusama", "Staking", "MinNominatorBond", 2500000000000, is_constant=false, readable="human_readable_kusama") }} while the minimum amount to join a pool is {{ rpc("kusama", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable_kusama") }}
+    The minimum bond to nominate on Kusama is {{ rpc("kusama-assethub", "Staking", "MinNominatorBond", 2500000000000, is_constant=false, readable="human_readable_kusama") }} while the minimum amount to join a pool is {{ rpc("kusama-assethub", "NominationPools", "MinJoinBond", 10000000000, is_constant=false, readable="human_readable_kusama") }}
 
     #### Minimum Validator Bond
 
-    To start a validator instance on Kusama, the minimum bond required is {{ rpc("kusama", "Staking", "MinValidatorBond", 0, is_constant=false, readable="human_readable_kusama") }}
+    To start a validator instance on Kusama, the minimum bond required is {{ rpc("kusama-assethub", "Staking", "MinValidatorBond", 0, is_constant=false, readable="human_readable_kusama") }}
 
     #### Minimum Validator Commission
 
-    The minimum commission a Kusama Validator can set is {{ rpc("kusama", "Staking", "MinCommission", 0, is_constant=false, readable="percentage") }}. [This does not guarantee entry into the active set and earning rewards](https://docs.polkadot.com/infrastructure/running-a-validator/#running-a-validator).
+    The minimum commission a Kusama Validator can set is {{ rpc("kusama-assethub", "Staking", "MinCommission", 0, is_constant=false, readable="percentage") }}. [This does not guarantee entry into the active set and earning rewards](https://docs.polkadot.com/infrastructure/running-a-validator/#running-a-validator).
 
     #### Multisig Deposit Base
 
-    The multisig deposit base on Kusama is {{ rpc("kusama", "Multisig", "DepositBase", 200880000000, is_constant=true, readable="human_readable_kusama") }}.
+    The multisig deposit base on Kusama is {{ rpc("kusama-assethub", "Multisig", "DepositBase", 200880000000, is_constant=true, readable="human_readable_kusama") }}.
 
     #### Multisig Deposit Factor
 
-    The multisig deposit factor on Kusama is {{ rpc("kusama", "Multisig", "DepositFactor", 320000000, is_constant=true, readable="human_readable_kusama") }}.
+    The multisig deposit factor on Kusama is {{ rpc("kusama-assethub", "Multisig", "DepositFactor", 320000000, is_constant=true, readable="human_readable_kusama") }}.
 
     #### Nomination Pool Max Commission
 
-    The maximum commission that can be set for a Kusama nomination pool is {{ rpc("kusama", "NominationPools", "GlobalMaxCommission", 100000000, is_constant=false, readable="percentage") }}.
+    The maximum commission that can be set for a Kusama nomination pool is {{ rpc("kusama-assethub", "NominationPools", "GlobalMaxCommission", 100000000, is_constant=false, readable="percentage") }}.
 
     #### Nomination Pool Members
 
-    There are currently {{ rpc("kusama", "NominationPools", "CounterForPoolMembers", 0, is_constant=false) }} members in {{ rpc("kusama", "NominationPools", "LastPoolId", 0, is_constant=false) }} Kusama nomination pools. There is no limit to the number of pools or pool members per pool.
+    There are currently {{ rpc("kusama-assethub", "NominationPools", "CounterForPoolMembers", 0, is_constant=false) }} members in {{ rpc("kusama-assethub", "NominationPools", "LastPoolId", 0, is_constant=false) }} Kusama nomination pools. There is no limit to the number of pools or pool members per pool.
 
     #### OpenGov Referendum Timeout
 
-    A Kusama referendum is timeout for not submitting the Decision Deposit within {{ rpc("kusama", "Referenda", "UndecidingTimeout", 0, is_constant=true, readable="blocks_to_days") }} days since its creation.
+    A Kusama referendum is timeout for not submitting the Decision Deposit within {{ rpc("kusama-assethub", "Referenda", "UndecidingTimeout", 0, is_constant=true, readable="blocks_to_days") }} days since its creation.
 
     #### OpenGov Submission Deposit
 
-    A deposit of {{ rpc("kusama", "Referenda", "SubmissionDeposit", 0, is_constant=true, readable="human_readable_kusama") }}is needed to submit a referendum on Kusama.
+    A deposit of {{ rpc("kusama-assethub", "Referenda", "SubmissionDeposit", 0, is_constant=true, readable="human_readable_kusama") }}is needed to submit a referendum on Kusama.
 
     #### Parachain ID Registration Deposit
 
-    Reserving a `ParaID` on Kusama requires a deposit of {{ rpc("kusama", "Registrar", "ParaDeposit", 0, is_constant=true, readable="human_readable_kusama") }}.
+    Reserving a `ParaID` on Kusama requires a deposit of {{ rpc("kusama-assethub", "Registrar", "ParaDeposit", 0, is_constant=true, readable="human_readable_kusama") }}.
 
     #### Parachain Genesis State Registration Deposit
 
-    Registering the genesis state and Wasm code of a Kusama parachain requires a deposit {{ rpc("kusama", "Registrar", "DataDepositPerByte", 0, is_constant=true, readable="human_readable_kusama") }} per byte.
+    Registering the genesis state and Wasm code of a Kusama parachain requires a deposit {{ rpc("kusama-assethub", "Registrar", "DataDepositPerByte", 0, is_constant=true, readable="human_readable_kusama") }} per byte.
 
     #### Proxy Deposits
 
-    The creation of proxies on Kusama requires a **proxy deposit base** of {{ rpc("kusama", "Proxy", "ProxyDepositBase", 0, is_constant=true, readable="human_readable_kusama") }} and a **proxy deposit factor** of {{ rpc("kusama", "Proxy", "ProxyDepositFactor", 0, is_constant=true, readable="human_readable_kusama") }} that is multiplied by the number of proxies under the same proxied account.
+    The creation of proxies on Kusama requires a **proxy deposit base** of {{ rpc("kusama-assethub", "Proxy", "ProxyDepositBase", 0, is_constant=true, readable="human_readable_kusama") }} and a **proxy deposit factor** of {{ rpc("kusama-assethub", "Proxy", "ProxyDepositFactor", 0, is_constant=true, readable="human_readable_kusama") }} that is multiplied by the number of proxies under the same proxied account.
 
-    In case of time-delayed proxies, there is an **announcement deposit base** of {{ rpc("kusama", "Proxy", "AnnouncementDepositBase", 0, is_constant=true, readable="human_readable_kusama") }} for announcing a call and an **announcement deposit factor** of {{ rpc("kusama", "Proxy", "AnnouncementDepositFactor", 0, is_constant=true, readable="human_readable_kusama") }} for each proxy call.
+    In case of time-delayed proxies, there is an **announcement deposit base** of {{ rpc("kusama-assethub", "Proxy", "AnnouncementDepositBase", 0, is_constant=true, readable="human_readable_kusama") }} for announcing a call and an **announcement deposit factor** of {{ rpc("kusama-assethub", "Proxy", "AnnouncementDepositFactor", 0, is_constant=true, readable="human_readable_kusama") }} for each proxy call.
 
     #### Staking Miner Deposit and Reward
 
-    Staking miners on Kusama are required to reserve a deposit to submit their solutions. The deposit is the sum of a **signed deposit base** of {{ rpc("kusama", "ElectionProviderMultiPhase", "SignedDepositBase", 0, is_constant=true, readable="human_readable_kusama") }}, a **signed deposit per byte** of {{ rpc("kusama", "ElectionProviderMultiPhase", "SignedDepositByte", 0, is_constant=true, readable="human_readable_kusama") }} (a solution weighing 200KB would yield 200 x 0.00000032551 = 0.000065102), and a **signed deposit weight** set to 0 and has no effect.
+    Staking miners on Kusama are required to reserve a deposit to submit their solutions. The deposit is the sum of a **signed deposit base** of {{ rpc("kusama-assethub", "ElectionProviderMultiPhase", "SignedDepositBase", 0, is_constant=true, readable="human_readable_kusama") }}, a **signed deposit per byte** of {{ rpc("kusama-assethub", "ElectionProviderMultiPhase", "SignedDepositByte", 0, is_constant=true, readable="human_readable_kusama") }} (a solution weighing 200KB would yield 200 x 0.00000032551 = 0.000065102), and a **signed deposit weight** set to 0 and has no effect.
 
-    The **signed reward base** on Kusama is {{ rpc("kusama", "ElectionProviderMultiPhase", "SignedRewardBase", 0, is_constant=true, readable="human_readable_kusama") }} which is a fixed amount.
+    The **signed reward base** on Kusama is {{ rpc("kusama-assethub", "ElectionProviderMultiPhase", "SignedRewardBase", 0, is_constant=true, readable="human_readable_kusama") }} which is a fixed amount.
 
     #### Staking Miner Max Submissions
 
-    The maximum number of submission for a staking miner on Kusama is {{ rpc("kusama", "ElectionProviderMultiPhase", "SignedMaxSubmissions", 0, is_constant=true) }}.
+    The maximum number of submission for a staking miner on Kusama is {{ rpc("kusama-assethub", "ElectionProviderMultiPhase", "SignedMaxSubmissions", 0, is_constant=true) }}.
 
     #### Staking Reward Retention
 
@@ -301,41 +304,21 @@ description: Explore chain constants and storage values for Polkadot, Kusama, an
 
     #### Total Issuance
 
-    Kusama's total issuance is {{ rpc("kusama", "Balances", "TotalIssuance", 0, is_constant=false, readable="human_readable_kusama") }} in the era {{ rpc("kusama", "Staking", "CurrentEra", 0, is_constant=false) }}.
+    Kusama's total issuance is {{ rpc("kusama-assethub", "Balances", "TotalIssuance", 0, is_constant=false, readable="human_readable_kusama") }} in the era {{ rpc("kusama-assethub", "Staking", "CurrentEra", 0, is_constant=false) }}.
 
     #### Treasury Burn Factor
 
-    At the end of every spending period on Kusama, {{ rpc("kusama", "Treasury", "Burn", 0, is_constant=true, readable="percentage") }} of the available funds are burned.
+    At the end of every spending period on Kusama, {{ rpc("kusama-assethub", "Treasury", "Burn", 0, is_constant=true, readable="percentage") }} of the available funds are burned.
 
     #### Treasury Spending Period
 
-    The spending period on Kusama is currently {{ rpc("kusama", "Treasury", "SpendPeriod", 0, is_constant=true, readable="blocks_to_days") }} days.
+    The spending period on Kusama is currently {{ rpc("kusama-assethub", "Treasury", "SpendPeriod", 0, is_constant=true, readable="blocks_to_days") }} days.
 
     #### Unbonding Duration
 
-    The unbonding duration on Kusama is set to {{ rpc("kusama", "Staking", "BondingDuration", 0, is_constant=true, readable="blocks_to_days") }} days. This is
+    The unbonding duration on Kusama is set to {{ rpc("kusama-assethub", "Staking", "BondingDuration", 0, is_constant=true, readable="blocks_to_days") }} days. This is
     calculated by taking the **bonding duration** (in eras), multiplying it by the **length of a single
     era** (in hours), and dividing by the **hours in a day** (24). Example: 28 × 6 ÷ 24 = 7 days.
-
-=== "Polkadot Asset Hub"
-
-    #### Asset Deposit
-
-    To reserve an asset on the Polkadot Asset Hub you need a deposit of {{ rpc("polkadot-assethub", "Assets", "AssetDeposit", 100000000000, true, readable="precise_dot") }} and {{ rpc("polkadot-assethub", "Assets", "MetadataDepositBase", 668933304, true, readable="precise_dot") }} for the asset metadata.
-
-    #### Existential Deposit
-
-    The minimum number of tokens to keep an account alive on the Polkadot Asset Hub is {{ rpc("polkadot-assethub", "Balances", "ExistentialDeposit", 100000000, true, readable="precise_dot") }}.
-
-=== "Kusama Asset Hub"
-
-    #### Asset Deposit
-
-    To reserve an asset on the Kusama Asset Hub you need a deposit of {{ rpc("kusama-assethub", "Assets", "AssetDeposit", 100000000000, true, readable="precise_ksm") }} and {{ rpc("kusama-assethub", "Assets", "MetadataDepositBase", 668933304, true, readable="precise_ksm") }} for the asset metadata.
-
-    #### Existential Deposit
-
-    The minimum number of tokens to keep an account alive on the Kusama Asset Hub is {{ rpc("kusama-assethub", "Balances", "ExistentialDeposit", 100000000, true, readable="precise_ksm") }}.
 
 === "Polkadot People"
 


### PR DESCRIPTION
Closes #6960 

Post-AHM, most of these pallets were moved to Asset Hub. The macro has been updated accordingly.