### PR TITLE
Edit bug bounty

### DIFF
--- a/docs/kusama/kusama-coc.md
+++ b/docs/kusama/kusama-coc.md
@@ -44,4 +44,4 @@ actions shouldn't be taken too seriously - try to assume jest before malice.
 
 Please understand that this network is, despite its success, an experiment with potential flaws, so
 it’s appreciated that community members help report any sort of exploits directly to the team before
-sharing publicly. Please see the [bug bounty program](kusama-bug-bounty.md).
+sharing publicly. Please see the [bug bounty program](https://security.parity.io/bug-bounties).

--- a/docs/kusama/kusama-getting-started.md
+++ b/docs/kusama/kusama-getting-started.md
@@ -27,7 +27,7 @@ on-chain governance, and parachains.
 
 - **[Timeline](kusama-timeline.md)** – Stay up-to-date with the latest action on Kusama.
 - **[Code of Conduct](kusama-coc.md)** - Kusama's Code of Conduct to sustain chaos.
-- **[Bug Bounty](kusama-bug-bounty.md)** - An Overview of how you can help catch bugs.
+- **[Bug Bounty](https://security.parity.io/bug-bounties)** - An Overview of how you can help catch bugs.
 - **[Account Recovery](kusama-social-recovery.md)** - Steps on how to perform account recovery on Kusama.
 - **[Adversarial Cheatsheet](kusama-adverserial-cheatsheet.md)** - A Cheatsheet to help you create chaos.
 - **[Kappa Sigma Mu](https://ksmsociety.io/)** - Learn about the Kappa Sigma Mu Society and Join as a Member.

--- a/material-overrides/partials/footer.html
+++ b/material-overrides/partials/footer.html
@@ -53,6 +53,7 @@
           <a href="https://web3.foundation/legal-disclosures/">Legal Disclosures</a>
           <a href="https://web3.foundation/privacy-and-cookies/">Privacy Policy</a>
           <a href="/policies/chatbot-terms">AI Chatbot Policy</a>
+          <a href="https://web3.foundation/security-report/">Report a Bug</a>
         </div>
         {% if config.extra.social %}
           {% include "partials/social.html" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,7 +159,6 @@ nav:
           - Ecosystem Funds: general/ecosystem-funds.md  
       - Programs:
           - Decentralized Voices: general/decentralized-voices.md
-          - Bug Bounty: general/bug-bounty.md
           - Ambassadors: general/ambassadors.md  
       - Stay Safe:
               - How to DYOR: general/how-to-dyor.md
@@ -175,7 +174,6 @@ nav:
         - Getting Started: kusama/kusama-getting-started.md
         - Timeline: kusama/kusama-timeline.md
         - Code of Conduct: kusama/kusama-coc.md
-        - Bug Bounty: kusama/kusama-bug-bounty.md
         - Social Recovery: kusama/kusama-social-recovery.md
         - Adversarial Cheatsheet: kusama/kusama-adverserial-cheatsheet.md
         - Kusama Inflation: kusama/kusama-inflation.md

--- a/scripts/_redirects
+++ b/scripts/_redirects
@@ -54,7 +54,7 @@
 /*/polkadot-community-foundation    /general/pcf   301
 /*/ecosystem-funds    /general/ecosystem-funds    301
 /*/decentralized-voices    /general/decentralized-voices    301
-/*/bug-bounty    /general/bug-bounty    301
+/*/bug-bounty    https://security.parity.io/bug-bounties    301
 /*/alpha-program    /general/new-alpha-program    301
 /*/thousand-contributors    https://polkadot.com/    301
 /*/dev-heroes    https://polkadot.com/    301
@@ -74,7 +74,7 @@
 /*/kusama-getting-started    /kusama/kusama-getting-started    301
 /*/kusama-timeline    /kusama/kusama-timeline    301
 /*/kusama-coc    /kusama/kusama-coc    301
-/*/kusama-bug-bounty    /kusama/kusama-bug-bounty    301
+/*/kusama-bug-bounty    https://security.parity.io/bug-bounties    301
 /*/kusama-social-recovery    /kusama/kusama-social-recovery    301
 /*/kusama-adversarial-cheatsheet    /kusama/kusama-adverserial-cheatsheet    301
 /*/maintain-guides-society-kusama    https://ksmsociety.io   301


### PR DESCRIPTION
Issue with bug bounty pages about Polkadot with a link to Web3 Foundation bug reports (two different things). There is an existing page about Polkadot bug bounties on Parity side.

- remove bug bounty pages from sidebar
- edit redirects, send requests to https://security.parity.io/bug-bounties
- add bug report for web3 foundation pages in footer