### PR TITLE
Fix precise token formatting and add regression tests

### DIFF
--- a/macros/rpc.py
+++ b/macros/rpc.py
@@ -49,11 +49,11 @@ def get_network_url(network):
         
 def human_readable(decimals_amount, number, rounded=True):
     balance_str = str(number)
-    
-    # Determine display decimals based on token type (derived from decimals_amount)
-    # For DOT (decimals_amount=10), show 2 decimals
-    # For KSM (decimals_amount=12), show 6 decimals
-    if decimals_amount == 10:  # DOT
+
+    # Keep full chain precision when rounded=False.
+    if not rounded:
+        display_decimals = decimals_amount
+    elif decimals_amount == 10:  # DOT
         display_decimals = 2
     elif decimals_amount == 12:  # KSM
         display_decimals = 6

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def load_rpc_module():
+    # Keep tests independent from substrate-interface installation.
+    fake_substrate = types.ModuleType("substrateinterface")
+
+    class FakeSubstrateInterface:
+        def __init__(self, url):
+            self.url = url
+
+    fake_substrate.SubstrateInterface = FakeSubstrateInterface
+    sys.modules["substrateinterface"] = fake_substrate
+
+    repo_root = str(Path(__file__).resolve().parents[1])
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+
+    if "macros.rpc" in sys.modules:
+        del sys.modules["macros.rpc"]
+
+    return importlib.import_module("macros.rpc")
+
+
+class HumanReadableTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rpc = load_rpc_module()
+
+    def test_human_readable_uses_short_precision_by_default_for_dot(self):
+        self.assertEqual(self.rpc.human_readable(10, 12345678901), "1.23")
+
+    def test_human_readable_keeps_full_precision_when_not_rounded_for_dot(self):
+        self.assertEqual(
+            self.rpc.human_readable(10, 12345678901, rounded=False),
+            "1.2345678901",
+        )
+
+    def test_human_readable_keeps_full_precision_for_small_values(self):
+        self.assertEqual(
+            self.rpc.human_readable(10, 12345, rounded=False),
+            "0.0000012345",
+        )
+
+    def test_format_precise_dot_uses_full_precision(self):
+        self.assertEqual(
+            self.rpc.format(12345678901, "precise_dot"),
+            "1.2345678901 DOT",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR fixes a precision bug in token formatting used by RPC-backed wiki values and adds regression tests.

## Problem
`human_readable(..., rounded=False)` was not actually using full precision.
Because of that, `format(..., "precise_dot")` / `format(..., "precise_ksm")` returned truncated values (for example `1.23 DOT`) instead of full on-chain precision.

## Root Cause
In `macros/rpc.py`, the `rounded` argument was ignored when choosing `display_decimals`.

## Changes
- Updated `human_readable` in `macros/rpc.py` to use full precision (`decimals_amount`) when `rounded=False`.
- Kept existing rounded behavior unchanged (`2` decimals for DOT, `6` for KSM).
- Added regression tests in `tests/test_rpc.py` covering:
1. Default rounded DOT formatting.
2. Full-precision DOT formatting when `rounded=False`.
3. Full-precision small-value formatting (leading zeros case).
4. `format(..., "precise_dot")` output path.

## Validation
Ran:
`python3 -m unittest discover -s tests -v`

Result:
All tests pass.

## Impact
- Fixes accuracy for `precise_dot` / `precise_ksm` outputs in rendered docs.
- Low risk: change is isolated to formatting logic and covered by tests.
