### PR TITLE
Add official Telegram announcements channel to community page

### DIFF
--- a/docs/general/community.md
+++ b/docs/general/community.md
@@ -71,6 +71,7 @@ community members. The application we use most often to interact with the Matrix
 
 - [Polkadot Discord](https://polkadot-discord.w3f.tools/) (RECOMMENDED)
 - [Kusama Discord](https://kusama-discord.w3f.tools/)
+- [Polkadot Official Announcements](https://t.me/PolkadotAnnouncements) - Official Telegram announcements channel
 
 ### Social media
 


### PR DESCRIPTION
# `polkadot-wiki` `#7061` PR Draft

Date: 2026-04-17

## Suggested PR Title

Add official Telegram announcements channel to community page

## Suggested PR Body

## Summary

Adds the verified official Polkadot Telegram announcements channel to the community page.

## What changed

- added `Polkadot Official Announcements` to `docs/general/community.md`

## Why

Issue `#7061` notes that the Polkadot Telegram presence is missing from the list of communities. This patch adds the Telegram surface I could verify from official Polkadot support material.

## Notes

- I used the official announcements channel:
  - `https://t.me/PolkadotAnnouncements`
- If the maintainers would prefer the broader community group instead, I am happy to update this to the preferred official Telegram link.

## Issue

- Closes #7061

## Optional Shorter Body

Adds the verified official Polkadot Telegram announcements channel to `docs/general/community.md` to address `#7061`.

If the broader community Telegram group is the preferred official surface, I can update the link in follow-up.
